### PR TITLE
feat: added generic properties and bumped version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posthog-rs"
 license = "MIT"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["christos <christos@openquery.io>"]
 description = "An unofficial Rust client for Posthog (https://posthog.com/)."
 repository = "https://github.com/openquery-io/posthog-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posthog-rs"
 license = "MIT"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["christos <christos@openquery.io>"]
 description = "An unofficial Rust client for Posthog (https://posthog.com/)."
 repository = "https://github.com/openquery-io/posthog-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posthog-rs"
 license = "MIT"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["christos <christos@openquery.io>"]
 description = "An unofficial Rust client for Posthog (https://posthog.com/)."
 repository = "https://github.com/openquery-io/posthog-rs"

--- a/README.md
+++ b/README.md
@@ -10,23 +10,17 @@ Add `posthog-rs` to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-posthog_rs = "0.1.0"
+posthog_rs = "0.2.0"
 ```
 
 ```rust
-let client = posthog_rs::client(env!("POSTHOG_API_KEY"));
+let client = crate::client(env!("POSTHOG_API_KEY"));
 
-let mut props = HashMap::new();
-props.insert("key1".to_string(), "value1".to_string());
-props.insert("key2".to_string(), "value2".to_string());
+let mut event = Event::new("test", "1234");
+event.insert_prop("key1", "value1").unwrap();
+event.insert_prop("key2", vec!["a", "b"]).unwrap();
 
-let event = Event {
-    event: "test".to_string(),
-    properties: Properties { distinct_id: "1234".to_string(), props },
-    timestamp: Some(Utc::now().naive_utc()),
-};
-
-let res = client.capture(event).unwrap();
+client.capture(event).unwrap();
 
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
 
 #[derive(Debug)]
 pub enum Error {
-    Connection(String)
+    Connection(String),
+    Serialization(String)
 }
 
 pub struct ClientOptions {
@@ -83,15 +84,41 @@ impl InnerEvent {
 
 
 pub struct Event {
-    pub event: String,
-    pub properties: Properties,
-    pub timestamp: Option<NaiveDateTime>,
+    event: String,
+    properties: Properties,
+    timestamp: Option<NaiveDateTime>,
 }
 
 #[derive(Serialize)]
 pub struct Properties {
-    pub distinct_id: String,
-    pub props: HashMap<String, String>,
+    distinct_id: String,
+    props: HashMap<String, serde_json::Value>,
+}
+
+impl Properties {
+    fn new<S: Into<String>>(distinct_id: S) -> Self {
+        Self {
+            distinct_id: distinct_id.into(),
+            props: Default::default()
+        }
+    }
+}
+
+impl Event {
+    pub fn new<S: Into<String>>(event: S, distinct_id: S) -> Self {
+        Self {
+            event: event.into(),
+            properties: Properties::new(distinct_id),
+            timestamp: None
+        }
+    }
+
+    /// Errors if `prop` fails to serialize
+    pub fn insert_prop<K: Into<String>, P: Serialize>(&mut self, key: K, prop: P) -> Result<(), Error> {
+        let as_json = serde_json::to_value(prop).map_err(|e| Error::Serialization(e.to_string()))?;
+        let _ = self.properties.props.insert(key.into(), as_json);
+        Ok(())
+    }
 }
 
 
@@ -104,15 +131,15 @@ pub mod tests {
     fn get_client() {
         let client = crate::client(env!("POSTHOG_API_KEY"));
 
-        let mut props = HashMap::new();
-        props.insert("key1".to_string(), "value1".to_string());
-        props.insert("key2".to_string(), "value2".to_string());
+        let mut child_map = HashMap::new();
+        child_map.insert("child_key1", "child_value1");
 
-        let event = Event {
-            event: "test".to_string(),
-            properties: Properties { distinct_id: "1234".to_string(), props },
-            timestamp: Some(Utc::now().naive_utc()),
-        };
+
+        let mut event = Event::new("test", "1234");
+        event.insert_prop("key1", "value1").unwrap();
+        event.insert_prop("key2", vec!["a", "b"]).unwrap();
+        event.insert_prop("key3", child_map).unwrap();
+
         client.capture(event).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 use chrono::{NaiveDateTime};
 use reqwest::blocking::Client as HttpClient;
 use reqwest::header::CONTENT_TYPE;
@@ -16,6 +17,19 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
         options: options.into(),
         client,
     }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Connection(msg) => write!(f, "Connection Error: {}", msg),
+            Error::Serialization(msg) => write!(f, "Serialization Error: {}", msg)
+        }
+    }
+}
+
+impl std::error::Error for Error {
+
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,13 +97,14 @@ impl InnerEvent {
 }
 
 
+#[derive(Serialize, Debug, PartialEq, Eq)]
 pub struct Event {
     event: String,
     properties: Properties,
     timestamp: Option<NaiveDateTime>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 pub struct Properties {
     distinct_id: String,
     props: HashMap<String, serde_json::Value>,


### PR DESCRIPTION
I created this PR as I need support for nested hierarchical data in the properties and not just string kv pairs.

I bumped the minor version since this breaks our first experimental API (fields are no longer public).

Hopefully we can get this merged ASAP and I'll push to crates.io because we need this dependency in the Synth project.