### PR TITLE
Add feature for enabling native-tls with reqwest

### DIFF
--- a/.sampo/changesets/regal-iceseeker-marjatta.md
+++ b/.sampo/changesets/regal-iceseeker-marjatta.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Added feature flag to enable native-tls for reqwest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ rust-version = "1.78.0"
 
 [dependencies]
 reqwest = { version = "0.11.3", default-features = false, features = [
-    "rustls-tls",
     "blocking",
     "json",
     "gzip",
@@ -41,6 +40,8 @@ futures = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
-default = ["async-client"]
+default = ["async-client", "rustls-tls"]
 e2e-test = []
 async-client = ["tokio"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
As a Linux Packager (Fedora) having the ability to easily swap from rustls-tls to native-tls is crucial in some environments.

This patch introduces a simple feature for enabling native-tls or rustls-tls (default)