### PR TITLE
docs: clarify Sampo changeset frontmatter

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,6 +3,17 @@
 This repository uses [Sampo](https://github.com/bruits/sampo) for versioning, changelogs, and publishing to crates.io.
 
 1. When making changes, include a changeset: `sampo add`
+   - Prefer letting `sampo add` create the file for you.
+   - If you create or edit a changeset manually, the frontmatter must use this exact package key:
+
+     ```md
+     ---
+     cargo/posthog-rs: patch
+     ---
+     ```
+
+   - Replace `patch` with `minor` or `major` when appropriate.
+
 2. Create a PR with your changes and the changeset file
 3. Add the `release` label and merge to `main`
 4. Approve the release in Slack when prompted — this triggers version bump, crates.io publish, git tag, and GitHub Release


### PR DESCRIPTION
## :bulb: Motivation and Context
Clarify the exact Sampo changeset frontmatter for this repo so ~contributors~ agents don't guess the package key when creating or editing a changeset manually.

## :green_heart: How did you test it?
Docs-only change; no code tests run.

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes
- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR
