### PR TITLE
chore: trigger releases from main changesets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,5 @@
 ### If releasing new changes
 
 - [ ] Ran `sampo add` to generate a changeset file
-- [ ] Added the `release` label to the PR
 
 <!-- For more details check RELEASING.md -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.sampo/changesets/**'
+      - '.sampo/changesets/*.md'
   workflow_dispatch:
 
 permissions:
@@ -129,7 +129,7 @@ jobs:
         if: steps.check-changes.outputs.committed == 'true'
         uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde
         with:
-          commit_message: "chore: Release v${{ steps.sampo-release.outputs.new_version }}"
+          commit_message: "chore: Release v${{ steps.sampo-release.outputs.new_version }} [skip ci]"
           repo: ${{ github.repository }}
           branch: main
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,27 @@
 name: "Release"
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+    paths:
+      - '.sampo/changesets/**'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 # Concurrency control: only one release process can run at a time
-# This prevents race conditions if multiple PRs with 'release' label merge simultaneously
+# This prevents race conditions if multiple releasable changesets merge simultaneously
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  check-release-label:
-    name: Check for release label
+  check-changesets:
+    name: Check for changesets
     runs-on: ubuntu-latest
-    # Run when PR with 'release' label is merged to main
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
-        contains(github.event.pull_request.labels.*.name, 'release'))
     outputs:
-      should-release: ${{ steps.check.outputs.should-release }}
+      has-changesets: ${{ steps.check.outputs.has-changesets }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -34,22 +29,22 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Check release conditions
+      - name: Check for changesets
         id: check
         run: |
           changeset_count=$(find .sampo/changesets -name '*.md' 2>/dev/null | wc -l)
           if [ "$changeset_count" -gt 0 ]; then
-            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "has-changesets=true" >> "$GITHUB_OUTPUT"
             echo "Found $changeset_count changeset(s), ready to release"
           else
-            echo "should-release=false" >> "$GITHUB_OUTPUT"
+            echo "has-changesets=false" >> "$GITHUB_OUTPUT"
             echo "No changesets to release"
           fi
 
   notify-approval-needed:
     name: Notify Slack - Approval Needed
-    needs: check-release-label
-    if: needs.check-release-label.outputs.should-release == 'true'
+    needs: check-changesets
+    if: needs.check-changesets.outputs.has-changesets == 'true'
     uses: posthog/.github/.github/workflows/notify-approval-needed.yml@main
     with:
       slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -60,9 +55,9 @@ jobs:
 
   release:
     name: Release and publish
-    needs: [check-release-label, notify-approval-needed]
+    needs: [check-changesets, notify-approval-needed]
     runs-on: ubuntu-latest
-    if: always() && needs.check-release-label.outputs.should-release == 'true'
+    if: always() && needs.check-changesets.outputs.has-changesets == 'true'
     environment: "Release"
     permissions:
       contents: write
@@ -199,7 +194,7 @@ jobs:
 
   notify-released:
     name: Notify Slack - Released
-    needs: [check-release-label, notify-approval-needed, release]
+    needs: [check-changesets, notify-approval-needed, release]
     runs-on: ubuntu-latest
     if: always() && needs.release.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
     steps:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ This repository uses [Sampo](https://github.com/bruits/sampo) for versioning and
 
 2. Commit the generated `.sampo/changesets/*.md` file with your pull request.
 3. After review, merge the PR to `main`. No GitHub release label is required.
-4. A push to `main` that includes `.sampo/changesets/**` changes automatically starts the release workflow.
+4. A push to `main` that includes `.sampo/changesets/*.md` changes automatically starts the release workflow.
 5. Approve the release when prompted in Slack / the GitHub `Release` environment.
 
 After approval, The workflow runs Sampo, publishes the crate, tags the release, and creates a GitHub Release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,26 +1,21 @@
 # Releasing
 
-This repository uses [Sampo](https://github.com/bruits/sampo) for versioning and changelog generation, with GitHub Actions handling publishing.
+This repository uses [Sampo](https://github.com/bruits/sampo) for versioning, changelogs, and publishing to crates.io.
 
-## How to Release
+1. When making changes, include a changeset: `sampo add`
+   - Prefer letting `sampo add` create the file for you.
+   - If you create or edit a changeset manually, the frontmatter must use this exact package key:
 
-1. When making a change that should be released, include a Sampo changeset:
+     ```md
+     ---
+     cargo/posthog-rs: patch
+     ---
+     ```
 
-   ```bash
-   sampo add
-   ```
+   - Replace `patch` with `minor` or `major` when appropriate.
 
-2. Commit the generated `.sampo/changesets/*.md` file with your pull request.
-3. After review, merge the PR to `main`. No GitHub release label is required.
-4. A push to `main` that includes `.sampo/changesets/*.md` changes automatically starts the release workflow.
-5. Approve the release when prompted in Slack / the GitHub `Release` environment.
+2. Create a PR with your changes and the changeset file
+3. Merge to `main` (no release label required)
+4. Approve the release in Slack when prompted — this triggers version bump, crates.io publish, git tag, and GitHub Release
 
-After approval, The workflow runs Sampo, publishes the crate, tags the release, and creates a GitHub Release.
-
-## Manual Trigger
-
-You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending Sampo changesets.
-
-## Troubleshooting
-
-If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.sampo/changesets/*.md` file.
+You can also trigger a release manually via the workflow's `workflow_dispatch` trigger (still requires pending changesets).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,21 +1,26 @@
 # Releasing
 
-This repository uses [Sampo](https://github.com/bruits/sampo) for versioning, changelogs, and publishing to crates.io.
+This repository uses [Sampo](https://github.com/bruits/sampo) for versioning and changelog generation, with GitHub Actions handling publishing.
 
-1. When making changes, include a changeset: `sampo add`
-   - Prefer letting `sampo add` create the file for you.
-   - If you create or edit a changeset manually, the frontmatter must use this exact package key:
+## How to Release
 
-     ```md
-     ---
-     cargo/posthog-rs: patch
-     ---
-     ```
+1. When making a change that should be released, include a Sampo changeset:
 
-   - Replace `patch` with `minor` or `major` when appropriate.
+   ```bash
+   sampo add
+   ```
 
-2. Create a PR with your changes and the changeset file
-3. Add the `release` label and merge to `main`
-4. Approve the release in Slack when prompted — this triggers version bump, crates.io publish, git tag, and GitHub Release
+2. Commit the generated `.sampo/changesets/*.md` file with your pull request.
+3. After review, merge the PR to `main`. No GitHub release label is required.
+4. A push to `main` that includes `.sampo/changesets/**` changes automatically starts the release workflow.
+5. Approve the release when prompted in Slack / the GitHub `Release` environment.
 
-You can also trigger a release manually via the workflow's `workflow_dispatch` trigger (still requires pending changesets).
+After approval, The workflow runs Sampo, publishes the crate, tags the release, and creates a GitHub Release.
+
+## Manual Trigger
+
+You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending Sampo changesets.
+
+## Troubleshooting
+
+If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.sampo/changesets/*.md` file.


### PR DESCRIPTION
## :bulb: Motivation and Context
Standardize SDK releases so they are triggered by pushes to `main` containing release changesets, rather than by PR labels or `pull_request.closed` events.

## Changes
- Updated the release workflow to run on `push` to `main` for `.sampo/changesets/**`, while keeping manual `workflow_dispatch`
- Removed release-label and bump-label checks from the release flow
- Added `[skip ci]` to release version-bump commits and narrowed release path filters to changeset markdown files to avoid re-triggering release workflows on consumed changeset deletions
- Updated only the release-label parts of the release docs and PR checklist

## :green_heart: How did you test it?
- Parsed the updated release workflow YAML locally
- Verified the release workflow no longer references `pull_request`, PR labels, or bump labels
- Verified PR templates no longer ask for release labels

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file (not needed for this release-process-only change)