### PR TITLE
fix: add timestamp setter

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ impl Display for Error {
             Error::Serialization(msg) => write!(f, "Serialization Error: {}", msg),
             Error::AlreadyInitialized => write!(f, "Client already initialized"),
             Error::NotInitialized => write!(f, "Client not initialized"),
+            Error::InvalidTimestamp(msg) => write!(f, "Invalid Timestamp: {}", msg),
         }
     }
 }
@@ -18,4 +19,5 @@ pub enum Error {
     Serialization(String),
     AlreadyInitialized,
     NotInitialized,
+    InvalidTimestamp(String),
 }


### PR DESCRIPTION
This really ought to have always been available. We're more strict that the posthog pipeline here as regards dates being required to be in the past (there is a leeway of about a day in the ingestion pipeline, but that's due to noncompliant or buggy SDK implementations).