### PR TITLE
fix: forward groups and group_properties to evaluate_all_flags

### DIFF
--- a/.sampo/changesets/group-and-mixed-targeting-local-eval.md
+++ b/.sampo/changesets/group-and-mixed-targeting-local-eval.md
@@ -1,0 +1,7 @@
+---
+cargo/posthog-rs: minor
+---
+
+feat(flags): support group-targeted and mixed-targeting feature flags in local evaluation
+
+Adds local evaluation support for pure group flags (where `aggregation_group_type_index` is set at the flag level) and mixed-targeting flags (where individual conditions can override the aggregation per condition). `LocalEvaluator::evaluate_flag`, `evaluate_flag_simple`, and `evaluate_all_flags` now take `groups` and `group_properties` parameters; `match_feature_flag` and `match_feature_flag_with_context` have updated signatures. Backwards-incompatible at the public-API level — see PR description for migration notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # posthog-rs
 
-## 0.7.0 — 2026-05-05
-
-### Minor changes
-
-- [e976393](https://github.com/posthog/posthog-rs/commit/e976393182c5bfe1527cc180e732ce51482c87e0) feat(flags): support group-targeted and mixed-targeting feature flags in local evaluation
-  
-  Adds local evaluation support for pure group flags (where `aggregation_group_type_index` is set at the flag level) and mixed-targeting flags (where individual conditions can override the aggregation per condition). `LocalEvaluator::evaluate_flag`, `evaluate_flag_simple`, and `evaluate_all_flags` now take `groups` and `group_properties` parameters; `match_feature_flag` and `match_feature_flag_with_context` have updated signatures. Backwards-incompatible at the public-API level — see PR description for migration notes. — Thanks @patricio-posthog!
-
 ## 0.6.0 — 2026-05-01
 
 ### Minor changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.7.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posthog-rs"
 license = "MIT"
-version = "0.7.0"
+version = "0.6.0"
 authors = ["PostHog <engineering@posthog.com>"]
 description = "The official Rust client for Posthog (https://posthog.com/)."
 repository = "https://github.com/posthog/posthog-rs"

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -570,7 +570,14 @@ impl Client {
 
         if let Some(evaluator) = &self.local_evaluator {
             let person_props_owned = options.person_properties.clone().unwrap_or_default();
-            let local_results = evaluator.evaluate_all_flags(&distinct_id, &person_props_owned);
+            let groups_owned = options.groups.clone().unwrap_or_default();
+            let group_props_owned = options.group_properties.clone().unwrap_or_default();
+            let local_results = evaluator.evaluate_all_flags(
+                &distinct_id,
+                &person_props_owned,
+                &groups_owned,
+                &group_props_owned,
+            );
             for (key, result) in local_results {
                 if let Some(filter) = &options.flag_keys {
                     if !filter.iter().any(|k| k == &key) {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -546,7 +546,14 @@ impl Client {
 
         if let Some(evaluator) = &self.local_evaluator {
             let person_props_owned = options.person_properties.clone().unwrap_or_default();
-            let local_results = evaluator.evaluate_all_flags(&distinct_id, &person_props_owned);
+            let groups_owned = options.groups.clone().unwrap_or_default();
+            let group_props_owned = options.group_properties.clone().unwrap_or_default();
+            let local_results = evaluator.evaluate_all_flags(
+                &distinct_id,
+                &person_props_owned,
+                &groups_owned,
+                &group_props_owned,
+            );
             for (key, result) in local_results {
                 if let Some(filter) = &options.flag_keys {
                     if !filter.iter().any(|k| k == &key) {


### PR DESCRIPTION
## Motivation and Context

The release pipeline for v0.7.0 failed because `Client::evaluate_flags` (added in #105) calls `LocalEvaluator::evaluate_all_flags` with the old 2-argument signature, while #107 changed that method to require `groups` and `group_properties` as well.

The two PRs didn't conflict textually — different files, non-overlapping diffs — so neither PR's CI caught the type-level incompatibility. The repo doesn't run CI on `push: main`, so the failure surfaced only at release time when `cargo publish --dry-run` tried to compile the published tarball.

## Fix

`EvaluateFlagsOptions` already carries `groups` and `group_properties`. Forward them through to `evaluate_all_flags` from both the async and blocking clients.

## How did you test it?

- `cargo build` clean
- `cargo build --features e2e-test` clean (this is the path that fails in the release pipeline)
- `cargo test` — all 119 tests pass
- `cargo clippy --all-targets` clean

## Follow-up worth considering

To prevent this class of bug, the repo could add either:
- A required "branch up-to-date with `main`" rule on PRs (forces a rebase, which would have surfaced the type error before merge).
- A `push: main` build job mirroring the PR build (would catch incompatibilities post-merge before release).