### PR TITLE
Add changeset for v0.5.0 release

### DIFF
--- a/.sampo/changesets/local-evaluation-only.md
+++ b/.sampo/changesets/local-evaluation-only.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Add `local_evaluation_only` option to prevent remote API fallback when local evaluation is inconclusive


### PR DESCRIPTION
## Summary

- Add sampo changeset for the `local_evaluation_only` feature merged in #83
- Marked as `minor` bump since it adds new public API surface

## Test plan

- [ ] CI passes
- [ ] Merging with `release` label triggers sampo release workflow