### PR TITLE
fix: use correct sampo package kind for crates.io

### DIFF
--- a/.sampo/changesets/flags-definitions-endpoint.md
+++ b/.sampo/changesets/flags-definitions-endpoint.md
@@ -1,5 +1,5 @@
 ---
-crates-io/posthog-rs: patch
+cargo/posthog-rs: patch
 ---
 
 feat(flags): switch local evaluation polling from `/api/feature_flag/local_evaluation` to `/flags/definitions`


### PR DESCRIPTION
## Problem

The changeset from PR #91 used `crates-io/posthog-rs` as the package reference, which Sampo doesn't support. The release workflow failed with `unsupported package kind 'crates-io'`.

## Changes

Changed package kind from `crates-io/posthog-rs` to `cargo/posthog-rs` in the changeset file.

## How did you test this code?

Sampo should pick up the corrected changeset and release successfully.