### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Thanks for your interest in improving the PostHog Rust SDK.
+
+## Prerequisites
+
+- Rust `1.78.0` or newer (see `Cargo.toml`)
+
+## Development commands
+
+From the repository root:
+
+```bash
+cargo build --verbose
+cargo test --verbose
+cargo test --verbose --features e2e-test --no-default-features
+cargo fmt -- --check
+cargo clippy -- -D warnings
+```
+
+## Running examples
+
+See [examples/README.md](examples/README.md) for the available example programs and the environment variables they use.
+
+## Pull requests
+
+Please make sure the relevant build, test, formatting, and clippy checks pass before opening a PR.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ Log levels:
 
 For release instructions, see [RELEASING.md](RELEASING.md).
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local development and verification commands.
+
 # Acknowledgements
 
 Thanks to [@christos-h](https://github.com/christos-h) for building the initial version of this project.


### PR DESCRIPTION
## :bulb: Motivation and Context

This repo did not have a dedicated root `CONTRIBUTING.md`.

This PR adds one and links to it from the README so contributors have a consistent place to find local development and verification commands.

## :green_heart: How did you test it?

- Not run (docs-only changes)
- Checked the updated markdown links and file locations

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR
