### PR TITLE
chore: run CI on main pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
-name: Test PR
+name: CI
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,10 @@ jobs:
         if: steps.check-changes.outputs.committed == 'true'
         run: git checkout -- . && git pull origin main
 
+      - name: Publish dry-run
+        if: steps.check-changes.outputs.committed == 'true'
+        run: cargo publish --workspace --dry-run
+
       - name: Authenticate with crates.io
         if: steps.check-changes.outputs.committed == 'true'
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4


### PR DESCRIPTION
## :bulb: Motivation and Context
CI only ran for pull requests, so changes merged after a PR check could reach `main` without the normal test workflow running on the final branch state. Release failures were also detected late during publish.

This updates the workflow so CI also runs on pushes to `main`, and adds a release dry-run before authenticating/publishing so package verification failures surface earlier.

## :green_heart: How did you test it?

- `git diff --check`
- Parsed `.github/workflows/ci.yaml` and `.github/workflows/release.yml` with Ruby's YAML parser

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
