### PR TITLE
docs: move release guide to RELEASING.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,4 @@
 - [ ] Ran `sampo add` to generate a changeset file
 - [ ] Added the `release` label to the PR
 
-<!-- For more details check README.md#releasing -->
+<!-- For more details check RELEASING.md -->

--- a/README.md
+++ b/README.md
@@ -230,16 +230,7 @@ Log levels:
 - `debug`: Flag evaluation results, API fallback decisions
 - `trace`: Detailed cache updates, individual flag lookups
 
-## Releasing
-
-This repository uses [Sampo](https://github.com/bruits/sampo) for versioning, changelogs, and publishing to crates.io.
-
-1. When making changes, include a changeset: `sampo add`
-2. Create a PR with your changes and the changeset file
-3. Add the `release` label and merge to `main`
-4. Approve the release in Slack when prompted — this triggers version bump, crates.io publish, git tag, and GitHub Release
-
-You can also trigger a release manually via the workflow's `workflow_dispatch` trigger (still requires pending changesets).
+For release instructions, see [RELEASING.md](RELEASING.md).
 
 # Acknowledgements
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,10 @@
+# Releasing
+
+This repository uses [Sampo](https://github.com/bruits/sampo) for versioning, changelogs, and publishing to crates.io.
+
+1. When making changes, include a changeset: `sampo add`
+2. Create a PR with your changes and the changeset file
+3. Add the `release` label and merge to `main`
+4. Approve the release in Slack when prompted — this triggers version bump, crates.io publish, git tag, and GitHub Release
+
+You can also trigger a release manually via the workflow's `workflow_dispatch` trigger (still requires pending changesets).


### PR DESCRIPTION
## :bulb: Motivation and Context
This repo kept its release instructions in `README.md`. Moving them into `RELEASING.md` makes release docs easier to find and keeps one source of truth for release guidance.

## :green_heart: How did you test it?
- Re-read `README.md` to confirm it now points to `RELEASING.md`
- Re-read `RELEASING.md` to confirm the full release flow was preserved
- Updated the PR template comment to point at `RELEASING.md`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
