### PR TITLE
Fix empty API key initialization

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -42,7 +42,9 @@ pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
         .build()
         .unwrap(); // Unwrap here is as safe as `HttpClient::new`
 
-    let (local_evaluator, flag_poller) = if options.enable_local_evaluation {
+    let (local_evaluator, flag_poller) = if options.enable_local_evaluation
+        && !options.is_disabled()
+    {
         if let Some(ref personal_key) = options.personal_api_key {
             let cache = FlagCache::new();
 
@@ -166,6 +168,11 @@ impl Client {
         ),
         Error,
     > {
+        if self.options.is_disabled() {
+            trace!("Client is disabled, skipping feature flags request");
+            return Ok((HashMap::new(), HashMap::new()));
+        }
+
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 
         let mut payload = json!({
@@ -301,6 +308,11 @@ impl Client {
         key: K,
         distinct_id: D,
     ) -> Result<Option<serde_json::Value>, Error> {
+        if self.options.is_disabled() {
+            trace!("Client is disabled, skipping feature flag payload request");
+            return Ok(None);
+        }
+
         let key_str = key.into();
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -41,7 +41,9 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
         .build()
         .unwrap(); // Unwrap here is as safe as `HttpClient::new`
 
-    let (local_evaluator, flag_poller) = if options.enable_local_evaluation {
+    let (local_evaluator, flag_poller) = if options.enable_local_evaluation
+        && !options.is_disabled()
+    {
         if let Some(ref personal_key) = options.personal_api_key {
             let cache = FlagCache::new();
 
@@ -164,6 +166,11 @@ impl Client {
         ),
         Error,
     > {
+        if self.options.is_disabled() {
+            trace!("Client is disabled, skipping feature flags request");
+            return Ok((HashMap::new(), HashMap::new()));
+        }
+
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 
         let mut payload = json!({
@@ -294,6 +301,11 @@ impl Client {
         key: K,
         distinct_id: D,
     ) -> Result<Option<serde_json::Value>, Error> {
+        if self.options.is_disabled() {
+            trace!("Client is disabled, skipping feature flag payload request");
+            return Ok(None);
+        }
+
         let key_str = key.into();
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,12 +33,14 @@ pub use async_client::Client;
 ///     .unwrap();
 /// ```
 #[derive(Builder, Clone)]
+#[builder(build_fn(name = "build_unchecked", private))]
 pub struct ClientOptions {
     /// Host URL for the PostHog API (defaults to US ingestion endpoint)
     #[builder(setter(into, strip_option), default)]
     host: Option<String>,
 
-    /// Project API key (required)
+    /// Project API key. If missing or blank, the client is disabled.
+    #[builder(default)]
     api_key: String,
 
     /// Request timeout in seconds
@@ -95,7 +97,8 @@ impl ClientOptions {
     fn sanitize(mut self) -> Self {
         self.api_key = self.api_key.trim().to_string();
         if self.api_key.is_empty() {
-            warn!("api_key is empty after trimming whitespace; check your project API key");
+            warn!("api_key is empty after trimming whitespace; disabling PostHog client");
+            self.disabled = true;
         }
         self.host = Some(match self.host {
             Some(host) => {
@@ -127,6 +130,17 @@ impl ClientOptions {
     /// Create ClientOptions with properly initialized endpoint_manager
     fn with_endpoint_manager(self) -> Self {
         self.sanitize()
+    }
+}
+
+impl ClientOptionsBuilder {
+    /// Build sanitized [`ClientOptions`].
+    ///
+    /// Missing or whitespace-only API keys are allowed and disable the client so
+    /// SDK initialization remains infallible while avoiding requests with an
+    /// empty API key.
+    pub fn build(&self) -> Result<ClientOptions, ClientOptionsBuilderError> {
+        Ok(self.build_unchecked()?.sanitize())
     }
 }
 
@@ -184,5 +198,24 @@ mod tests {
 
         assert_eq!(options.host.as_deref(), Some(US_INGESTION_ENDPOINT));
         assert_eq!(options.endpoints().api_host(), US_INGESTION_ENDPOINT);
+    }
+
+    #[test]
+    fn builder_allows_missing_api_key_and_disables_client() {
+        let options = ClientOptionsBuilder::default().build().unwrap();
+
+        assert_eq!(options.api_key, "");
+        assert!(options.is_disabled());
+    }
+
+    #[test]
+    fn builder_disables_client_for_trim_empty_api_key() {
+        let options = ClientOptionsBuilder::default()
+            .api_key(" \n\t ".to_string())
+            .build()
+            .unwrap();
+
+        assert_eq!(options.api_key, "");
+        assert!(options.is_disabled());
     }
 }

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -401,6 +401,99 @@ async fn test_groups_parameter() {
 }
 
 #[tokio::test]
+async fn test_client_with_missing_api_key_is_noop() {
+    let server = MockServer::start();
+
+    let capture_mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v0/e/");
+        then.status(200);
+    });
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/batch/");
+        then.status(200);
+    });
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .build()
+        .unwrap();
+    assert!(options.is_disabled());
+
+    let client = posthog_rs::client(options).await;
+    let event = posthog_rs::Event::new("test_event", "user1");
+
+    assert!(client.capture(event.clone()).await.is_ok());
+    assert!(client.capture_batch(vec![event], false).await.is_ok());
+
+    let (feature_flags, payloads) = client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .await
+        .unwrap();
+    assert!(feature_flags.is_empty());
+    assert!(payloads.is_empty());
+
+    assert_eq!(
+        client
+            .get_feature_flag("test-flag", "test-user", None, None, None)
+            .await
+            .unwrap(),
+        None
+    );
+    assert!(!client
+        .is_feature_enabled("test-flag", "test-user", None, None, None)
+        .await
+        .unwrap());
+    assert_eq!(
+        client
+            .get_feature_flag_payload("test-flag", "test-user")
+            .await
+            .unwrap(),
+        None
+    );
+
+    capture_mock.assert_hits(0);
+    batch_mock.assert_hits(0);
+    flags_mock.assert_hits(0);
+}
+
+#[tokio::test]
+async fn test_client_with_whitespace_api_key_is_noop() {
+    let server = MockServer::start();
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .api_key(" \n\t ".to_string())
+        .host(server.base_url())
+        .build()
+        .unwrap();
+    assert!(options.is_disabled());
+
+    let client = posthog_rs::client(options).await;
+
+    assert!(client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .await
+        .unwrap()
+        .0
+        .is_empty());
+    flags_mock.assert_hits(0);
+}
+
+#[tokio::test]
 async fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -222,6 +222,94 @@ fn test_api_error_handling() {
 }
 
 #[test]
+fn test_client_with_missing_api_key_is_noop() {
+    let server = MockServer::start();
+
+    let capture_mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v0/e/");
+        then.status(200);
+    });
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/batch/");
+        then.status(200);
+    });
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .build()
+        .unwrap();
+    assert!(options.is_disabled());
+
+    let client = posthog_rs::client(options);
+    let event = posthog_rs::Event::new("test_event", "user1");
+
+    assert!(client.capture(event.clone()).is_ok());
+    assert!(client.capture_batch(vec![event], false).is_ok());
+
+    let (feature_flags, payloads) = client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .unwrap();
+    assert!(feature_flags.is_empty());
+    assert!(payloads.is_empty());
+
+    assert_eq!(
+        client
+            .get_feature_flag("test-flag", "test-user", None, None, None)
+            .unwrap(),
+        None
+    );
+    assert!(!client
+        .is_feature_enabled("test-flag", "test-user", None, None, None)
+        .unwrap());
+    assert_eq!(
+        client
+            .get_feature_flag_payload("test-flag", "test-user")
+            .unwrap(),
+        None
+    );
+
+    capture_mock.assert_hits(0);
+    batch_mock.assert_hits(0);
+    flags_mock.assert_hits(0);
+}
+
+#[test]
+fn test_client_with_whitespace_api_key_is_noop() {
+    let server = MockServer::start();
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .api_key(" \n\t ".to_string())
+        .host(server.base_url())
+        .build()
+        .unwrap();
+    assert!(options.is_disabled());
+
+    let client = posthog_rs::client(options);
+
+    assert!(client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .unwrap()
+        .0
+        .is_empty());
+    flags_mock.assert_hits(0);
+}
+
+#[test]
 fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();
 


### PR DESCRIPTION
## Summary
- allow ClientOptionsBuilder to build without an API key and disable the client after trimming blank keys
- no-op disabled clients across capture and feature flag calls so empty API keys are never sent
- add focused async, blocking, and unit coverage for missing and whitespace API keys

## Tests
- cargo test
- cargo test --no-default-features