### PR TITLE
feat(flags): switch local evaluation endpoint to /flags/definitions

### DIFF
--- a/.sampo/changesets/flags-definitions-endpoint.md
+++ b/.sampo/changesets/flags-definitions-endpoint.md
@@ -1,0 +1,5 @@
+---
+crates-io/posthog-rs: patch
+---
+
+feat(flags): switch local evaluation polling from `/api/feature_flag/local_evaluation` to `/flags/definitions`

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -29,7 +29,7 @@ impl Endpoint {
             Endpoint::Capture => "/i/v0/e/",
             Endpoint::Batch => "/batch/",
             Endpoint::Flags => "/flags/?v=2",
-            Endpoint::LocalEvaluation => "/api/feature_flag/local_evaluation/?send_cohorts",
+            Endpoint::LocalEvaluation => "/flags/definitions/?send_cohorts",
         }
     }
 }
@@ -110,7 +110,7 @@ impl EndpointManager {
     /// Build the local evaluation URL with a token
     pub fn build_local_eval_url(&self, token: &str) -> String {
         format!(
-            "{}/api/feature_flag/local_evaluation/?token={}&send_cohorts",
+            "{}/flags/definitions/?token={}&send_cohorts",
             self.base_host.trim_end_matches('/'),
             token
         )

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -223,7 +223,7 @@ impl FlagPoller {
                 }
 
                 let url = format!(
-                    "{}/api/feature_flag/local_evaluation/?send_cohorts",
+                    "{}/flags/definitions/?send_cohorts",
                     config.api_host.trim_end_matches('/')
                 );
 
@@ -275,7 +275,7 @@ impl FlagPoller {
     #[instrument(skip(self), level = "debug")]
     pub fn load_flags(&self) -> Result<(), Error> {
         let url = format!(
-            "{}/api/feature_flag/local_evaluation/?send_cohorts",
+            "{}/flags/definitions/?send_cohorts",
             self.config.api_host.trim_end_matches('/')
         );
 
@@ -401,7 +401,7 @@ impl AsyncFlagPoller {
                         }
 
                         let url = format!(
-                            "{}/api/feature_flag/local_evaluation/?send_cohorts",
+                            "{}/flags/definitions/?send_cohorts",
                             config.api_host.trim_end_matches('/')
                         );
 
@@ -455,7 +455,7 @@ impl AsyncFlagPoller {
     #[instrument(skip(self), level = "debug")]
     pub async fn load_flags(&self) -> Result<(), Error> {
         let url = format!(
-            "{}/api/feature_flag/local_evaluation/?send_cohorts",
+            "{}/flags/definitions/?send_cohorts",
             self.config.api_host.trim_end_matches('/')
         );
 

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -160,7 +160,7 @@ async fn test_local_evaluation_with_mock_server() {
 
     let eval_mock = server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .header("Authorization", "Bearer test_personal_key")
             .header("X-PostHog-Project-Api-Key", "test_project_key")
             .query_param("send_cohorts", "");
@@ -267,7 +267,7 @@ async fn test_etag_sent_on_second_poll() {
     // Registered FIRST but uses matches() to only match when header is present with correct value
     let etag_mock = server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .query_param("send_cohorts", "")
             .matches(|req| {
                 // Match only if If-None-Match header exists with the correct value
@@ -284,7 +284,7 @@ async fn test_etag_sent_on_second_poll() {
     // Registered SECOND - will be tried first but etag_mock's matches() will fail if no header
     let no_etag_mock = server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .query_param("send_cohorts", "");
         then.status(200)
             .header("ETag", "\"abc123\"")
@@ -355,7 +355,7 @@ async fn test_304_preserves_cache() {
     // Registered FIRST but uses matches() to only match when header is present with correct value
     let etag_mock = server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .query_param("send_cohorts", "")
             .matches(|req| {
                 // Match only if If-None-Match header exists with the correct value
@@ -372,7 +372,7 @@ async fn test_304_preserves_cache() {
     // Registered SECOND - will be tried first but etag_mock's matches() will fail if no header
     server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .query_param("send_cohorts", "");
         then.status(200)
             .header("ETag", "\"v1\"")
@@ -440,7 +440,7 @@ async fn test_no_etag_from_server() {
 
     // Server returns 200 without ETag header
     let mock = server.mock(|when, then| {
-        when.method(GET).path("/api/feature_flag/local_evaluation/");
+        when.method(GET).path("/flags/definitions/");
         then.status(200).json_body(mock_flags);
     });
 
@@ -497,7 +497,7 @@ fn test_sync_etag_sent_on_second_poll() {
     // Mock for requests WITH If-None-Match header (subsequent polls) -> 304
     let etag_mock = server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .query_param("send_cohorts", "")
             .matches(|req| {
                 // Match only if If-None-Match header exists with the correct value
@@ -513,7 +513,7 @@ fn test_sync_etag_sent_on_second_poll() {
     // Mock for requests WITHOUT If-None-Match -> 200 with ETag
     let no_etag_mock = server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .query_param("send_cohorts", "");
         then.status(200)
             .header("ETag", "\"sync-abc123\"")
@@ -582,7 +582,7 @@ fn test_sync_304_preserves_cache() {
     // Mock for requests WITH If-None-Match -> returns 304
     let etag_mock = server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .query_param("send_cohorts", "")
             .matches(|req| {
                 // Match only if If-None-Match header exists with the correct value
@@ -598,7 +598,7 @@ fn test_sync_304_preserves_cache() {
     // Mock for requests WITHOUT If-None-Match -> returns 200 with ETag
     server.mock(|when, then| {
         when.method(GET)
-            .path("/api/feature_flag/local_evaluation/")
+            .path("/flags/definitions/")
             .query_param("send_cohorts", "");
         then.status(200)
             .header("ETag", "\"sync-v1\"")
@@ -665,7 +665,7 @@ fn test_sync_no_etag_from_server() {
 
     // Server returns 200 without ETag header
     let mock = server.mock(|when, then| {
-        when.method(GET).path("/api/feature_flag/local_evaluation/");
+        when.method(GET).path("/flags/definitions/");
         then.status(200).json_body(mock_flags);
     });
 


### PR DESCRIPTION
## Motivation and Context

The Rust feature flags definitions fleet now serves 100% of `/api/feature_flag/local_evaluation` traffic in all environments. This switches the SDK's default polling URL from the legacy Django path to the Rust endpoint's native path (`/flags/definitions`).

The old `/api/feature_flag/local_evaluation` path remains registered as a route alias on the Rust service, so older SDK versions continue to work.

## How did you test it?

- Updated all httpmock path matchers across test files
- The `/flags/definitions` endpoint has been serving production traffic since 2026-04-09