### PR TITLE
fix: include group context in $feature_flag_called dedupe key

### DIFF
--- a/.sampo/changesets/include-group-context-in-flag-called-dedupe.md
+++ b/.sampo/changesets/include-group-context-in-flag-called-dedupe.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Include group context in the `$feature_flag_called` dedupe key so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinct_id, flag, response)` was seen under.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -196,7 +196,9 @@ fn build_dedup_key(
 }
 
 fn pct(s: &str) -> String {
-    s.replace('%', "%25").replace('=', "%3D").replace(';', "%3B")
+    s.replace('%', "%25")
+        .replace('=', "%3D")
+        .replace(';', "%3B")
 }
 
 /// This function constructs a new client using the options provided.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -137,7 +137,7 @@ impl AsyncFlagEventHost {
 
 impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
     fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
-        let dedup_key = build_dedup_key(&params.key, params.response.as_ref());
+        let dedup_key = build_dedup_key(&params.key, params.response.as_ref(), &params.groups);
         if self.already_reported(&params.distinct_id, &dedup_key) {
             return;
         }
@@ -167,14 +167,32 @@ impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
     }
 }
 
-fn build_dedup_key(flag_key: &str, response: Option<&FlagValue>) -> String {
+fn build_dedup_key(
+    flag_key: &str,
+    response: Option<&FlagValue>,
+    groups: &HashMap<String, String>,
+) -> String {
     let response_repr = match response {
         Some(FlagValue::Boolean(true)) => "true".to_string(),
         Some(FlagValue::Boolean(false)) => "false".to_string(),
         Some(FlagValue::String(s)) => s.clone(),
         None => "::null::".to_string(),
     };
-    format!("{flag_key}_{response_repr}")
+    if groups.is_empty() {
+        format!("{flag_key}_{response_repr}")
+    } else {
+        // Canonicalize so two equal group maps with different insertion orders
+        // produce the same dedup key — necessary for group-scoped flags to fire
+        // exactly once per distinct group context.
+        let mut sorted: Vec<(&String, &String)> = groups.iter().collect();
+        sorted.sort_by(|a, b| a.0.cmp(b.0));
+        let groups_repr: String = sorted
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(";");
+        format!("{flag_key}_{response_repr}_{groups_repr}")
+    }
 }
 
 /// This function constructs a new client using the options provided.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -188,11 +188,15 @@ fn build_dedup_key(
         sorted.sort_by(|a, b| a.0.cmp(b.0));
         let groups_repr: String = sorted
             .iter()
-            .map(|(k, v)| format!("{k}={v}"))
+            .map(|(k, v)| format!("{}={}", pct(k), pct(v)))
             .collect::<Vec<_>>()
             .join(";");
         format!("{flag_key}_{response_repr}_{groups_repr}")
     }
+}
+
+fn pct(s: &str) -> String {
+    s.replace('%', "%25").replace('=', "%3D").replace(';', "%3B")
 }
 
 /// This function constructs a new client using the options provided.

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -180,7 +180,9 @@ fn build_dedup_key(
 }
 
 fn pct(s: &str) -> String {
-    s.replace('%', "%25").replace('=', "%3D").replace(';', "%3B")
+    s.replace('%', "%25")
+        .replace('=', "%3D")
+        .replace(';', "%3B")
 }
 
 /// This function constructs a new client using the options provided.

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -121,7 +121,7 @@ impl BlockingFlagEventHost {
 
 impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
     fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
-        let dedup_key = build_dedup_key(&params.key, params.response.as_ref());
+        let dedup_key = build_dedup_key(&params.key, params.response.as_ref(), &params.groups);
         if self.already_reported(&params.distinct_id, &dedup_key) {
             return;
         }
@@ -151,14 +151,32 @@ impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
     }
 }
 
-fn build_dedup_key(flag_key: &str, response: Option<&FlagValue>) -> String {
+fn build_dedup_key(
+    flag_key: &str,
+    response: Option<&FlagValue>,
+    groups: &HashMap<String, String>,
+) -> String {
     let response_repr = match response {
         Some(FlagValue::Boolean(true)) => "true".to_string(),
         Some(FlagValue::Boolean(false)) => "false".to_string(),
         Some(FlagValue::String(s)) => s.clone(),
         None => "::null::".to_string(),
     };
-    format!("{flag_key}_{response_repr}")
+    if groups.is_empty() {
+        format!("{flag_key}_{response_repr}")
+    } else {
+        // Canonicalize so two equal group maps with different insertion orders
+        // produce the same dedup key — necessary for group-scoped flags to fire
+        // exactly once per distinct group context.
+        let mut sorted: Vec<(&String, &String)> = groups.iter().collect();
+        sorted.sort_by(|a, b| a.0.cmp(b.0));
+        let groups_repr: String = sorted
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(";");
+        format!("{flag_key}_{response_repr}_{groups_repr}")
+    }
 }
 
 /// This function constructs a new client using the options provided.

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -172,11 +172,15 @@ fn build_dedup_key(
         sorted.sort_by(|a, b| a.0.cmp(b.0));
         let groups_repr: String = sorted
             .iter()
-            .map(|(k, v)| format!("{k}={v}"))
+            .map(|(k, v)| format!("{}={}", pct(k), pct(v)))
             .collect::<Vec<_>>()
             .join(";");
         format!("{flag_key}_{response_repr}_{groups_repr}")
     }
+}
+
+fn pct(s: &str) -> String {
+    s.replace('%', "%25").replace('=', "%3D").replace(';', "%3B")
 }
 
 /// This function constructs a new client using the options provided.

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -168,6 +168,127 @@ mod blocking {
     }
 
     #[test]
+    fn is_enabled_fires_per_group_context() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST).path("/i/v0/e/");
+            then.status(200);
+        });
+        let client = create_test_client(server.base_url());
+
+        let mut org_a = std::collections::HashMap::new();
+        org_a.insert("organization".to_string(), "org-a".to_string());
+        let mut org_b = std::collections::HashMap::new();
+        org_b.insert("organization".to_string(), "org-b".to_string());
+
+        let snap_a = client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    groups: Some(org_a),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let snap_b = client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    groups: Some(org_b),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(snap_a.is_enabled("alpha"));
+        assert!(snap_b.is_enabled("alpha"));
+
+        // Same user, same flag, same response but two different group contexts —
+        // both must fire.
+        capture_mock.assert_hits(2);
+    }
+
+    #[test]
+    fn is_enabled_dedupes_across_repeated_calls_under_same_group() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST).path("/i/v0/e/");
+            then.status(200);
+        });
+        let client = create_test_client(server.base_url());
+
+        let mut groups = std::collections::HashMap::new();
+        groups.insert("organization".to_string(), "org-a".to_string());
+
+        let snap = client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    groups: Some(groups),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(snap.is_enabled("alpha"));
+        assert!(snap.is_enabled("alpha"));
+        assert!(snap.is_enabled("alpha"));
+
+        capture_mock.assert_hits(1);
+    }
+
+    #[test]
+    fn is_enabled_dedupes_across_group_insertion_order() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST).path("/i/v0/e/");
+            then.status(200);
+        });
+        let client = create_test_client(server.base_url());
+
+        let mut g1 = std::collections::HashMap::new();
+        g1.insert("organization".to_string(), "org-a".to_string());
+        g1.insert("team".to_string(), "red".to_string());
+        let mut g2 = std::collections::HashMap::new();
+        g2.insert("team".to_string(), "red".to_string());
+        g2.insert("organization".to_string(), "org-a".to_string());
+
+        let snap_1 = client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    groups: Some(g1),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let snap_2 = client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    groups: Some(g2),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(snap_1.is_enabled("alpha"));
+        assert!(snap_2.is_enabled("alpha"));
+
+        capture_mock.assert_hits(1);
+    }
+
+    #[test]
     fn flag_keys_forwarded_to_request_body() {
         let server = MockServer::start();
         let flags_mock = server.mock(|when, then| {

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -167,8 +167,11 @@ mod blocking {
         capture_mock.assert_hits(0);
     }
 
-    #[test]
-    fn is_enabled_fires_per_group_context() {
+    fn assert_group_dedup(
+        g1: std::collections::HashMap<String, String>,
+        g2: std::collections::HashMap<String, String>,
+        expected_hits: usize,
+    ) {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(POST).path("/flags/");
@@ -179,90 +182,6 @@ mod blocking {
             then.status(200);
         });
         let client = create_test_client(server.base_url());
-
-        let mut org_a = std::collections::HashMap::new();
-        org_a.insert("organization".to_string(), "org-a".to_string());
-        let mut org_b = std::collections::HashMap::new();
-        org_b.insert("organization".to_string(), "org-b".to_string());
-
-        let snap_a = client
-            .evaluate_flags(
-                "user-1",
-                EvaluateFlagsOptions {
-                    groups: Some(org_a),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-        let snap_b = client
-            .evaluate_flags(
-                "user-1",
-                EvaluateFlagsOptions {
-                    groups: Some(org_b),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-
-        assert!(snap_a.is_enabled("alpha"));
-        assert!(snap_b.is_enabled("alpha"));
-
-        // Same user, same flag, same response but two different group contexts —
-        // both must fire.
-        capture_mock.assert_hits(2);
-    }
-
-    #[test]
-    fn is_enabled_dedupes_across_repeated_calls_under_same_group() {
-        let server = MockServer::start();
-        server.mock(|when, then| {
-            when.method(POST).path("/flags/");
-            then.status(200).json_body(flags_response_fixture());
-        });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
-        let client = create_test_client(server.base_url());
-
-        let mut groups = std::collections::HashMap::new();
-        groups.insert("organization".to_string(), "org-a".to_string());
-
-        let snap = client
-            .evaluate_flags(
-                "user-1",
-                EvaluateFlagsOptions {
-                    groups: Some(groups),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-        assert!(snap.is_enabled("alpha"));
-        assert!(snap.is_enabled("alpha"));
-        assert!(snap.is_enabled("alpha"));
-
-        capture_mock.assert_hits(1);
-    }
-
-    #[test]
-    fn is_enabled_dedupes_across_group_insertion_order() {
-        let server = MockServer::start();
-        server.mock(|when, then| {
-            when.method(POST).path("/flags/");
-            then.status(200).json_body(flags_response_fixture());
-        });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
-        let client = create_test_client(server.base_url());
-
-        let mut g1 = std::collections::HashMap::new();
-        g1.insert("organization".to_string(), "org-a".to_string());
-        g1.insert("team".to_string(), "red".to_string());
-        let mut g2 = std::collections::HashMap::new();
-        g2.insert("team".to_string(), "red".to_string());
-        g2.insert("organization".to_string(), "org-a".to_string());
 
         let snap_1 = client
             .evaluate_flags(
@@ -284,8 +203,71 @@ mod blocking {
             .unwrap();
         assert!(snap_1.is_enabled("alpha"));
         assert!(snap_2.is_enabled("alpha"));
+        capture_mock.assert_hits(expected_hits);
+    }
 
+    fn groups(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+    }
+
+    #[test]
+    fn is_enabled_fires_per_group_context() {
+        // Same user, same flag, different group context — both must fire.
+        assert_group_dedup(
+            groups(&[("organization", "org-a")]),
+            groups(&[("organization", "org-b")]),
+            2,
+        );
+    }
+
+    #[test]
+    fn is_enabled_dedupes_across_repeated_calls_under_same_group() {
+        // Calling is_enabled multiple times on the same snapshot fires only once.
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST).path("/i/v0/e/");
+            then.status(200);
+        });
+        let client = create_test_client(server.base_url());
+        let snap = client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    groups: Some(groups(&[("organization", "org-a")])),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(snap.is_enabled("alpha"));
+        assert!(snap.is_enabled("alpha"));
+        assert!(snap.is_enabled("alpha"));
         capture_mock.assert_hits(1);
+    }
+
+    #[test]
+    fn is_enabled_dedupes_across_group_insertion_order() {
+        // Same content, different insertion order — only one event.
+        assert_group_dedup(
+            groups(&[("organization", "org-a"), ("team", "red")]),
+            groups(&[("team", "red"), ("organization", "org-a")]),
+            1,
+        );
+    }
+
+    #[test]
+    fn is_enabled_treats_groups_with_separator_chars_as_distinct() {
+        // {"a=b": "c"} and {"a": "b=c"} must produce different dedup keys;
+        // without encoding both serialise to "a=b=c" and the second event
+        // would be incorrectly suppressed.
+        assert_group_dedup(
+            groups(&[("a=b", "c")]),
+            groups(&[("a", "b=c")]),
+            2,
+        );
     }
 
     #[test]

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -207,7 +207,10 @@ mod blocking {
     }
 
     fn groups(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
-        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
     }
 
     #[test]
@@ -263,11 +266,7 @@ mod blocking {
         // {"a=b": "c"} and {"a": "b=c"} must produce different dedup keys;
         // without encoding both serialise to "a=b=c" and the second event
         // would be incorrectly suppressed.
-        assert_group_dedup(
-            groups(&[("a=b", "c")]),
-            groups(&[("a", "b=c")]),
-            2,
-        );
+        assert_group_dedup(groups(&[("a=b", "c")]), groups(&[("a", "b=c")]), 2);
     }
 
     #[test]


### PR DESCRIPTION
## :bulb: Motivation and Context

In `build_dedup_key` (in both `client/async_client.rs` and `client/blocking.rs`), the per-`distinct_id` dedup key only included `(flag_key, response)`. For group-scoped flags this meant that when the same user was evaluated under a different group, no new `$feature_flag_called` event was fired — causing per-group exposure undercount for experiments scoped to a group key.

Mirrors the posthog-node fix in PostHog/posthog-js#3658 (which closes PostHog/posthog-js#3651). Both SDKs share the same dedupe shape, so backend evaluation needs the same change.

## :green_heart: How did you test it?

Added three integration tests in `tests/test_evaluate_flags.rs` (under the blocking module):

- `is_enabled_fires_per_group_context` — same user, same flag, two different group contexts → two events fired.
- `is_enabled_dedupes_across_repeated_calls_under_same_group` — repeated access under the same group → one event.
- `is_enabled_dedupes_across_group_insertion_order` — same groups passed in different insertion order → one event (canonicalized via `sort_by`).

`cargo test --test test_evaluate_flags --no-default-features` is green (17/17). The async-client tests pass as well via `cargo test`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*