### PR TITLE
Update version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `posthog-rs` to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-posthog-rs = "0.2.0"
+posthog-rs = "0.3.5"
 ```
 
 ```rust


### PR DESCRIPTION
I noticed the version listed in the README is behind the version listed on crates.io. This PR updates the version number.