### PR TITLE
Fix: Remove OpenSSL from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posthog-rs"
 license = "MIT"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["christos <christos@openquery.io>"]
 description = "An unofficial Rust client for Posthog (https://posthog.com/)."
 repository = "https://github.com/openquery-io/posthog-rs"
@@ -10,7 +10,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.3", features = ["blocking"] }
+reqwest = { version = "0.11.3", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1.0.125", features = ["derive"] }
 chrono = {version = "0.4.19", features = ["serde"] }
 serde_json = "1.0.64"


### PR DESCRIPTION
The OpenSSL dependency in this is breaking some Synth telemetry builds