### PR TITLE
chore: simplify crate author metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "posthog-rs"
 license = "MIT"
 version = "0.5.0"
-authors = ["christos <christos@openquery.io>", "olly <oliver@posthog.com>"]
+authors = ["christos <christos@openquery.io>", "olly <engineering@posthog.com>"]
 description = "The official Rust client for Posthog (https://posthog.com/)."
 repository = "https://github.com/posthog/posthog-rs"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "posthog-rs"
 license = "MIT"
 version = "0.5.0"
-authors = ["christos <christos@openquery.io>", "olly <engineering@posthog.com>"]
+authors = ["PostHog <engineering@posthog.com>"]
 description = "The official Rust client for Posthog (https://posthog.com/)."
 repository = "https://github.com/posthog/posthog-rs"
 edition = "2018"


### PR DESCRIPTION
## Problem

The crate metadata uses specific individual author entries. We want the published package metadata to use a shared PostHog author identity and the shared `engineering@posthog.com` contact address instead.

## Changes

- Updated `Cargo.toml` authors metadata
- Replaced the individual author entries with `PostHog <engineering@posthog.com>`

## How did you test it?

- Verified `Cargo.toml` now uses `PostHog <engineering@posthog.com>`
- Confirmed there are no other non-`engineering@posthog.com` `@posthog.com` addresses in package metadata files in this repo
