### PR TITLE
Add Doc Comments where missing.

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -6,11 +6,13 @@ use crate::{event::InnerEvent, Error, Event};
 
 use super::ClientOptions;
 
+/// A [`Client`] facilitates interactions with the PostHog API over HTTP.
 pub struct Client {
     options: ClientOptions,
     client: HttpClient,
 }
 
+/// This function constructs a new client using the options provided.
 pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
     let options = options.into();
     let client = HttpClient::builder()
@@ -21,6 +23,7 @@ pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
 }
 
 impl Client {
+    /// Capture the provided event, sending it to PostHog.
     pub async fn capture(&self, event: Event) -> Result<(), Error> {
         let inner_event = InnerEvent::new(event, self.options.api_key.clone());
 
@@ -38,6 +41,8 @@ impl Client {
         Ok(())
     }
 
+    /// Capture a collection of events with a single request. This function may be
+    /// more performant than capturing a list of events individually.
     pub async fn capture_batch(&self, events: Vec<Event>) -> Result<(), Error> {
         let events: Vec<_> = events
             .into_iter()

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,6 +7,10 @@ use uuid::Uuid;
 
 use crate::Error;
 
+/// An [`Event`] represents an interaction a user has with your app or
+/// website. Examples include button clicks, pageviews, query completions, and signups.
+/// See the [PostHog documentation](https://posthog.com/docs/data/events)
+/// for a detailed explanation of PostHog Events.
 #[derive(Serialize, Debug, PartialEq, Eq)]
 pub struct Event {
     event: String,
@@ -18,8 +22,8 @@ pub struct Event {
 }
 
 impl Event {
-    /// Capture a new identified event. Unless you have a distinct ID you can
-    /// associate with a user, you probably want to use `new_anon` instead.
+    /// Capture a new identified [`Event`]. Unless you have a distinct ID you can
+    /// associate with a user, you probably want to use [`new_anon`] instead.
     pub fn new<S: Into<String>>(event: S, distinct_id: S) -> Self {
         Self {
             event: event.into(),

--- a/src/global.rs
+++ b/src/global.rs
@@ -5,6 +5,11 @@ use crate::{client, Client, ClientOptions, Error, Event};
 static GLOBAL_CLIENT: OnceLock<Client> = OnceLock::new();
 static GLOBAL_DISABLE: OnceLock<bool> = OnceLock::new();
 
+/// [`init_global_client`] will initialize a globally available client singleton. This singleton
+/// can be used when you don't need more than one instance and have no need to regularly change
+/// the client options.
+/// # Errors
+/// This function returns [`Error::AlreadyInitialized`] if called more than once.
 #[cfg(feature = "async-client")]
 pub async fn init_global_client<C: Into<ClientOptions>>(options: C) -> Result<(), Error> {
     if is_disabled() {
@@ -17,6 +22,11 @@ pub async fn init_global_client<C: Into<ClientOptions>>(options: C) -> Result<()
         .map_err(|_| Error::AlreadyInitialized)
 }
 
+/// [`init_global_client`] will initialize a globally available client singleton. This singleton
+/// can be used when you don't need more than one instance and have no need to regularly change
+/// the client options.
+/// # Errors
+/// This function returns [`Error::AlreadyInitialized`] if called more than once.
 #[cfg(not(feature = "async-client"))]
 pub fn init_global_client<C: Into<ClientOptions>>(options: C) -> Result<(), Error> {
     if is_disabled() {
@@ -29,20 +39,27 @@ pub fn init_global_client<C: Into<ClientOptions>>(options: C) -> Result<(), Erro
         .map_err(|_| Error::AlreadyInitialized)
 }
 
+/// [`disable`] prevents the global client from being initialized.
+/// **NOTE:** It does *not* prevent use of the global client once initialized.
 pub fn disable() {
     let _ = GLOBAL_DISABLE.set(true);
 }
 
+/// [`is_disabled`] returns true if the global client has been disabled.
+/// **NOTE:** A disabled global client can still be used as long as it was
+/// initialized before it was disabled.
 pub fn is_disabled() -> bool {
     *GLOBAL_DISABLE.get().unwrap_or(&false)
 }
 
+/// Capture the provided event, sending it to PostHog using the global client.
 #[cfg(feature = "async-client")]
 pub async fn capture(event: Event) -> Result<(), Error> {
     let client = GLOBAL_CLIENT.get().ok_or(Error::NotInitialized)?;
     client.capture(event).await
 }
 
+/// Capture the provided event, sending it to PostHog using the global client.
 #[cfg(not(feature = "async-client"))]
 pub fn capture(event: Event) -> Result<(), Error> {
     let client = GLOBAL_CLIENT.get().ok_or(Error::NotInitialized)?;


### PR DESCRIPTION
This commit adds doc comments for (almost) every item in the public API. I attempted to interpret the behavior of the code as true to the original intention as possible, which may have been different than originally intended by the original developer, particularly in the case of the `disable` functions of the global client, which confusingly do not seem to actually disable the client if it has already been initialized.