### PR TITLE
fix: trim whitespace from API keys and host config

### DIFF
--- a/.sampo/changesets/gallant-runesinger-ahti.md
+++ b/.sampo/changesets/gallant-runesinger-ahti.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Trim surrounding whitespace from API keys and host config before using them.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -5,7 +5,7 @@ use reqwest::{header::CONTENT_TYPE, Client as HttpClient};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
 
-use crate::endpoints::{Endpoint, EndpointManager};
+use crate::endpoints::Endpoint;
 use crate::event::BatchRequest;
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
@@ -36,9 +36,10 @@ pub struct Client {
 
 /// This function constructs a new client using the options provided.
 pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
-    let mut options = options.into();
-    // Ensure endpoint_manager is properly initialized based on the host
-    options.endpoint_manager = EndpointManager::new(options.host.clone());
+    let options = options.into().sanitize();
+    if options.api_key.is_empty() {
+        warn!("api_key is empty after trimming whitespace; check your project API key");
+    }
     let client = HttpClient::builder()
         .timeout(Duration::from_secs(options.request_timeout_seconds))
         .build()

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -37,9 +37,6 @@ pub struct Client {
 /// This function constructs a new client using the options provided.
 pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
     let options = options.into().sanitize();
-    if options.api_key.is_empty() {
-        warn!("api_key is empty after trimming whitespace; check your project API key");
-    }
     let client = HttpClient::builder()
         .timeout(Duration::from_secs(options.request_timeout_seconds))
         .build()

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -5,7 +5,7 @@ use reqwest::{blocking::Client as HttpClient, header::CONTENT_TYPE};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
 
-use crate::endpoints::{Endpoint, EndpointManager};
+use crate::endpoints::Endpoint;
 use crate::event::BatchRequest;
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
@@ -35,9 +35,10 @@ pub struct Client {
 
 /// This function constructs a new client using the options provided.
 pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
-    let mut options = options.into();
-    // Ensure endpoint_manager is properly initialized based on the host
-    options.endpoint_manager = EndpointManager::new(options.host.clone());
+    let options = options.into().sanitize();
+    if options.api_key.is_empty() {
+        warn!("api_key is empty after trimming whitespace; check your project API key");
+    }
     let client = HttpClient::builder()
         .timeout(Duration::from_secs(options.request_timeout_seconds))
         .build()

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -36,9 +36,6 @@ pub struct Client {
 /// This function constructs a new client using the options provided.
 pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
     let options = options.into().sanitize();
-    if options.api_key.is_empty() {
-        warn!("api_key is empty after trimming whitespace; check your project API key");
-    }
     let client = HttpClient::builder()
         .timeout(Duration::from_secs(options.request_timeout_seconds))
         .build()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -91,10 +91,31 @@ impl ClientOptions {
         self.disabled
     }
 
-    /// Create ClientOptions with properly initialized endpoint_manager
-    fn with_endpoint_manager(mut self) -> Self {
+    fn sanitize(mut self) -> Self {
+        self.api_key = self.api_key.trim().to_string();
+        self.host = self.host.and_then(|host| {
+            let normalized = host.trim().to_string();
+            if normalized.is_empty() {
+                None
+            } else {
+                Some(normalized)
+            }
+        });
+        self.personal_api_key = self.personal_api_key.and_then(|personal_api_key| {
+            let normalized = personal_api_key.trim().to_string();
+            if normalized.is_empty() {
+                None
+            } else {
+                Some(normalized)
+            }
+        });
         self.endpoint_manager = EndpointManager::new(self.host.clone());
         self
+    }
+
+    /// Create ClientOptions with properly initialized endpoint_manager
+    fn with_endpoint_manager(self) -> Self {
+        self.sanitize()
     }
 }
 
@@ -117,5 +138,40 @@ impl From<(&str, &str)> for ClientOptions {
             .build()
             .expect("We always set the API key, so this is infallible")
             .with_endpoint_manager()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClientOptionsBuilder;
+    use crate::endpoints::{EU_INGESTION_ENDPOINT, US_INGESTION_ENDPOINT};
+
+    #[test]
+    fn trims_whitespace_sensitive_options() {
+        let options = ClientOptionsBuilder::default()
+            .api_key(" \n test-api-key\t ".to_string())
+            .host(" \nhttps://eu.posthog.com/\t ")
+            .personal_api_key(" \n\t ")
+            .build()
+            .unwrap()
+            .sanitize();
+
+        assert_eq!(options.api_key, "test-api-key");
+        assert_eq!(options.host.as_deref(), Some("https://eu.posthog.com/"));
+        assert_eq!(options.personal_api_key, None);
+        assert_eq!(options.endpoints().api_host(), EU_INGESTION_ENDPOINT);
+    }
+
+    #[test]
+    fn defaults_blank_host_after_trimming_whitespace() {
+        let options = ClientOptionsBuilder::default()
+            .api_key("test-api-key".to_string())
+            .host(" \n\t ")
+            .build()
+            .unwrap()
+            .sanitize();
+
+        assert_eq!(options.host, None);
+        assert_eq!(options.endpoints().api_host(), US_INGESTION_ENDPOINT);
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,4 @@
-use crate::endpoints::EndpointManager;
+use crate::endpoints::{EndpointManager, DEFAULT_HOST};
 use derive_builder::Builder;
 use tracing::warn;
 
@@ -97,13 +97,16 @@ impl ClientOptions {
         if self.api_key.is_empty() {
             warn!("api_key is empty after trimming whitespace; check your project API key");
         }
-        self.host = self.host.and_then(|host| {
-            let normalized = host.trim().to_string();
-            if normalized.is_empty() {
-                None
-            } else {
-                Some(normalized)
+        self.host = Some(match self.host {
+            Some(host) => {
+                let normalized = host.trim().to_string();
+                if normalized.is_empty() {
+                    DEFAULT_HOST.to_string()
+                } else {
+                    normalized
+                }
             }
+            None => DEFAULT_HOST.to_string(),
         });
         self.personal_api_key = self.personal_api_key.and_then(|personal_api_key| {
             let normalized = personal_api_key.trim().to_string();
@@ -175,7 +178,7 @@ mod tests {
             .unwrap()
             .sanitize();
 
-        assert_eq!(options.host, None);
+        assert_eq!(options.host.as_deref(), Some(US_INGESTION_ENDPOINT));
         assert_eq!(options.endpoints().api_host(), US_INGESTION_ENDPOINT);
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,6 @@
 use crate::endpoints::EndpointManager;
 use derive_builder::Builder;
+use tracing::warn;
 
 #[cfg(not(feature = "async-client"))]
 mod blocking;
@@ -93,6 +94,9 @@ impl ClientOptions {
 
     fn sanitize(mut self) -> Self {
         self.api_key = self.api_key.trim().to_string();
+        if self.api_key.is_empty() {
+            warn!("api_key is empty after trimming whitespace; check your project API key");
+        }
         self.host = self.host.and_then(|host| {
             let normalized = host.trim().to_string();
             if normalized.is_empty() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -77,7 +77,7 @@ pub struct ClientOptions {
     local_evaluation_only: bool,
 
     #[builder(setter(skip))]
-    #[builder(default = "EndpointManager::new(None)")]
+    #[builder(default = "EndpointManager::new(DEFAULT_HOST.to_string())")]
     endpoint_manager: EndpointManager,
 }
 
@@ -116,7 +116,11 @@ impl ClientOptions {
                 Some(normalized)
             }
         });
-        self.endpoint_manager = EndpointManager::new(self.host.clone());
+        self.endpoint_manager = EndpointManager::new(
+            self.host
+                .clone()
+                .expect("host is always normalized in sanitize"),
+        );
         self
     }
 

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -50,7 +50,12 @@ pub struct EndpointManager {
 impl EndpointManager {
     /// Create a new endpoint manager with the given host
     pub fn new(host: Option<String>) -> Self {
-        let raw_host = host.clone().unwrap_or_else(|| DEFAULT_HOST.to_string());
+        let raw_host = host
+            .as_deref()
+            .map(str::trim)
+            .filter(|host| !host.is_empty())
+            .unwrap_or(DEFAULT_HOST)
+            .to_string();
         let base_host = Self::determine_server_host(host);
 
         Self {
@@ -62,7 +67,12 @@ impl EndpointManager {
     /// Determine the actual server host based on the provided host
     /// Similar to posthog-python's determine_server_host function
     pub fn determine_server_host(host: Option<String>) -> String {
-        let host_or_default = host.unwrap_or_else(|| DEFAULT_HOST.to_string());
+        let host_or_default = host
+            .as_deref()
+            .map(str::trim)
+            .filter(|host| !host.is_empty())
+            .unwrap_or(DEFAULT_HOST)
+            .to_string();
         let trimmed_host = host_or_default.trim_end_matches('/');
 
         match trimmed_host {
@@ -151,6 +161,16 @@ mod tests {
         assert_eq!(
             EndpointManager::determine_server_host(Some("https://custom.domain.com".to_string())),
             "https://custom.domain.com"
+        );
+
+        assert_eq!(
+            EndpointManager::determine_server_host(Some(" \nhttps://eu.posthog.com/\t ".to_string())),
+            EU_INGESTION_ENDPOINT
+        );
+
+        assert_eq!(
+            EndpointManager::determine_server_host(Some(" \n\t ".to_string())),
+            US_INGESTION_ENDPOINT
         );
     }
 

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -48,32 +48,20 @@ pub struct EndpointManager {
 }
 
 impl EndpointManager {
-    /// Create a new endpoint manager with the given host
-    pub fn new(host: Option<String>) -> Self {
-        let raw_host = host
-            .as_deref()
-            .map(str::trim)
-            .filter(|host| !host.is_empty())
-            .unwrap_or(DEFAULT_HOST)
-            .to_string();
-        let base_host = Self::determine_server_host(host);
+    /// Create a new endpoint manager with the given normalized host
+    pub fn new(host: String) -> Self {
+        let base_host = Self::determine_server_host(&host);
 
         Self {
             base_host,
-            raw_host,
+            raw_host: host,
         }
     }
 
-    /// Determine the actual server host based on the provided host
+    /// Determine the actual server host based on the provided normalized host
     /// Similar to posthog-python's determine_server_host function
-    pub fn determine_server_host(host: Option<String>) -> String {
-        let host_or_default = host
-            .as_deref()
-            .map(str::trim)
-            .filter(|host| !host.is_empty())
-            .unwrap_or(DEFAULT_HOST)
-            .to_string();
-        let trimmed_host = host_or_default.trim_end_matches('/');
+    pub fn determine_server_host(host: &str) -> String {
+        let trimmed_host = host.trim_end_matches('/');
 
         match trimmed_host {
             "https://app.posthog.com" | "https://us.posthog.com" => {
@@ -139,46 +127,34 @@ mod tests {
     #[test]
     fn test_determine_server_host() {
         assert_eq!(
-            EndpointManager::determine_server_host(None),
+            EndpointManager::determine_server_host("https://app.posthog.com"),
             US_INGESTION_ENDPOINT
         );
 
         assert_eq!(
-            EndpointManager::determine_server_host(Some("https://app.posthog.com".to_string())),
+            EndpointManager::determine_server_host("https://us.posthog.com"),
             US_INGESTION_ENDPOINT
         );
 
         assert_eq!(
-            EndpointManager::determine_server_host(Some("https://us.posthog.com".to_string())),
-            US_INGESTION_ENDPOINT
-        );
-
-        assert_eq!(
-            EndpointManager::determine_server_host(Some("https://eu.posthog.com".to_string())),
+            EndpointManager::determine_server_host("https://eu.posthog.com"),
             EU_INGESTION_ENDPOINT
         );
 
         assert_eq!(
-            EndpointManager::determine_server_host(Some("https://custom.domain.com".to_string())),
+            EndpointManager::determine_server_host("https://custom.domain.com"),
             "https://custom.domain.com"
         );
 
         assert_eq!(
-            EndpointManager::determine_server_host(Some(
-                " \nhttps://eu.posthog.com/\t ".to_string()
-            )),
+            EndpointManager::determine_server_host("https://eu.posthog.com/"),
             EU_INGESTION_ENDPOINT
-        );
-
-        assert_eq!(
-            EndpointManager::determine_server_host(Some(" \n\t ".to_string())),
-            US_INGESTION_ENDPOINT
         );
     }
 
     #[test]
     fn test_build_url() {
-        let manager = EndpointManager::new(None);
+        let manager = EndpointManager::new(DEFAULT_HOST.to_string());
 
         assert_eq!(
             manager.build_url(Endpoint::Capture),
@@ -193,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_build_custom_url() {
-        let manager = EndpointManager::new(Some("https://custom.com/".to_string()));
+        let manager = EndpointManager::new("https://custom.com/".to_string());
 
         assert_eq!(
             manager.build_custom_url("/api/test"),

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -164,7 +164,9 @@ mod tests {
         );
 
         assert_eq!(
-            EndpointManager::determine_server_host(Some(" \nhttps://eu.posthog.com/\t ".to_string())),
+            EndpointManager::determine_server_host(Some(
+                " \nhttps://eu.posthog.com/\t ".to_string()
+            )),
             EU_INGESTION_ENDPOINT
         );
 


### PR DESCRIPTION
## :bulb: Motivation and Context
This ports the whitespace-trimming fix from `posthog-go` to `posthog-rs`. It trims surrounding spaces and line breaks from the project API key, personal API key, and host before using them so the SDK does not silently send invalid tokens or build broken endpoints from whitespace-polluted configuration.


## :green_heart: How did you test it?
- `cargo test trims_whitespace_sensitive_options`
- `cargo test defaults_blank_host_after_trimming_whitespace`
- `cargo test test_determine_server_host`


## :pencil: Checklist
- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
