### PR TITLE
Commit initial framework for SDK test harness integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,14 @@ jobs:
     - name: Build
       run: cargo build --verbose
 
-    - name: Unit test
+    - name: Unit test (default features)
       run: cargo test --verbose
 
+    - name: Unit test (workspace, includes capture-v1)
+      run: cargo test --workspace --verbose
+
+    # TODO: when v1 endpoint ships, remove the capture-v1 feature gate;
+    # v1 e2e test (get_client_v1_async) will then run here automatically.
     - name: E2E test
       run: cargo test --verbose --features e2e-test --no-default-features
       env:

--- a/.github/workflows/sdk-compliance-tests-v0.yml
+++ b/.github/workflows/sdk-compliance-tests-v0.yml
@@ -1,0 +1,34 @@
+name: SDK Compliance Tests (V0 Capture)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'compliance/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/sdk-compliance-tests-v0.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'compliance/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/sdk-compliance-tests-v0.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  pull-requests: write
+
+jobs:
+  test-rust-sdk-v0:
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@main
+    with:
+      adapter-dockerfile: compliance/v0/Dockerfile
+      adapter-context: .
+      test-harness-version: latest
+      report-name: rust-sdk-compliance-report-v0

--- a/.github/workflows/sdk-compliance-tests-v0.yml
+++ b/.github/workflows/sdk-compliance-tests-v0.yml
@@ -32,3 +32,4 @@ jobs:
       adapter-context: .
       test-harness-version: latest
       report-name: rust-sdk-compliance-report-v0
+      concurrency: 10

--- a/.github/workflows/sdk-compliance-tests-v1.yml
+++ b/.github/workflows/sdk-compliance-tests-v1.yml
@@ -1,0 +1,34 @@
+name: SDK Compliance Tests (V1 Capture)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'compliance/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/sdk-compliance-tests-v1.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'compliance/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/sdk-compliance-tests-v1.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  pull-requests: write
+
+jobs:
+  test-rust-sdk-v1:
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@main
+    with:
+      adapter-dockerfile: compliance/v1/Dockerfile
+      adapter-context: .
+      test-harness-version: latest
+      report-name: rust-sdk-compliance-report-v1

--- a/.github/workflows/sdk-compliance-tests-v1.yml
+++ b/.github/workflows/sdk-compliance-tests-v1.yml
@@ -32,3 +32,4 @@ jobs:
       adapter-context: .
       test-harness-version: latest
       report-name: rust-sdk-compliance-report-v1
+      concurrency: 10

--- a/.sampo/changesets/add-v1-capture-pipeline.md
+++ b/.sampo/changesets/add-v1-capture-pipeline.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Add V1 capture pipeline (`/i/v1/analytics/events/`) behind the unstable `capture-v1` Cargo feature (off by default). Includes gzip/deflate/br/zstd compression, automatic partial-batch retry with exponential backoff, per-event options (cookieless mode, skew correction, person profile, product tour), and historical migration support. A separate `test-harness` feature enables injecting extra request headers for compliance test isolation.

--- a/.sampo/changesets/non-exhaustive-endpoint-enum.md
+++ b/.sampo/changesets/non-exhaustive-endpoint-enum.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Mark public `Endpoint` enum as `#[non_exhaustive]` and add `CaptureV1` variant. Downstream code that exhaustively matches on `Endpoint` without a wildcard arm will need to add `_ => { ... }`.

--- a/.sampo/changesets/non-exhaustive-endpoint-enum.md
+++ b/.sampo/changesets/non-exhaustive-endpoint-enum.md
@@ -1,5 +1,0 @@
----
-cargo/posthog-rs: minor
----
-
-Mark public `Endpoint` enum as `#[non_exhaustive]` and add `CaptureV1` variant. Downstream code that exhaustively matches on `Endpoint` without a wildcard arm will need to add `_ => { ... }`.

--- a/.sampo/config.toml
+++ b/.sampo/config.toml
@@ -14,6 +14,4 @@ repository = "posthog/posthog-rs"
 # show_acknowledgments = true (default)
 
 [packages]
-# Options for package discovery and filtering.
-# ignore_unpublished = false (default)
-# ignore = ["internal-*", "examples/*"]
+ignore = ["compliance/*"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1111,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1466,10 +1519,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2008,6 +2073,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2101,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdk-adapter"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "posthog-rs",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "security-framework"
@@ -2104,12 +2188,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_regex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
 dependencies = [
  "regex",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2445,6 +2552,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2488,6 +2596,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,10 +303,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -319,7 +334,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -394,6 +409,27 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1677,6 +1713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,10 +1736,12 @@ dependencies = [
 name = "posthog-rs"
 version = "0.8.0"
 dependencies = [
+ "brotli",
  "chrono",
  "ctor",
  "derive_builder",
  "dotenv",
+ "flate2",
  "futures",
  "httpmock",
  "regex",
@@ -1710,6 +1754,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -3345,3 +3390,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 default = ["async-client"]
 e2e-test = []
 async-client = ["tokio"]
+capture-v1 = []
+test-harness = []
 
 [workspace]
 members = ["compliance/adapter"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ tokio = { version = "1", features = [
     "time",
     "macros",
 ], optional = true }
+flate2 = { version = "1.0", optional = true }
+brotli = { version = "7.0", optional = true }
+zstd = { version = "0.13", optional = true }
 
 [dev-dependencies]
 dotenv = "0.15.0"
@@ -44,7 +47,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 default = ["async-client"]
 e2e-test = []
 async-client = ["tokio"]
-capture-v1 = []
+capture-v1 = ["flate2", "brotli", "zstd"]
 test-harness = []
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 default = ["async-client"]
 e2e-test = []
 async-client = ["tokio"]
+
+[workspace]
+members = ["compliance/adapter"]

--- a/compliance/adapter/Cargo.toml
+++ b/compliance/adapter/Cargo.toml
@@ -5,10 +5,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-posthog-rs = { path = "../..", features = ["async-client"] }
+posthog-rs = { path = "../..", features = ["async-client", "test-harness"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v7"] }
 chrono = "0.4"
+
+[features]
+capture-v1 = ["posthog-rs/capture-v1"]

--- a/compliance/adapter/Cargo.toml
+++ b/compliance/adapter/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sdk-adapter"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+posthog-rs = { path = "../..", features = ["async-client"] }
+axum = "0.8"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+uuid = { version = "1", features = ["v7"] }
+chrono = "0.4"

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -1,0 +1,278 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use posthog_rs::{CaptureMode, Client, ClientOptionsBuilder, Event};
+
+#[derive(Clone)]
+struct AppState {
+    inner: Arc<Mutex<AdapterState>>,
+    capture_mode: CaptureMode,
+}
+
+struct AdapterState {
+    client: Option<Client>,
+    total_events_captured: u64,
+    total_events_sent: u64,
+    total_retries: u64,
+    last_error: Option<String>,
+    requests_made: Vec<RequestRecord>,
+    pending_events: i64,
+}
+
+impl Default for AdapterState {
+    fn default() -> Self {
+        Self {
+            client: None,
+            total_events_captured: 0,
+            total_events_sent: 0,
+            total_retries: 0,
+            last_error: None,
+            requests_made: Vec::new(),
+            pending_events: 0,
+        }
+    }
+}
+
+#[derive(Serialize, Clone)]
+struct RequestRecord {
+    timestamp_ms: u64,
+    status_code: u16,
+    retry_attempt: u32,
+    event_count: usize,
+    uuid_list: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct InitRequest {
+    api_key: String,
+    host: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    flush_at: Option<u32>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    flush_interval_ms: Option<u64>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    max_retries: Option<u32>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    enable_compression: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct CaptureRequest {
+    distinct_id: String,
+    event: String,
+    #[serde(default)]
+    properties: Option<serde_json::Value>,
+    #[serde(default)]
+    timestamp: Option<String>,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    sdk_name: &'static str,
+    sdk_version: &'static str,
+    adapter_version: &'static str,
+    capabilities: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct StateResponse {
+    pending_events: i64,
+    total_events_captured: u64,
+    total_events_sent: u64,
+    total_retries: u64,
+    last_error: Option<String>,
+    requests_made: Vec<RequestRecord>,
+}
+
+fn parse_capture_mode() -> CaptureMode {
+    match std::env::var("CAPTURE_MODE").as_deref() {
+        Ok("v1") => CaptureMode::V1,
+        _ => CaptureMode::V0,
+    }
+}
+
+async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
+    let capability = match state.capture_mode {
+        CaptureMode::V0 => "capture_v0",
+        CaptureMode::V1 => "capture_v1",
+    };
+    Json(HealthResponse {
+        sdk_name: "posthog-rs",
+        sdk_version: env!("CARGO_PKG_VERSION"),
+        adapter_version: "0.1.0",
+        capabilities: vec![capability],
+    })
+}
+
+async fn init(
+    State(state): State<AppState>,
+    Json(req): Json<InitRequest>,
+) -> impl IntoResponse {
+    let mut s = state.inner.lock().await;
+
+    // Reset state
+    *s = AdapterState::default();
+
+    let options = ClientOptionsBuilder::default()
+        .api_key(req.api_key)
+        .host(req.host)
+        .capture_mode(state.capture_mode)
+        .build();
+
+    match options {
+        Ok(opts) => {
+            let client = posthog_rs::client(opts).await;
+            s.client = Some(client);
+            Json(serde_json::json!({ "success": true })).into_response()
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            s.last_error = Some(msg.clone());
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": msg })),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn capture_event(
+    State(state): State<AppState>,
+    Json(req): Json<CaptureRequest>,
+) -> impl IntoResponse {
+    let mut s = state.inner.lock().await;
+
+    let client = match &s.client {
+        Some(c) => c,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "SDK not initialized" })),
+            )
+                .into_response();
+        }
+    };
+
+    let mut event = Event::new(req.event, req.distinct_id);
+
+    if let Some(props) = req.properties {
+        if let Some(obj) = props.as_object() {
+            for (k, v) in obj {
+                let _ = event.insert_prop(k.clone(), v.clone());
+            }
+        }
+    }
+
+    if let Some(ts_str) = req.timestamp {
+        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&ts_str) {
+            let _ = event.set_timestamp(ts);
+        }
+    }
+
+    let uuid = uuid::Uuid::now_v7().to_string();
+
+    match client.capture(event).await {
+        Ok(()) => {
+            s.total_events_captured += 1;
+            s.pending_events += 1;
+            // For V0, events are sent immediately by capture()
+            s.total_events_sent += 1;
+            s.pending_events -= 1;
+            if s.pending_events < 0 {
+                s.pending_events = 0;
+            }
+            Json(serde_json::json!({ "success": true, "uuid": uuid })).into_response()
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            s.total_events_captured += 1;
+            s.last_error = Some(msg.clone());
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": msg })),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn flush(State(state): State<AppState>) -> impl IntoResponse {
+    let s = state.inner.lock().await;
+
+    if s.client.is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "SDK not initialized" })),
+        )
+            .into_response();
+    }
+
+    // posthog-rs sends events immediately in capture(), so flush is a no-op
+    Json(serde_json::json!({
+        "success": true,
+        "events_flushed": s.total_events_sent
+    }))
+    .into_response()
+}
+
+async fn get_state(State(state): State<AppState>) -> Json<StateResponse> {
+    let s = state.inner.lock().await;
+    Json(StateResponse {
+        pending_events: s.pending_events,
+        total_events_captured: s.total_events_captured,
+        total_events_sent: s.total_events_sent,
+        total_retries: s.total_retries,
+        last_error: s.last_error.clone(),
+        requests_made: s.requests_made.clone(),
+    })
+}
+
+async fn reset(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let mut s = state.inner.lock().await;
+    *s = AdapterState::default();
+    Json(serde_json::json!({ "success": true }))
+}
+
+#[tokio::main]
+async fn main() {
+    let capture_mode = parse_capture_mode();
+    let mode_str = match capture_mode {
+        CaptureMode::V0 => "v0",
+        CaptureMode::V1 => "v1",
+    };
+    eprintln!("Starting posthog-rs SDK adapter (CAPTURE_MODE={mode_str})");
+
+    let state = AppState {
+        inner: Arc::new(Mutex::new(AdapterState::default())),
+        capture_mode,
+    };
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/init", post(init))
+        .route("/capture", post(capture_event))
+        .route("/flush", post(flush))
+        .route("/state", get(get_state))
+        .route("/reset", post(reset))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080")
+        .await
+        .expect("failed to bind to port 8080");
+    eprintln!("Listening on 0.0.0.0:8080");
+    axum::serve(listener, app).await.expect("server error");
+}

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -11,14 +11,13 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
-use posthog_rs::{CaptureMode, Client, ClientOptionsBuilder, Event};
+use posthog_rs::{Client, ClientOptionsBuilder, Event};
 
 const SUPPORTS_PARALLEL: bool = true;
 
 #[derive(Clone)]
 struct AppState {
     instances: Arc<Mutex<HashMap<String, AdapterState>>>,
-    capture_mode: CaptureMode,
 }
 
 const DEFAULT_TEST_ID: &str = "_global";
@@ -97,17 +96,11 @@ struct StateResponse {
     last_error: Option<String>,
 }
 
-fn parse_capture_mode() -> CaptureMode {
-    match std::env::var("CAPTURE_MODE").as_deref() {
-        Ok("v1") => CaptureMode::V1,
-        _ => CaptureMode::V0,
-    }
-}
-
-async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
-    let capability = match state.capture_mode {
-        CaptureMode::V0 => "capture_v0",
-        CaptureMode::V1 => "capture_v1",
+async fn health() -> Json<HealthResponse> {
+    let capability = if cfg!(feature = "capture-v1") {
+        "capture_v1"
+    } else {
+        "capture_v0"
     };
     Json(HealthResponse {
         sdk_name: "posthog-rs",
@@ -130,10 +123,7 @@ async fn init(
     s.historical_migration = req.historical_migration.unwrap_or(false);
 
     let mut builder = ClientOptionsBuilder::default();
-    builder
-        .api_key(req.api_key)
-        .host(req.host)
-        .capture_mode(state.capture_mode);
+    builder.api_key(req.api_key).host(req.host);
 
     if req.disable_geoip.unwrap_or(false) {
         builder.disable_geoip(true);
@@ -313,18 +303,15 @@ async fn reset(
 
 #[tokio::main]
 async fn main() {
-    let capture_mode = parse_capture_mode();
-    let mode_str = match capture_mode {
-        CaptureMode::V0 => "v0",
-        CaptureMode::V1 => "v1",
+    let mode_str = if cfg!(feature = "capture-v1") {
+        "v1"
+    } else {
+        "v0"
     };
-    eprintln!(
-        "Starting posthog-rs SDK adapter (CAPTURE_MODE={mode_str}, parallel={SUPPORTS_PARALLEL})"
-    );
+    eprintln!("Starting posthog-rs SDK adapter (capture={mode_str}, parallel={SUPPORTS_PARALLEL})");
 
     let state = AppState {
         instances: Arc::new(Mutex::new(HashMap::new())),
-        capture_mode,
     };
 
     let app = Router::new()

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -23,26 +23,14 @@ struct AppState {
 
 const DEFAULT_TEST_ID: &str = "_global";
 
+#[derive(Default)]
 struct AdapterState {
-    client: Option<Client>,
+    client: Option<Arc<Client>>,
     historical_migration: bool,
     total_events_captured: u64,
     total_events_sent: u64,
     last_error: Option<String>,
     pending_events: i64,
-}
-
-impl Default for AdapterState {
-    fn default() -> Self {
-        Self {
-            client: None,
-            historical_migration: false,
-            total_events_captured: 0,
-            total_events_sent: 0,
-            last_error: None,
-            pending_events: 0,
-        }
-    }
 }
 
 #[derive(Deserialize)]
@@ -124,7 +112,7 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     Json(HealthResponse {
         sdk_name: "posthog-rs",
         sdk_version: env!("CARGO_PKG_VERSION"),
-        adapter_version: "0.3.0",
+        adapter_version: env!("CARGO_PKG_VERSION"),
         capabilities: vec![capability],
         supports_parallel: SUPPORTS_PARALLEL,
     })
@@ -162,7 +150,7 @@ async fn init(
     match builder.build() {
         Ok(opts) => {
             let client = posthog_rs::client(opts).await;
-            s.client = Some(client);
+            s.client = Some(Arc::new(client));
             Json(serde_json::json!({ "success": true })).into_response()
         }
         Err(e) => {
@@ -182,20 +170,29 @@ async fn capture_event(
     Query(params): Query<TestIdParam>,
     Json(req): Json<CaptureRequest>,
 ) -> impl IntoResponse {
-    let mut instances = state.instances.lock().await;
-    let s = instances.entry(params.key().to_string()).or_default();
+    let key = params.key().to_string();
 
-    let client = match &s.client {
-        Some(c) => c,
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "error": "SDK not initialized" })),
-            )
-                .into_response();
+    // Phase 1: short lock — clone Arc<Client>, bump in-flight counter
+    let client = {
+        let mut instances = state.instances.lock().await;
+        let s = instances.entry(key.clone()).or_default();
+        match &s.client {
+            Some(c) => {
+                s.total_events_captured += 1;
+                s.pending_events += 1;
+                c.clone()
+            }
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": "SDK not initialized" })),
+                )
+                    .into_response();
+            }
         }
     };
 
+    // Build event outside the lock
     let mut event = Event::new(req.event, req.distinct_id);
 
     if let Some(props) = req.properties {
@@ -218,27 +215,32 @@ async fn capture_event(
 
     let uuid = uuid::Uuid::now_v7().to_string();
 
-    match client.capture(event).await {
-        Ok(()) => {
-            s.total_events_captured += 1;
-            s.pending_events += 1;
-            s.total_events_sent += 1;
-            s.pending_events -= 1;
-            if s.pending_events < 0 {
-                s.pending_events = 0;
+    // Phase 2: network call without holding the lock
+    let result = client.capture(event).await;
+
+    // Phase 3: short lock — record outcome
+    {
+        let mut instances = state.instances.lock().await;
+        if let Some(s) = instances.get_mut(&key) {
+            s.pending_events = (s.pending_events - 1).max(0);
+            match &result {
+                Ok(()) => {
+                    s.total_events_sent += 1;
+                }
+                Err(e) => {
+                    s.last_error = Some(e.to_string());
+                }
             }
-            Json(serde_json::json!({ "success": true, "uuid": uuid })).into_response()
         }
-        Err(e) => {
-            let msg = e.to_string();
-            s.total_events_captured += 1;
-            s.last_error = Some(msg.clone());
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": msg })),
-            )
-                .into_response()
-        }
+    }
+
+    match result {
+        Ok(()) => Json(serde_json::json!({ "success": true, "uuid": uuid })).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
     }
 }
 

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -13,6 +13,8 @@ use tokio::sync::Mutex;
 
 use posthog_rs::{CaptureMode, Client, ClientOptionsBuilder, Event};
 
+const SUPPORTS_PARALLEL: bool = true;
+
 #[derive(Clone)]
 struct AppState {
     instances: Arc<Mutex<HashMap<String, AdapterState>>>,
@@ -23,11 +25,10 @@ const DEFAULT_TEST_ID: &str = "_global";
 
 struct AdapterState {
     client: Option<Client>,
+    historical_migration: bool,
     total_events_captured: u64,
     total_events_sent: u64,
-    total_retries: u64,
     last_error: Option<String>,
-    requests_made: Vec<RequestRecord>,
     pending_events: i64,
 }
 
@@ -35,23 +36,13 @@ impl Default for AdapterState {
     fn default() -> Self {
         Self {
             client: None,
+            historical_migration: false,
             total_events_captured: 0,
             total_events_sent: 0,
-            total_retries: 0,
             last_error: None,
-            requests_made: Vec::new(),
             pending_events: 0,
         }
     }
-}
-
-#[derive(Serialize, Clone)]
-struct RequestRecord {
-    timestamp_ms: u64,
-    status_code: u16,
-    retry_attempt: u32,
-    event_count: usize,
-    uuid_list: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -70,6 +61,10 @@ struct InitRequest {
     #[allow(dead_code)]
     #[serde(default)]
     enable_compression: Option<bool>,
+    #[serde(default)]
+    disable_geoip: Option<bool>,
+    #[serde(default)]
+    historical_migration: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -80,6 +75,8 @@ struct CaptureRequest {
     properties: Option<serde_json::Value>,
     #[serde(default)]
     timestamp: Option<String>,
+    #[serde(default)]
+    options: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize, Default)]
@@ -110,7 +107,6 @@ struct StateResponse {
     total_events_sent: u64,
     total_retries: u64,
     last_error: Option<String>,
-    requests_made: Vec<RequestRecord>,
 }
 
 fn parse_capture_mode() -> CaptureMode {
@@ -128,9 +124,9 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     Json(HealthResponse {
         sdk_name: "posthog-rs",
         sdk_version: env!("CARGO_PKG_VERSION"),
-        adapter_version: "0.1.0",
+        adapter_version: "0.3.0",
         capabilities: vec![capability],
-        supports_parallel: true,
+        supports_parallel: SUPPORTS_PARALLEL,
     })
 }
 
@@ -143,14 +139,27 @@ async fn init(
     let s = instances.entry(params.key().to_string()).or_default();
 
     *s = AdapterState::default();
+    s.historical_migration = req.historical_migration.unwrap_or(false);
 
-    let options = ClientOptionsBuilder::default()
+    let mut builder = ClientOptionsBuilder::default();
+    builder
         .api_key(req.api_key)
         .host(req.host)
-        .capture_mode(state.capture_mode)
-        .build();
+        .capture_mode(state.capture_mode);
 
-    match options {
+    if req.disable_geoip.unwrap_or(false) {
+        builder.disable_geoip(true);
+    }
+
+    // Inject X-Test-Id header so the mock capture server can partition
+    // requests by test when running in parallel mode.
+    if let Some(ref test_id) = params.test_id {
+        let mut headers = HashMap::new();
+        headers.insert("X-Test-Id".to_string(), test_id.clone());
+        builder.extra_capture_headers(headers);
+    }
+
+    match builder.build() {
         Ok(opts) => {
             let client = posthog_rs::client(opts).await;
             s.client = Some(client);
@@ -202,6 +211,10 @@ async fn capture_event(
             let _ = event.set_timestamp(ts);
         }
     }
+
+    // EventOptions wiring (set_options) is applied in the V1 capture
+    // implementation branch where EventOptions exists on Event.
+    let _ = req.options;
 
     let uuid = uuid::Uuid::now_v7().to_string();
 
@@ -272,9 +285,8 @@ async fn get_state(
             pending_events: s.pending_events,
             total_events_captured: s.total_events_captured,
             total_events_sent: s.total_events_sent,
-            total_retries: s.total_retries,
+            total_retries: 0,
             last_error: s.last_error.clone(),
-            requests_made: s.requests_made.clone(),
         }))
         .into_response(),
         None => Json(serde_json::json!(StateResponse {
@@ -283,7 +295,6 @@ async fn get_state(
             total_events_sent: 0,
             total_retries: 0,
             last_error: None,
-            requests_made: vec![],
         }))
         .into_response(),
     }
@@ -305,7 +316,9 @@ async fn main() {
         CaptureMode::V0 => "v0",
         CaptureMode::V1 => "v1",
     };
-    eprintln!("Starting posthog-rs SDK adapter (CAPTURE_MODE={mode_str}, parallel=true)");
+    eprintln!(
+        "Starting posthog-rs SDK adapter (CAPTURE_MODE={mode_str}, parallel={SUPPORTS_PARALLEL})"
+    );
 
     let state = AppState {
         instances: Arc::new(Mutex::new(HashMap::new())),

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -117,10 +117,7 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     })
 }
 
-async fn init(
-    State(state): State<AppState>,
-    Json(req): Json<InitRequest>,
-) -> impl IntoResponse {
+async fn init(State(state): State<AppState>, Json(req): Json<InitRequest>) -> impl IntoResponse {
     let mut s = state.inner.lock().await;
 
     // Reset state

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::{
-    extract::State,
+    extract::{Query, State},
     http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
@@ -14,9 +15,11 @@ use posthog_rs::{CaptureMode, Client, ClientOptionsBuilder, Event};
 
 #[derive(Clone)]
 struct AppState {
-    inner: Arc<Mutex<AdapterState>>,
+    instances: Arc<Mutex<HashMap<String, AdapterState>>>,
     capture_mode: CaptureMode,
 }
+
+const DEFAULT_TEST_ID: &str = "_global";
 
 struct AdapterState {
     client: Option<Client>,
@@ -79,12 +82,25 @@ struct CaptureRequest {
     timestamp: Option<String>,
 }
 
+#[derive(Deserialize, Default)]
+struct TestIdParam {
+    #[serde(default)]
+    test_id: Option<String>,
+}
+
+impl TestIdParam {
+    fn key(&self) -> &str {
+        self.test_id.as_deref().unwrap_or(DEFAULT_TEST_ID)
+    }
+}
+
 #[derive(Serialize)]
 struct HealthResponse {
     sdk_name: &'static str,
     sdk_version: &'static str,
     adapter_version: &'static str,
     capabilities: Vec<&'static str>,
+    supports_parallel: bool,
 }
 
 #[derive(Serialize)]
@@ -114,13 +130,18 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         sdk_version: env!("CARGO_PKG_VERSION"),
         adapter_version: "0.1.0",
         capabilities: vec![capability],
+        supports_parallel: true,
     })
 }
 
-async fn init(State(state): State<AppState>, Json(req): Json<InitRequest>) -> impl IntoResponse {
-    let mut s = state.inner.lock().await;
+async fn init(
+    State(state): State<AppState>,
+    Query(params): Query<TestIdParam>,
+    Json(req): Json<InitRequest>,
+) -> impl IntoResponse {
+    let mut instances = state.instances.lock().await;
+    let s = instances.entry(params.key().to_string()).or_default();
 
-    // Reset state
     *s = AdapterState::default();
 
     let options = ClientOptionsBuilder::default()
@@ -149,9 +170,11 @@ async fn init(State(state): State<AppState>, Json(req): Json<InitRequest>) -> im
 
 async fn capture_event(
     State(state): State<AppState>,
+    Query(params): Query<TestIdParam>,
     Json(req): Json<CaptureRequest>,
 ) -> impl IntoResponse {
-    let mut s = state.inner.lock().await;
+    let mut instances = state.instances.lock().await;
+    let s = instances.entry(params.key().to_string()).or_default();
 
     let client = match &s.client {
         Some(c) => c,
@@ -186,7 +209,6 @@ async fn capture_event(
         Ok(()) => {
             s.total_events_captured += 1;
             s.pending_events += 1;
-            // For V0, events are sent immediately by capture()
             s.total_events_sent += 1;
             s.pending_events -= 1;
             if s.pending_events < 0 {
@@ -207,8 +229,21 @@ async fn capture_event(
     }
 }
 
-async fn flush(State(state): State<AppState>) -> impl IntoResponse {
-    let s = state.inner.lock().await;
+async fn flush(
+    State(state): State<AppState>,
+    Query(params): Query<TestIdParam>,
+) -> impl IntoResponse {
+    let instances = state.instances.lock().await;
+    let s = match instances.get(params.key()) {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "SDK not initialized" })),
+            )
+                .into_response();
+        }
+    };
 
     if s.client.is_none() {
         return (
@@ -218,7 +253,6 @@ async fn flush(State(state): State<AppState>) -> impl IntoResponse {
             .into_response();
     }
 
-    // posthog-rs sends events immediately in capture(), so flush is a no-op
     Json(serde_json::json!({
         "success": true,
         "events_flushed": s.total_events_sent
@@ -226,21 +260,41 @@ async fn flush(State(state): State<AppState>) -> impl IntoResponse {
     .into_response()
 }
 
-async fn get_state(State(state): State<AppState>) -> Json<StateResponse> {
-    let s = state.inner.lock().await;
-    Json(StateResponse {
-        pending_events: s.pending_events,
-        total_events_captured: s.total_events_captured,
-        total_events_sent: s.total_events_sent,
-        total_retries: s.total_retries,
-        last_error: s.last_error.clone(),
-        requests_made: s.requests_made.clone(),
-    })
+async fn get_state(
+    State(state): State<AppState>,
+    Query(params): Query<TestIdParam>,
+) -> impl IntoResponse {
+    let instances = state.instances.lock().await;
+    let s = instances.get(params.key());
+
+    match s {
+        Some(s) => Json(serde_json::json!(StateResponse {
+            pending_events: s.pending_events,
+            total_events_captured: s.total_events_captured,
+            total_events_sent: s.total_events_sent,
+            total_retries: s.total_retries,
+            last_error: s.last_error.clone(),
+            requests_made: s.requests_made.clone(),
+        }))
+        .into_response(),
+        None => Json(serde_json::json!(StateResponse {
+            pending_events: 0,
+            total_events_captured: 0,
+            total_events_sent: 0,
+            total_retries: 0,
+            last_error: None,
+            requests_made: vec![],
+        }))
+        .into_response(),
+    }
 }
 
-async fn reset(State(state): State<AppState>) -> Json<serde_json::Value> {
-    let mut s = state.inner.lock().await;
-    *s = AdapterState::default();
+async fn reset(
+    State(state): State<AppState>,
+    Query(params): Query<TestIdParam>,
+) -> Json<serde_json::Value> {
+    let mut instances = state.instances.lock().await;
+    instances.remove(params.key());
     Json(serde_json::json!({ "success": true }))
 }
 
@@ -251,10 +305,10 @@ async fn main() {
         CaptureMode::V0 => "v0",
         CaptureMode::V1 => "v1",
     };
-    eprintln!("Starting posthog-rs SDK adapter (CAPTURE_MODE={mode_str})");
+    eprintln!("Starting posthog-rs SDK adapter (CAPTURE_MODE={mode_str}, parallel=true)");
 
     let state = AppState {
-        inner: Arc::new(Mutex::new(AdapterState::default())),
+        instances: Arc::new(Mutex::new(HashMap::new())),
         capture_mode,
     };
 

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -11,13 +11,14 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
-use posthog_rs::{Client, ClientOptionsBuilder, Event};
+use posthog_rs::{CaptureCompression, Client, ClientOptionsBuilder, Event};
 
 const SUPPORTS_PARALLEL: bool = true;
 
 #[derive(Clone)]
 struct AppState {
     instances: Arc<Mutex<HashMap<String, AdapterState>>>,
+    compression: Option<CaptureCompression>,
 }
 
 const DEFAULT_TEST_ID: &str = "_global";
@@ -26,6 +27,8 @@ const DEFAULT_TEST_ID: &str = "_global";
 struct AdapterState {
     client: Option<Arc<Client>>,
     historical_migration: bool,
+    buffer: Vec<Event>,
+    flush_at: Option<u32>,
     total_events_captured: u64,
     total_events_sent: u64,
     last_error: Option<String>,
@@ -36,16 +39,13 @@ struct AdapterState {
 struct InitRequest {
     api_key: String,
     host: String,
-    #[allow(dead_code)]
     #[serde(default)]
     flush_at: Option<u32>,
     #[allow(dead_code)]
     #[serde(default)]
     flush_interval_ms: Option<u64>,
-    #[allow(dead_code)]
     #[serde(default)]
     max_retries: Option<u32>,
-    #[allow(dead_code)]
     #[serde(default)]
     enable_compression: Option<bool>,
     #[serde(default)]
@@ -62,6 +62,7 @@ struct CaptureRequest {
     properties: Option<serde_json::Value>,
     #[serde(default)]
     timestamp: Option<String>,
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
     #[serde(default)]
     options: Option<serde_json::Value>,
 }
@@ -83,7 +84,7 @@ struct HealthResponse {
     sdk_name: &'static str,
     sdk_version: &'static str,
     adapter_version: &'static str,
-    capabilities: Vec<&'static str>,
+    capabilities: Vec<String>,
     supports_parallel: bool,
 }
 
@@ -92,21 +93,45 @@ struct StateResponse {
     pending_events: i64,
     total_events_captured: u64,
     total_events_sent: u64,
+    // Always 0: capture API does not expose retry counts; retries are validated at the wire level.
     total_retries: u64,
     last_error: Option<String>,
 }
 
-async fn health() -> Json<HealthResponse> {
-    let capability = if cfg!(feature = "capture-v1") {
-        "capture_v1"
+fn parse_compression() -> Option<CaptureCompression> {
+    match std::env::var("COMPRESSION").as_deref() {
+        Ok("gzip") => Some(CaptureCompression::Gzip),
+        Ok("deflate") => Some(CaptureCompression::Deflate),
+        Ok("br") => Some(CaptureCompression::Br),
+        Ok("zstd") => Some(CaptureCompression::Zstd),
+        _ => None,
+    }
+}
+
+fn compression_capability(c: CaptureCompression) -> &'static str {
+    match c {
+        CaptureCompression::Gzip => "encoding_gzip",
+        CaptureCompression::Deflate => "encoding_deflate",
+        CaptureCompression::Br => "encoding_br",
+        CaptureCompression::Zstd => "encoding_zstd",
+    }
+}
+
+async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
+    let mut capabilities: Vec<String> = Vec::new();
+    if cfg!(feature = "capture-v1") {
+        capabilities.push("capture_v1".to_string());
+        if let Some(algo) = state.compression {
+            capabilities.push(compression_capability(algo).to_string());
+        }
     } else {
-        "capture_v0"
-    };
+        capabilities.push("capture_v0".to_string());
+    }
     Json(HealthResponse {
         sdk_name: "posthog-rs",
         sdk_version: env!("CARGO_PKG_VERSION"),
         adapter_version: env!("CARGO_PKG_VERSION"),
-        capabilities: vec![capability],
+        capabilities,
         supports_parallel: SUPPORTS_PARALLEL,
     })
 }
@@ -121,9 +146,22 @@ async fn init(
 
     *s = AdapterState::default();
     s.historical_migration = req.historical_migration.unwrap_or(false);
+    s.flush_at = req.flush_at;
 
     let mut builder = ClientOptionsBuilder::default();
     builder.api_key(req.api_key).host(req.host);
+
+    // The harness `max_retries` counts retries; the SDK option counts total
+    // attempts (initial + retries), so add one.
+    if let Some(retries) = req.max_retries {
+        builder.max_capture_attempts(retries.saturating_add(1));
+    }
+
+    if req.enable_compression.unwrap_or(false) {
+        if let Some(algo) = state.compression {
+            builder.capture_compression(algo);
+        }
+    }
 
     if req.disable_geoip.unwrap_or(false) {
         builder.disable_geoip(true);
@@ -155,6 +193,52 @@ async fn init(
     }
 }
 
+/// Drain pending events from the buffer under the lock, then send the batch
+/// without holding the lock, and finally re-acquire the lock to record the
+/// outcome. Returns the number of events flushed in this call.
+async fn flush_buffer(instances: &Mutex<HashMap<String, AdapterState>>, key: &str) -> u64 {
+    let (client, events, historical_migration) = {
+        let mut map = instances.lock().await;
+        let s = match map.get_mut(key) {
+            Some(s) => s,
+            None => return 0,
+        };
+        if s.buffer.is_empty() {
+            return 0;
+        }
+        let client = match &s.client {
+            Some(c) => c.clone(),
+            None => return 0,
+        };
+        let events = std::mem::take(&mut s.buffer);
+        (client, events, s.historical_migration)
+    };
+
+    let count = events.len() as u64;
+    let result = client.capture_batch(events, historical_migration).await;
+
+    let flushed = {
+        let mut map = instances.lock().await;
+        if let Some(s) = map.get_mut(key) {
+            match result {
+                Ok(()) => {
+                    s.pending_events = (s.pending_events - count as i64).max(0);
+                    s.total_events_sent += count;
+                    count
+                }
+                Err(e) => {
+                    s.last_error = Some(e.to_string());
+                    0
+                }
+            }
+        } else {
+            0
+        }
+    };
+
+    flushed
+}
+
 async fn capture_event(
     State(state): State<AppState>,
     Query(params): Query<TestIdParam>,
@@ -162,17 +246,69 @@ async fn capture_event(
 ) -> impl IntoResponse {
     let key = params.key().to_string();
 
-    // Phase 1: short lock — clone Arc<Client>, bump in-flight counter
-    let client = {
+    let needs_flush = {
         let mut instances = state.instances.lock().await;
         let s = instances.entry(key.clone()).or_default();
-        match &s.client {
-            Some(c) => {
-                s.total_events_captured += 1;
-                s.pending_events += 1;
-                c.clone()
+
+        if s.client.is_none() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "SDK not initialized" })),
+            )
+                .into_response();
+        }
+
+        let mut event = Event::new(req.event, req.distinct_id);
+
+        if let Some(props) = req.properties {
+            if let Some(obj) = props.as_object() {
+                for (k, v) in obj {
+                    let _ = event.insert_prop(k.clone(), v.clone());
+                }
             }
-            None => {
+        }
+
+        if let Some(ts_str) = req.timestamp {
+            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&ts_str) {
+                let _ = event.set_timestamp(ts);
+            }
+        }
+
+        #[cfg(feature = "capture-v1")]
+        if let Some(opts_val) = req.options {
+            if let Some(obj) = opts_val.as_object() {
+                for (k, v) in obj {
+                    let _ = event.set_option(k, v.clone());
+                }
+            }
+        }
+
+        s.total_events_captured += 1;
+        s.pending_events += 1;
+        s.buffer.push(event);
+
+        matches!(s.flush_at, Some(threshold) if s.buffer.len() as u32 >= threshold)
+    };
+
+    if needs_flush {
+        flush_buffer(&state.instances, &key).await;
+    }
+
+    let uuid = uuid::Uuid::now_v7().to_string();
+    Json(serde_json::json!({ "success": true, "uuid": uuid })).into_response()
+}
+
+async fn flush(
+    State(state): State<AppState>,
+    Query(params): Query<TestIdParam>,
+) -> impl IntoResponse {
+    let key = params.key().to_string();
+
+    {
+        let instances = state.instances.lock().await;
+        match instances.get(&key) {
+            Some(s) if s.client.is_some() => {}
+            _ => {
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(serde_json::json!({ "error": "SDK not initialized" })),
@@ -180,87 +316,13 @@ async fn capture_event(
                     .into_response();
             }
         }
-    };
-
-    // Build event outside the lock
-    let mut event = Event::new(req.event, req.distinct_id);
-
-    if let Some(props) = req.properties {
-        if let Some(obj) = props.as_object() {
-            for (k, v) in obj {
-                let _ = event.insert_prop(k.clone(), v.clone());
-            }
-        }
     }
 
-    if let Some(ts_str) = req.timestamp {
-        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&ts_str) {
-            let _ = event.set_timestamp(ts);
-        }
-    }
-
-    // EventOptions wiring (set_options) is applied in the V1 capture
-    // implementation branch where EventOptions exists on Event.
-    let _ = req.options;
-
-    let uuid = uuid::Uuid::now_v7().to_string();
-
-    // Phase 2: network call without holding the lock
-    let result = client.capture(event).await;
-
-    // Phase 3: short lock — record outcome
-    {
-        let mut instances = state.instances.lock().await;
-        if let Some(s) = instances.get_mut(&key) {
-            s.pending_events = (s.pending_events - 1).max(0);
-            match &result {
-                Ok(()) => {
-                    s.total_events_sent += 1;
-                }
-                Err(e) => {
-                    s.last_error = Some(e.to_string());
-                }
-            }
-        }
-    }
-
-    match result {
-        Ok(()) => Json(serde_json::json!({ "success": true, "uuid": uuid })).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": e.to_string() })),
-        )
-            .into_response(),
-    }
-}
-
-async fn flush(
-    State(state): State<AppState>,
-    Query(params): Query<TestIdParam>,
-) -> impl IntoResponse {
-    let instances = state.instances.lock().await;
-    let s = match instances.get(params.key()) {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "error": "SDK not initialized" })),
-            )
-                .into_response();
-        }
-    };
-
-    if s.client.is_none() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "SDK not initialized" })),
-        )
-            .into_response();
-    }
+    let flushed = flush_buffer(&state.instances, &key).await;
 
     Json(serde_json::json!({
         "success": true,
-        "events_flushed": s.total_events_sent
+        "events_flushed": flushed
     }))
     .into_response()
 }
@@ -270,9 +332,7 @@ async fn get_state(
     Query(params): Query<TestIdParam>,
 ) -> impl IntoResponse {
     let instances = state.instances.lock().await;
-    let s = instances.get(params.key());
-
-    match s {
+    match instances.get(params.key()) {
         Some(s) => Json(serde_json::json!(StateResponse {
             pending_events: s.pending_events,
             total_events_captured: s.total_events_captured,
@@ -303,15 +363,23 @@ async fn reset(
 
 #[tokio::main]
 async fn main() {
+    let compression = parse_compression();
     let mode_str = if cfg!(feature = "capture-v1") {
         "v1"
     } else {
         "v0"
     };
-    eprintln!("Starting posthog-rs SDK adapter (capture={mode_str}, parallel={SUPPORTS_PARALLEL})");
+    let compression_str = match compression {
+        Some(algo) => compression_capability(algo),
+        None => "none",
+    };
+    eprintln!(
+        "Starting posthog-rs SDK adapter (capture={mode_str}, compression={compression_str}, parallel={SUPPORTS_PARALLEL})"
+    );
 
     let state = AppState {
         instances: Arc::new(Mutex::new(HashMap::new())),
+        compression,
     };
 
     let app = Router::new()

--- a/compliance/v0/Dockerfile
+++ b/compliance/v0/Dockerfile
@@ -6,6 +6,5 @@ RUN cargo build --release -p sdk-adapter
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/sdk-adapter /usr/local/bin/
-ENV CAPTURE_MODE=v0
 EXPOSE 8080
 CMD ["sdk-adapter"]

--- a/compliance/v0/Dockerfile
+++ b/compliance/v0/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:latest AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release -p sdk-adapter
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/sdk-adapter /usr/local/bin/
+ENV CAPTURE_MODE=v0
+EXPOSE 8080
+CMD ["sdk-adapter"]

--- a/compliance/v0/Dockerfile
+++ b/compliance/v0/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS builder
+FROM rust:1-bookworm AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release -p sdk-adapter

--- a/compliance/v0/docker-compose.yml
+++ b/compliance/v0/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   test-harness:
     image: posthog-sdk-test-harness:debug
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10", "--suite", "capture"]
     networks:
       - test-network
     depends_on:

--- a/compliance/v0/docker-compose.yml
+++ b/compliance/v0/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   test-harness:
     image: posthog-sdk-test-harness:debug
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10"]
     networks:
       - test-network
     depends_on:

--- a/compliance/v0/docker-compose.yml
+++ b/compliance/v0/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  sdk-adapter:
+    build:
+      context: ../..
+      dockerfile: compliance/v0/Dockerfile
+    ports:
+      - "8080:8080"
+    networks:
+      - test-network
+
+  test-harness:
+    image: posthog-sdk-test-harness:debug
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
+    networks:
+      - test-network
+    depends_on:
+      - sdk-adapter
+
+networks:
+  test-network:
+    driver: bridge

--- a/compliance/v1/Dockerfile
+++ b/compliance/v1/Dockerfile
@@ -1,11 +1,10 @@
 FROM rust:1-bookworm AS builder
 WORKDIR /app
 COPY . .
-RUN cargo build --release -p sdk-adapter
+RUN cargo build --release -p sdk-adapter --features sdk-adapter/capture-v1
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/sdk-adapter /usr/local/bin/
-ENV CAPTURE_MODE=v1
 EXPOSE 8080
 CMD ["sdk-adapter"]

--- a/compliance/v1/Dockerfile
+++ b/compliance/v1/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS builder
+FROM rust:1-bookworm AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release -p sdk-adapter

--- a/compliance/v1/Dockerfile
+++ b/compliance/v1/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:latest AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release -p sdk-adapter
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/sdk-adapter /usr/local/bin/
+ENV CAPTURE_MODE=v1
+EXPOSE 8080
+CMD ["sdk-adapter"]

--- a/compliance/v1/docker-compose.yml
+++ b/compliance/v1/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   test-harness:
     image: posthog-sdk-test-harness:debug
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10", "--suite", "capture_v1"]
     networks:
       - test-network
     depends_on:

--- a/compliance/v1/docker-compose.yml
+++ b/compliance/v1/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ../..
       dockerfile: compliance/v1/Dockerfile
+    environment:
+      - COMPRESSION=gzip
     ports:
       - "8080:8080"
     networks:

--- a/compliance/v1/docker-compose.yml
+++ b/compliance/v1/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  sdk-adapter:
+    build:
+      context: ../..
+      dockerfile: compliance/v1/Dockerfile
+    ports:
+      - "8080:8080"
+    networks:
+      - test-network
+
+  test-harness:
+    image: posthog-sdk-test-harness:debug
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
+    networks:
+      - test-network
+    depends_on:
+      - sdk-adapter
+
+networks:
+  test-network:
+    driver: bridge

--- a/compliance/v1/docker-compose.yml
+++ b/compliance/v1/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   test-harness:
     image: posthog-sdk-test-harness:debug
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10"]
     networks:
       - test-network
     depends_on:

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -18,7 +18,7 @@ use crate::feature_flags::{
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{event::InnerEvent, Error, Event};
 
-use super::ClientOptions;
+use super::{CaptureMode, ClientOptions};
 
 /// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
 /// dedup cache. On overflow the entire map is reset (matches the JS SDK).
@@ -288,6 +288,10 @@ impl Client {
             return Ok(());
         }
 
+        if self.options.capture_mode == CaptureMode::V1 {
+            return self.capture_v1(event).await;
+        }
+
         // Add geoip disable property if configured
         if self.options.disable_geoip {
             event.insert_prop("$geoip_disable", true).ok();
@@ -338,6 +342,10 @@ impl Client {
             return Ok(());
         }
 
+        if self.options.capture_mode == CaptureMode::V1 {
+            return self.capture_batch_v1(events).await;
+        }
+
         let disable_geoip = self.options.disable_geoip;
         let is_server = self.options.is_server;
         let inner_events: Vec<InnerEvent> = events
@@ -372,6 +380,20 @@ impl Client {
             .map_err(|e| Error::Connection(e.to_string()))?;
 
         check_response(response).await
+    }
+
+    async fn capture_v1(&self, _event: Event) -> Result<(), Error> {
+        Err(Error::ServerError {
+            status: 500,
+            message: "Capture V1 not yet implemented".to_string(),
+        })
+    }
+
+    async fn capture_batch_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
+        Err(Error::ServerError {
+            status: 500,
+            message: "Capture V1 not yet implemented".to_string(),
+        })
     }
 
     /// Get all remote feature flags and payloads for a user.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -308,11 +308,14 @@ impl Client {
 
         let url = self.options.endpoints().build_url(Endpoint::Capture);
 
-        let response = self
+        let mut request = self
             .client
             .post(&url)
             .header(CONTENT_TYPE, "application/json")
-            .body(payload)
+            .body(payload);
+        request = self.apply_extra_headers(request);
+
+        let response = request
             .send()
             .await
             .map_err(|e| Error::Connection(e.to_string()))?;
@@ -370,16 +373,28 @@ impl Client {
             .map_err(|e| Error::Serialization(e.to_string()))?;
         let url = self.options.endpoints().build_url(Endpoint::Batch);
 
-        let response = self
+        let mut request = self
             .client
             .post(&url)
             .header(CONTENT_TYPE, "application/json")
-            .body(payload)
+            .body(payload);
+        request = self.apply_extra_headers(request);
+
+        let response = request
             .send()
             .await
             .map_err(|e| Error::Connection(e.to_string()))?;
 
         check_response(response).await
+    }
+
+    fn apply_extra_headers(&self, mut request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(ref extra) = self.options.extra_capture_headers {
+            for (k, v) in extra {
+                request = request.header(k.as_str(), v.as_str());
+            }
+        }
+        request
     }
 
     async fn capture_v1(&self, _events: Vec<Event>) -> Result<(), Error> {

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -289,7 +289,7 @@ impl Client {
         }
 
         if self.options.capture_mode == CaptureMode::V1 {
-            return self.capture_v1(event).await;
+            return self.capture_v1(vec![event]).await;
         }
 
         // Add geoip disable property if configured
@@ -343,7 +343,7 @@ impl Client {
         }
 
         if self.options.capture_mode == CaptureMode::V1 {
-            return self.capture_batch_v1(events).await;
+            return self.capture_v1(events).await;
         }
 
         let disable_geoip = self.options.disable_geoip;
@@ -382,14 +382,7 @@ impl Client {
         check_response(response).await
     }
 
-    async fn capture_v1(&self, _event: Event) -> Result<(), Error> {
-        Err(Error::ServerError {
-            status: 500,
-            message: "Capture V1 not yet implemented".to_string(),
-        })
-    }
-
-    async fn capture_batch_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
+    async fn capture_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
         Err(Error::ServerError {
             status: 500,
             message: "Capture V1 not yet implemented".to_string(),

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -2,13 +2,17 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
+#[cfg(feature = "capture-v1")]
+use chrono::Utc;
 use reqwest::{header::CONTENT_TYPE, Client as HttpClient};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
+#[cfg(feature = "capture-v1")]
+use uuid::Uuid;
 
 use crate::endpoints::Endpoint;
-#[cfg(not(feature = "capture-v1"))]
-use crate::event::BatchRequest;
+#[cfg(feature = "capture-v1")]
+use crate::event_v1::CaptureResponse;
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
     FlagCalledEventParams,
@@ -56,8 +60,7 @@ struct AsyncFlagEventHost {
     api_key: String,
     capture_url: String,
     disabled: bool,
-    disable_geoip: bool,
-    is_server: bool,
+    defaults: super::CaptureDefaults,
     dedup_cache: Mutex<HashMap<String, HashSet<String>>>,
     /// Tokio runtime handle captured at host construction (which always runs
     /// inside the runtime that hosts `evaluate_flags`). This lets snapshot
@@ -75,8 +78,7 @@ impl AsyncFlagEventHost {
             api_key: options.api_key.clone(),
             capture_url,
             disabled: options.is_disabled(),
-            disable_geoip: options.disable_geoip,
-            is_server: options.is_server,
+            defaults: options.capture_defaults(),
             dedup_cache: Mutex::new(HashMap::new()),
             runtime: tokio::runtime::Handle::current(),
         }
@@ -101,10 +103,11 @@ impl AsyncFlagEventHost {
         false
     }
 
-    fn spawn_ship(&self, event: Event) {
+    fn spawn_ship(&self, mut event: Event) {
         if self.disabled {
             return;
         }
+        event.prepare_for_v0();
         let inner_event = InnerEvent::new(event, self.api_key.clone());
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
@@ -157,11 +160,13 @@ impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
         for (group_name, group_id) in &params.groups {
             event.add_group(group_name, group_id);
         }
-        if params.disable_geoip.unwrap_or(self.disable_geoip) {
-            let _ = event.insert_prop("$geoip_disable", true);
+        // Per-call geoip override takes precedence over client default; caller-wins.
+        let effective_geoip = params.disable_geoip.unwrap_or(self.defaults.disable_geoip);
+        if effective_geoip {
+            event.insert_prop_default("$geoip_disable", serde_json::Value::Bool(true));
         }
-        if self.is_server {
-            let _ = event.insert_prop("$is_server", true);
+        if self.defaults.is_server {
+            event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
         }
         self.spawn_ship(event);
     }
@@ -283,8 +288,7 @@ impl Client {
     ///
     /// Disabled clients skip the request and return `Ok(())`.
     #[instrument(skip(self, event), level = "debug")]
-    #[allow(unused_mut)]
-    pub async fn capture(&self, mut event: Event) -> Result<(), Error> {
+    pub async fn capture(&self, event: Event) -> Result<(), Error> {
         if self.options.is_disabled() {
             trace!("Client is disabled, skipping capture");
             return Ok(());
@@ -292,41 +296,11 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
-            return self.capture_v1(vec![event]).await;
+            return self.capture_v1(vec![event], false).await.map(|_| ());
         }
 
         #[cfg(not(feature = "capture-v1"))]
-        {
-            // Add geoip disable property if configured
-            if self.options.disable_geoip {
-                event.insert_prop("$geoip_disable", true).ok();
-            }
-            // Mark server-side events so ingestion doesn't attribute the host OS to the person.
-            if self.options.is_server {
-                event.insert_prop("$is_server", true).ok();
-            }
-
-            let inner_event = InnerEvent::new(event, self.options.api_key.clone());
-
-            let payload = serde_json::to_string(&inner_event)
-                .map_err(|e| Error::Serialization(e.to_string()))?;
-
-            let url = self.options.endpoints().build_url(Endpoint::Capture);
-
-            let mut request = self
-                .client
-                .post(&url)
-                .header(CONTENT_TYPE, "application/json")
-                .body(payload);
-            request = self.apply_extra_headers(request);
-
-            let response = request
-                .send()
-                .await
-                .map_err(|e| Error::Connection(e.to_string()))?;
-
-            check_response(response).await
-        }
+        self.capture_v0(event).await
     }
 
     /// Capture a collection of events with a single request.
@@ -353,71 +327,147 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
-            let _ = historical_migration;
-            return self.capture_v1(events).await;
+            return self
+                .capture_v1(events, historical_migration)
+                .await
+                .map(|_| ());
         }
 
         #[cfg(not(feature = "capture-v1"))]
-        {
-            let disable_geoip = self.options.disable_geoip;
-            let is_server = self.options.is_server;
-            let inner_events: Vec<InnerEvent> = events
-                .into_iter()
-                .map(|mut event| {
-                    if disable_geoip {
-                        event.insert_prop("$geoip_disable", true).ok();
-                    }
-                    if is_server {
-                        event.insert_prop("$is_server", true).ok();
-                    }
-                    InnerEvent::new(event, self.options.api_key.clone())
-                })
-                .collect();
-
-            let batch_request = BatchRequest {
-                api_key: self.options.api_key.clone(),
-                historical_migration,
-                batch: inner_events,
-            };
-            let payload = serde_json::to_string(&batch_request)
-                .map_err(|e| Error::Serialization(e.to_string()))?;
-            let url = self.options.endpoints().build_url(Endpoint::Batch);
-
-            let mut request = self
-                .client
-                .post(&url)
-                .header(CONTENT_TYPE, "application/json")
-                .body(payload);
-            request = self.apply_extra_headers(request);
-
-            let response = request
-                .send()
-                .await
-                .map_err(|e| Error::Connection(e.to_string()))?;
-
-            check_response(response).await
-        }
+        self.capture_batch_v0(events, historical_migration).await
     }
 
     #[cfg(not(feature = "capture-v1"))]
-    #[allow(unused_mut)]
-    fn apply_extra_headers(&self, mut request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        #[cfg(feature = "test-harness")]
-        {
-            if let Some(ref extra) = self.options.extra_capture_headers {
-                for (k, v) in extra {
-                    request = request.header(k.as_str(), v.as_str());
-                }
-            }
-        }
-        request
+    async fn capture_v0(&self, mut event: Event) -> Result<(), Error> {
+        let defaults = self.options.capture_defaults();
+        super::v0_capture::prepare_event(&mut event, &defaults);
+        let payload =
+            super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
+
+        let url = self.options.endpoints().build_url(Endpoint::Capture);
+        let request = self
+            .client
+            .post(&url)
+            .header(CONTENT_TYPE, "application/json")
+            .body(payload);
+        let request = super::v0_capture::apply_extra_headers(&self.options, request);
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        check_response(response).await
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    async fn capture_batch_v0(
+        &self,
+        events: Vec<Event>,
+        historical_migration: bool,
+    ) -> Result<(), Error> {
+        let defaults = self.options.capture_defaults();
+        let payload = super::v0_capture::build_batch_payload(
+            events,
+            self.options.api_key.clone(),
+            historical_migration,
+            &defaults,
+        )?;
+        let url = self.options.endpoints().build_url(Endpoint::Batch);
+        let request = self
+            .client
+            .post(&url)
+            .header(CONTENT_TYPE, "application/json")
+            .body(payload);
+        let request = super::v0_capture::apply_extra_headers(&self.options, request);
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        check_response(response).await
     }
 
     #[cfg(feature = "capture-v1")]
-    async fn capture_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
-        Err(Error::ServerError {
-            status: 500,
-            message: "Capture V1 not yet implemented".to_string(),
+    async fn capture_v1(
+        &self,
+        events: Vec<Event>,
+        historical_migration: bool,
+    ) -> Result<CaptureResponse, Error> {
+        use super::v1_capture::{self, Step};
+        use crate::event_v1::V1BatchRequestRef;
+
+        let request_id = Uuid::now_v7();
+        let created_at = Utc::now().to_rfc3339();
+        let mut attempt: u32 = 1;
+        let defaults = self.options.capture_defaults();
+        let mut pending = v1_capture::build_events(&events, &defaults);
+        let mut final_results = HashMap::new();
+        let historical_migration = historical_migration.then_some(true);
+        let url = self
+            .options
+            .endpoints()
+            .build_custom_url(v1_capture::V1_CAPTURE_PATH);
+
+        loop {
+            let req = V1BatchRequestRef {
+                created_at: &created_at,
+                historical_migration,
+                batch: &pending,
+            };
+            let payload =
+                serde_json::to_vec(&req).map_err(|e| Error::Serialization(e.to_string()))?;
+            let mut headers = v1_capture::build_headers(&self.options, &request_id, attempt);
+            let body =
+                v1_capture::maybe_compress(self.options.capture_compression, &mut headers, payload);
+
+            let step = match self
+                .client
+                .post(&url)
+                .headers(headers)
+                .body(body)
+                .send()
+                .await
+            {
+                Err(e) => v1_capture::after_transport_error(
+                    &self.options,
+                    &request_id,
+                    attempt,
+                    e.to_string(),
+                ),
+                Ok(resp) => {
+                    let status = resp.status().as_u16();
+                    let retry_after = v1_capture::parse_retry_after(resp.headers());
+                    let text = resp
+                        .text()
+                        .await
+                        .unwrap_or_else(|_| "Unknown error".to_string());
+                    v1_capture::after_response(
+                        &self.options,
+                        &request_id,
+                        attempt,
+                        status,
+                        retry_after,
+                        &text,
+                        &mut pending,
+                        &mut final_results,
+                    )
+                }
+            };
+
+            match step {
+                Step::Done => break,
+                Step::Fail(e) => return Err(e),
+                Step::Backoff(d) => {
+                    attempt += 1;
+                    tokio::time::sleep(d).await;
+                }
+            }
+        }
+
+        Ok(CaptureResponse {
+            results: final_results,
         })
     }
 

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -7,6 +7,7 @@ use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
 
 use crate::endpoints::Endpoint;
+#[cfg(not(feature = "capture-v1"))]
 use crate::event::BatchRequest;
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
@@ -18,7 +19,7 @@ use crate::feature_flags::{
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{event::InnerEvent, Error, Event};
 
-use super::{CaptureMode, ClientOptions};
+use super::ClientOptions;
 
 /// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
 /// dedup cache. On overflow the entire map is reset (matches the JS SDK).
@@ -282,45 +283,50 @@ impl Client {
     ///
     /// Disabled clients skip the request and return `Ok(())`.
     #[instrument(skip(self, event), level = "debug")]
+    #[allow(unused_mut)]
     pub async fn capture(&self, mut event: Event) -> Result<(), Error> {
         if self.options.is_disabled() {
             trace!("Client is disabled, skipping capture");
             return Ok(());
         }
 
-        if self.options.capture_mode == CaptureMode::V1 {
+        #[cfg(feature = "capture-v1")]
+        {
             return self.capture_v1(vec![event]).await;
         }
 
-        // Add geoip disable property if configured
-        if self.options.disable_geoip {
-            event.insert_prop("$geoip_disable", true).ok();
+        #[cfg(not(feature = "capture-v1"))]
+        {
+            // Add geoip disable property if configured
+            if self.options.disable_geoip {
+                event.insert_prop("$geoip_disable", true).ok();
+            }
+            // Mark server-side events so ingestion doesn't attribute the host OS to the person.
+            if self.options.is_server {
+                event.insert_prop("$is_server", true).ok();
+            }
+
+            let inner_event = InnerEvent::new(event, self.options.api_key.clone());
+
+            let payload = serde_json::to_string(&inner_event)
+                .map_err(|e| Error::Serialization(e.to_string()))?;
+
+            let url = self.options.endpoints().build_url(Endpoint::Capture);
+
+            let mut request = self
+                .client
+                .post(&url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(payload);
+            request = self.apply_extra_headers(request);
+
+            let response = request
+                .send()
+                .await
+                .map_err(|e| Error::Connection(e.to_string()))?;
+
+            check_response(response).await
         }
-        // Mark server-side events so ingestion doesn't attribute the host OS to the person.
-        if self.options.is_server {
-            event.insert_prop("$is_server", true).ok();
-        }
-
-        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
-
-        let payload =
-            serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))?;
-
-        let url = self.options.endpoints().build_url(Endpoint::Capture);
-
-        let mut request = self
-            .client
-            .post(&url)
-            .header(CONTENT_TYPE, "application/json")
-            .body(payload);
-        request = self.apply_extra_headers(request);
-
-        let response = request
-            .send()
-            .await
-            .map_err(|e| Error::Connection(e.to_string()))?;
-
-        check_response(response).await
     }
 
     /// Capture a collection of events with a single request.
@@ -345,58 +351,69 @@ impl Client {
             return Ok(());
         }
 
-        if self.options.capture_mode == CaptureMode::V1 {
+        #[cfg(feature = "capture-v1")]
+        {
+            let _ = historical_migration;
             return self.capture_v1(events).await;
         }
 
-        let disable_geoip = self.options.disable_geoip;
-        let is_server = self.options.is_server;
-        let inner_events: Vec<InnerEvent> = events
-            .into_iter()
-            .map(|mut event| {
-                if disable_geoip {
-                    event.insert_prop("$geoip_disable", true).ok();
-                }
-                if is_server {
-                    event.insert_prop("$is_server", true).ok();
-                }
-                InnerEvent::new(event, self.options.api_key.clone())
-            })
-            .collect();
+        #[cfg(not(feature = "capture-v1"))]
+        {
+            let disable_geoip = self.options.disable_geoip;
+            let is_server = self.options.is_server;
+            let inner_events: Vec<InnerEvent> = events
+                .into_iter()
+                .map(|mut event| {
+                    if disable_geoip {
+                        event.insert_prop("$geoip_disable", true).ok();
+                    }
+                    if is_server {
+                        event.insert_prop("$is_server", true).ok();
+                    }
+                    InnerEvent::new(event, self.options.api_key.clone())
+                })
+                .collect();
 
-        let batch_request = BatchRequest {
-            api_key: self.options.api_key.clone(),
-            historical_migration,
-            batch: inner_events,
-        };
-        let payload = serde_json::to_string(&batch_request)
-            .map_err(|e| Error::Serialization(e.to_string()))?;
-        let url = self.options.endpoints().build_url(Endpoint::Batch);
+            let batch_request = BatchRequest {
+                api_key: self.options.api_key.clone(),
+                historical_migration,
+                batch: inner_events,
+            };
+            let payload = serde_json::to_string(&batch_request)
+                .map_err(|e| Error::Serialization(e.to_string()))?;
+            let url = self.options.endpoints().build_url(Endpoint::Batch);
 
-        let mut request = self
-            .client
-            .post(&url)
-            .header(CONTENT_TYPE, "application/json")
-            .body(payload);
-        request = self.apply_extra_headers(request);
+            let mut request = self
+                .client
+                .post(&url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(payload);
+            request = self.apply_extra_headers(request);
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| Error::Connection(e.to_string()))?;
+            let response = request
+                .send()
+                .await
+                .map_err(|e| Error::Connection(e.to_string()))?;
 
-        check_response(response).await
+            check_response(response).await
+        }
     }
 
+    #[cfg(not(feature = "capture-v1"))]
+    #[allow(unused_mut)]
     fn apply_extra_headers(&self, mut request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        if let Some(ref extra) = self.options.extra_capture_headers {
-            for (k, v) in extra {
-                request = request.header(k.as_str(), v.as_str());
+        #[cfg(feature = "test-harness")]
+        {
+            if let Some(ref extra) = self.options.extra_capture_headers {
+                for (k, v) in extra {
+                    request = request.header(k.as_str(), v.as_str());
+                }
             }
         }
         request
     }
 
+    #[cfg(feature = "capture-v1")]
     async fn capture_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
         Err(Error::ServerError {
             status: 500,

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -7,6 +7,7 @@ use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
 
 use crate::endpoints::{Endpoint, EndpointManager};
+#[cfg(not(feature = "capture-v1"))]
 use crate::event::BatchRequest;
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
@@ -18,7 +19,7 @@ use crate::feature_flags::{
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{event::InnerEvent, Error, Event};
 
-use super::{CaptureMode, ClientOptions};
+use super::ClientOptions;
 
 /// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
 /// dedup cache. On overflow the entire map is reset (matches the JS SDK).
@@ -266,43 +267,48 @@ impl Client {
     ///
     /// Disabled clients skip the request and return `Ok(())`.
     #[instrument(skip(self, event), level = "debug")]
+    #[allow(unused_mut)]
     pub fn capture(&self, mut event: Event) -> Result<(), Error> {
         if self.options.is_disabled() {
             trace!("Client is disabled, skipping capture");
             return Ok(());
         }
 
-        if self.options.capture_mode == CaptureMode::V1 {
+        #[cfg(feature = "capture-v1")]
+        {
             return self.capture_v1(vec![event]);
         }
 
-        // Add geoip disable property if configured
-        if self.options.disable_geoip {
-            event.insert_prop("$geoip_disable", true).ok();
+        #[cfg(not(feature = "capture-v1"))]
+        {
+            // Add geoip disable property if configured
+            if self.options.disable_geoip {
+                event.insert_prop("$geoip_disable", true).ok();
+            }
+            // Mark server-side events so ingestion doesn't attribute the host OS to the person.
+            if self.options.is_server {
+                event.insert_prop("$is_server", true).ok();
+            }
+
+            let inner_event = InnerEvent::new(event, self.options.api_key.clone());
+
+            let payload = serde_json::to_string(&inner_event)
+                .map_err(|e| Error::Serialization(e.to_string()))?;
+
+            let url = self.options.endpoints().build_url(Endpoint::Capture);
+            let mut request = self
+                .client
+                .post(&url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(payload);
+            request = self.apply_extra_headers(request);
+
+            let response = request
+                .send()
+                .map_err(|e| Error::Connection(e.to_string()))?;
+
+            check_response(response)
         }
-        // Mark server-side events so ingestion doesn't attribute the host OS to the person.
-        if self.options.is_server {
-            event.insert_prop("$is_server", true).ok();
-        }
-
-        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
-
-        let payload =
-            serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))?;
-
-        let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let mut request = self
-            .client
-            .post(&url)
-            .header(CONTENT_TYPE, "application/json")
-            .body(payload);
-        request = self.apply_extra_headers(request);
-
-        let response = request
-            .send()
-            .map_err(|e| Error::Connection(e.to_string()))?;
-
-        check_response(response)
     }
 
     /// Capture a collection of events with a single request.
@@ -329,60 +335,71 @@ impl Client {
             return Ok(());
         }
 
-        if self.options.capture_mode == CaptureMode::V1 {
+        #[cfg(feature = "capture-v1")]
+        {
+            let _ = historical_migration;
             return self.capture_v1(events);
         }
 
-        let disable_geoip = self.options.disable_geoip;
-        let is_server = self.options.is_server;
-        let inner_events: Vec<InnerEvent> = events
-            .into_iter()
-            .map(|mut event| {
-                if disable_geoip {
-                    event.insert_prop("$geoip_disable", true).ok();
-                }
-                if is_server {
-                    event.insert_prop("$is_server", true).ok();
-                }
-                InnerEvent::new(event, self.options.api_key.clone())
-            })
-            .collect();
+        #[cfg(not(feature = "capture-v1"))]
+        {
+            let disable_geoip = self.options.disable_geoip;
+            let is_server = self.options.is_server;
+            let inner_events: Vec<InnerEvent> = events
+                .into_iter()
+                .map(|mut event| {
+                    if disable_geoip {
+                        event.insert_prop("$geoip_disable", true).ok();
+                    }
+                    if is_server {
+                        event.insert_prop("$is_server", true).ok();
+                    }
+                    InnerEvent::new(event, self.options.api_key.clone())
+                })
+                .collect();
 
-        let batch_request = BatchRequest {
-            api_key: self.options.api_key.clone(),
-            historical_migration,
-            batch: inner_events,
-        };
-        let payload = serde_json::to_string(&batch_request)
-            .map_err(|e| Error::Serialization(e.to_string()))?;
-        let url = self.options.endpoints().build_url(Endpoint::Batch);
+            let batch_request = BatchRequest {
+                api_key: self.options.api_key.clone(),
+                historical_migration,
+                batch: inner_events,
+            };
+            let payload = serde_json::to_string(&batch_request)
+                .map_err(|e| Error::Serialization(e.to_string()))?;
+            let url = self.options.endpoints().build_url(Endpoint::Batch);
 
-        let mut request = self
-            .client
-            .post(&url)
-            .header(CONTENT_TYPE, "application/json")
-            .body(payload);
-        request = self.apply_extra_headers(request);
+            let mut request = self
+                .client
+                .post(&url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(payload);
+            request = self.apply_extra_headers(request);
 
-        let response = request
-            .send()
-            .map_err(|e| Error::Connection(e.to_string()))?;
+            let response = request
+                .send()
+                .map_err(|e| Error::Connection(e.to_string()))?;
 
-        check_response(response)
+            check_response(response)
+        }
     }
 
+    #[cfg(not(feature = "capture-v1"))]
+    #[allow(unused_mut)]
     fn apply_extra_headers(
         &self,
         mut request: reqwest::blocking::RequestBuilder,
     ) -> reqwest::blocking::RequestBuilder {
-        if let Some(ref extra) = self.options.extra_capture_headers {
-            for (k, v) in extra {
-                request = request.header(k.as_str(), v.as_str());
+        #[cfg(feature = "test-harness")]
+        {
+            if let Some(ref extra) = self.options.extra_capture_headers {
+                for (k, v) in extra {
+                    request = request.header(k.as_str(), v.as_str());
+                }
             }
         }
         request
     }
 
+    #[cfg(feature = "capture-v1")]
     fn capture_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
         Err(Error::ServerError {
             status: 500,

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -2,13 +2,17 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
+#[cfg(feature = "capture-v1")]
+use chrono::Utc;
 use reqwest::{blocking::Client as HttpClient, header::CONTENT_TYPE};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
+#[cfg(feature = "capture-v1")]
+use uuid::Uuid;
 
 use crate::endpoints::{Endpoint, EndpointManager};
-#[cfg(not(feature = "capture-v1"))]
-use crate::event::BatchRequest;
+#[cfg(feature = "capture-v1")]
+use crate::event_v1::CaptureResponse;
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
     FlagCalledEventParams,
@@ -55,8 +59,7 @@ struct BlockingFlagEventHost {
     api_key: String,
     endpoints: EndpointManager,
     disabled: bool,
-    disable_geoip: bool,
-    is_server: bool,
+    defaults: super::CaptureDefaults,
     dedup_cache: Mutex<HashMap<String, HashSet<String>>>,
 }
 
@@ -67,8 +70,7 @@ impl BlockingFlagEventHost {
             api_key: options.api_key.clone(),
             endpoints: options.endpoints().clone(),
             disabled: options.is_disabled(),
-            disable_geoip: options.disable_geoip,
-            is_server: options.is_server,
+            defaults: options.capture_defaults(),
             dedup_cache: Mutex::new(HashMap::new()),
         }
     }
@@ -92,10 +94,11 @@ impl BlockingFlagEventHost {
         false
     }
 
-    fn ship_event(&self, event: Event) {
+    fn ship_event(&self, mut event: Event) {
         if self.disabled {
             return;
         }
+        event.prepare_for_v0();
         let inner_event = InnerEvent::new(event, self.api_key.clone());
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
@@ -141,11 +144,13 @@ impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
         for (group_name, group_id) in &params.groups {
             event.add_group(group_name, group_id);
         }
-        if params.disable_geoip.unwrap_or(self.disable_geoip) {
-            let _ = event.insert_prop("$geoip_disable", true);
+        // Per-call geoip override takes precedence over client default; caller-wins.
+        let effective_geoip = params.disable_geoip.unwrap_or(self.defaults.disable_geoip);
+        if effective_geoip {
+            event.insert_prop_default("$geoip_disable", serde_json::Value::Bool(true));
         }
-        if self.is_server {
-            let _ = event.insert_prop("$is_server", true);
+        if self.defaults.is_server {
+            event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
         }
         self.ship_event(event);
     }
@@ -267,8 +272,7 @@ impl Client {
     ///
     /// Disabled clients skip the request and return `Ok(())`.
     #[instrument(skip(self, event), level = "debug")]
-    #[allow(unused_mut)]
-    pub fn capture(&self, mut event: Event) -> Result<(), Error> {
+    pub fn capture(&self, event: Event) -> Result<(), Error> {
         if self.options.is_disabled() {
             trace!("Client is disabled, skipping capture");
             return Ok(());
@@ -276,39 +280,11 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
-            return self.capture_v1(vec![event]);
+            return self.capture_v1(vec![event], false).map(|_| ());
         }
 
         #[cfg(not(feature = "capture-v1"))]
-        {
-            // Add geoip disable property if configured
-            if self.options.disable_geoip {
-                event.insert_prop("$geoip_disable", true).ok();
-            }
-            // Mark server-side events so ingestion doesn't attribute the host OS to the person.
-            if self.options.is_server {
-                event.insert_prop("$is_server", true).ok();
-            }
-
-            let inner_event = InnerEvent::new(event, self.options.api_key.clone());
-
-            let payload = serde_json::to_string(&inner_event)
-                .map_err(|e| Error::Serialization(e.to_string()))?;
-
-            let url = self.options.endpoints().build_url(Endpoint::Capture);
-            let mut request = self
-                .client
-                .post(&url)
-                .header(CONTENT_TYPE, "application/json")
-                .body(payload);
-            request = self.apply_extra_headers(request);
-
-            let response = request
-                .send()
-                .map_err(|e| Error::Connection(e.to_string()))?;
-
-            check_response(response)
-        }
+        self.capture_v0(event)
     }
 
     /// Capture a collection of events with a single request.
@@ -337,73 +313,132 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
-            let _ = historical_migration;
-            return self.capture_v1(events);
+            return self.capture_v1(events, historical_migration).map(|_| ());
         }
 
         #[cfg(not(feature = "capture-v1"))]
-        {
-            let disable_geoip = self.options.disable_geoip;
-            let is_server = self.options.is_server;
-            let inner_events: Vec<InnerEvent> = events
-                .into_iter()
-                .map(|mut event| {
-                    if disable_geoip {
-                        event.insert_prop("$geoip_disable", true).ok();
-                    }
-                    if is_server {
-                        event.insert_prop("$is_server", true).ok();
-                    }
-                    InnerEvent::new(event, self.options.api_key.clone())
-                })
-                .collect();
-
-            let batch_request = BatchRequest {
-                api_key: self.options.api_key.clone(),
-                historical_migration,
-                batch: inner_events,
-            };
-            let payload = serde_json::to_string(&batch_request)
-                .map_err(|e| Error::Serialization(e.to_string()))?;
-            let url = self.options.endpoints().build_url(Endpoint::Batch);
-
-            let mut request = self
-                .client
-                .post(&url)
-                .header(CONTENT_TYPE, "application/json")
-                .body(payload);
-            request = self.apply_extra_headers(request);
-
-            let response = request
-                .send()
-                .map_err(|e| Error::Connection(e.to_string()))?;
-
-            check_response(response)
-        }
+        self.capture_batch_v0(events, historical_migration)
     }
 
     #[cfg(not(feature = "capture-v1"))]
-    #[allow(unused_mut)]
-    fn apply_extra_headers(
+    fn capture_v0(&self, mut event: Event) -> Result<(), Error> {
+        let defaults = self.options.capture_defaults();
+        super::v0_capture::prepare_event(&mut event, &defaults);
+        let payload =
+            super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
+
+        let url = self.options.endpoints().build_url(Endpoint::Capture);
+        let request = self
+            .client
+            .post(&url)
+            .header(CONTENT_TYPE, "application/json")
+            .body(payload);
+        let request = super::v0_capture::apply_extra_headers(&self.options, request);
+
+        let response = request
+            .send()
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        check_response(response)
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    fn capture_batch_v0(
         &self,
-        mut request: reqwest::blocking::RequestBuilder,
-    ) -> reqwest::blocking::RequestBuilder {
-        #[cfg(feature = "test-harness")]
-        {
-            if let Some(ref extra) = self.options.extra_capture_headers {
-                for (k, v) in extra {
-                    request = request.header(k.as_str(), v.as_str());
-                }
-            }
-        }
-        request
+        events: Vec<Event>,
+        historical_migration: bool,
+    ) -> Result<(), Error> {
+        let defaults = self.options.capture_defaults();
+        let payload = super::v0_capture::build_batch_payload(
+            events,
+            self.options.api_key.clone(),
+            historical_migration,
+            &defaults,
+        )?;
+        let url = self.options.endpoints().build_url(Endpoint::Batch);
+        let request = self
+            .client
+            .post(&url)
+            .header(CONTENT_TYPE, "application/json")
+            .body(payload);
+        let request = super::v0_capture::apply_extra_headers(&self.options, request);
+
+        let response = request
+            .send()
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        check_response(response)
     }
 
     #[cfg(feature = "capture-v1")]
-    fn capture_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
-        Err(Error::ServerError {
-            status: 500,
-            message: "Capture V1 not yet implemented".to_string(),
+    fn capture_v1(
+        &self,
+        events: Vec<Event>,
+        historical_migration: bool,
+    ) -> Result<CaptureResponse, Error> {
+        use super::v1_capture::{self, Step};
+        use crate::event_v1::V1BatchRequestRef;
+
+        let request_id = Uuid::now_v7();
+        let created_at = Utc::now().to_rfc3339();
+        let mut attempt: u32 = 1;
+        let defaults = self.options.capture_defaults();
+        let mut pending = v1_capture::build_events(&events, &defaults);
+        let mut final_results = HashMap::new();
+        let historical_migration = historical_migration.then_some(true);
+        let url = self
+            .options
+            .endpoints()
+            .build_custom_url(v1_capture::V1_CAPTURE_PATH);
+
+        loop {
+            let req = V1BatchRequestRef {
+                created_at: &created_at,
+                historical_migration,
+                batch: &pending,
+            };
+            let payload =
+                serde_json::to_vec(&req).map_err(|e| Error::Serialization(e.to_string()))?;
+            let mut headers = v1_capture::build_headers(&self.options, &request_id, attempt);
+            let body =
+                v1_capture::maybe_compress(self.options.capture_compression, &mut headers, payload);
+
+            let step = match self.client.post(&url).headers(headers).body(body).send() {
+                Err(e) => v1_capture::after_transport_error(
+                    &self.options,
+                    &request_id,
+                    attempt,
+                    e.to_string(),
+                ),
+                Ok(resp) => {
+                    let status = resp.status().as_u16();
+                    let retry_after = v1_capture::parse_retry_after(resp.headers());
+                    let text = resp.text().unwrap_or_else(|_| "Unknown error".to_string());
+                    v1_capture::after_response(
+                        &self.options,
+                        &request_id,
+                        attempt,
+                        status,
+                        retry_after,
+                        &text,
+                        &mut pending,
+                        &mut final_results,
+                    )
+                }
+            };
+
+            match step {
+                Step::Done => break,
+                Step::Fail(e) => return Err(e),
+                Step::Backoff(d) => {
+                    attempt += 1;
+                    std::thread::sleep(d);
+                }
+            }
+        }
+
+        Ok(CaptureResponse {
+            results: final_results,
         })
     }
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -18,7 +18,7 @@ use crate::feature_flags::{
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{event::InnerEvent, Error, Event};
 
-use super::ClientOptions;
+use super::{CaptureMode, ClientOptions};
 
 /// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
 /// dedup cache. On overflow the entire map is reset (matches the JS SDK).
@@ -272,6 +272,10 @@ impl Client {
             return Ok(());
         }
 
+        if self.options.capture_mode == CaptureMode::V1 {
+            return self.capture_v1(event);
+        }
+
         // Add geoip disable property if configured
         if self.options.disable_geoip {
             event.insert_prop("$geoip_disable", true).ok();
@@ -322,6 +326,10 @@ impl Client {
             return Ok(());
         }
 
+        if self.options.capture_mode == CaptureMode::V1 {
+            return self.capture_batch_v1(events);
+        }
+
         let disable_geoip = self.options.disable_geoip;
         let is_server = self.options.is_server;
         let inner_events: Vec<InnerEvent> = events
@@ -355,6 +363,20 @@ impl Client {
             .map_err(|e| Error::Connection(e.to_string()))?;
 
         check_response(response)
+    }
+
+    fn capture_v1(&self, _event: Event) -> Result<(), Error> {
+        Err(Error::ServerError {
+            status: 500,
+            message: "Capture V1 not yet implemented".to_string(),
+        })
+    }
+
+    fn capture_batch_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
+        Err(Error::ServerError {
+            status: 500,
+            message: "Capture V1 not yet implemented".to_string(),
+        })
     }
 
     /// Get all remote feature flags and payloads for a user.

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -291,11 +291,14 @@ impl Client {
             serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))?;
 
         let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let response = self
+        let mut request = self
             .client
             .post(&url)
             .header(CONTENT_TYPE, "application/json")
-            .body(payload)
+            .body(payload);
+        request = self.apply_extra_headers(request);
+
+        let response = request
             .send()
             .map_err(|e| Error::Connection(e.to_string()))?;
 
@@ -354,15 +357,30 @@ impl Client {
             .map_err(|e| Error::Serialization(e.to_string()))?;
         let url = self.options.endpoints().build_url(Endpoint::Batch);
 
-        let response = self
+        let mut request = self
             .client
             .post(&url)
             .header(CONTENT_TYPE, "application/json")
-            .body(payload)
+            .body(payload);
+        request = self.apply_extra_headers(request);
+
+        let response = request
             .send()
             .map_err(|e| Error::Connection(e.to_string()))?;
 
         check_response(response)
+    }
+
+    fn apply_extra_headers(
+        &self,
+        mut request: reqwest::blocking::RequestBuilder,
+    ) -> reqwest::blocking::RequestBuilder {
+        if let Some(ref extra) = self.options.extra_capture_headers {
+            for (k, v) in extra {
+                request = request.header(k.as_str(), v.as_str());
+            }
+        }
+        request
     }
 
     fn capture_v1(&self, _events: Vec<Event>) -> Result<(), Error> {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -273,7 +273,7 @@ impl Client {
         }
 
         if self.options.capture_mode == CaptureMode::V1 {
-            return self.capture_v1(event);
+            return self.capture_v1(vec![event]);
         }
 
         // Add geoip disable property if configured
@@ -327,7 +327,7 @@ impl Client {
         }
 
         if self.options.capture_mode == CaptureMode::V1 {
-            return self.capture_batch_v1(events);
+            return self.capture_v1(events);
         }
 
         let disable_geoip = self.options.disable_geoip;
@@ -365,14 +365,7 @@ impl Client {
         check_response(response)
     }
 
-    fn capture_v1(&self, _event: Event) -> Result<(), Error> {
-        Err(Error::ServerError {
-            status: 500,
-            message: "Capture V1 not yet implemented".to_string(),
-        })
-    }
-
-    fn capture_batch_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
+    fn capture_v1(&self, _events: Vec<Event>) -> Result<(), Error> {
         Err(Error::ServerError {
             status: 500,
             message: "Capture V1 not yet implemented".to_string(),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,19 +1,6 @@
-use std::collections::HashMap;
-
 use crate::endpoints::{EndpointManager, DEFAULT_HOST};
 use derive_builder::Builder;
 use tracing::warn;
-
-/// Selects which capture pipeline the client uses.
-///
-/// - `V0` (default): legacy `/batch/` endpoint with `api_key` in body
-/// - `V1`: new `/i/v1/analytics/events/` endpoint with `Authorization: Bearer` header
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum CaptureMode {
-    #[default]
-    V0,
-    V1,
-}
 
 #[cfg(not(feature = "async-client"))]
 mod blocking;
@@ -105,15 +92,13 @@ pub struct ClientOptions {
     #[builder(default = "false")]
     local_evaluation_only: bool,
 
-    /// Selects the capture pipeline. Defaults to `V0` (legacy `/batch/`).
-    #[builder(default)]
-    pub(crate) capture_mode: CaptureMode,
-
     /// Extra HTTP headers injected into every outbound capture request.
     /// Used by the SDK test harness adapter to attach `X-Test-Id` for
     /// parallel test isolation.
+    #[cfg(feature = "test-harness")]
     #[builder(default, setter(strip_option))]
-    pub(crate) extra_capture_headers: Option<HashMap<String, String>>,
+    #[allow(dead_code)]
+    pub(crate) extra_capture_headers: Option<std::collections::HashMap<String, String>>,
 
     #[builder(setter(skip))]
     #[builder(default = "EndpointManager::new(DEFAULT_HOST.to_string())")]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,6 +2,17 @@ use crate::endpoints::{EndpointManager, DEFAULT_HOST};
 use derive_builder::Builder;
 use tracing::warn;
 
+/// Selects which capture pipeline the client uses.
+///
+/// - `V0` (default): legacy `/batch/` endpoint with `api_key` in body
+/// - `V1`: new `/i/v1/analytics/events/` endpoint with `Authorization: Bearer` header
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CaptureMode {
+    #[default]
+    V0,
+    V1,
+}
+
 #[cfg(not(feature = "async-client"))]
 mod blocking;
 #[cfg(not(feature = "async-client"))]
@@ -91,6 +102,10 @@ pub struct ClientOptions {
     /// `enable_local_evaluation` is also true.
     #[builder(default = "false")]
     local_evaluation_only: bool,
+
+    /// Selects the capture pipeline. Defaults to `V0` (legacy `/batch/`).
+    #[builder(default)]
+    pub(crate) capture_mode: CaptureMode,
 
     #[builder(setter(skip))]
     #[builder(default = "EndpointManager::new(DEFAULT_HOST.to_string())")]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,8 +2,38 @@ use crate::endpoints::{EndpointManager, DEFAULT_HOST};
 use derive_builder::Builder;
 use tracing::warn;
 
+/// Request-body compression algorithm for the V1 capture pipeline.
+///
+/// When set on [`ClientOptions`], V1 capture requests are compressed and the
+/// matching `Content-Encoding` header is sent. The variant string matches the
+/// HTTP `Content-Encoding` token the server expects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureCompression {
+    Gzip,
+    Deflate,
+    Br,
+    Zstd,
+}
+
+impl CaptureCompression {
+    /// The HTTP `Content-Encoding` token for this algorithm.
+    #[cfg(feature = "capture-v1")]
+    pub(crate) fn content_encoding(self) -> &'static str {
+        match self {
+            CaptureCompression::Gzip => "gzip",
+            CaptureCompression::Deflate => "deflate",
+            CaptureCompression::Br => "br",
+            CaptureCompression::Zstd => "zstd",
+        }
+    }
+}
+
 #[cfg(not(feature = "async-client"))]
 mod blocking;
+#[cfg(not(feature = "capture-v1"))]
+mod v0_capture;
+#[cfg(feature = "capture-v1")]
+mod v1_capture;
 #[cfg(not(feature = "async-client"))]
 pub use blocking::client;
 #[cfg(not(feature = "async-client"))]
@@ -92,6 +122,29 @@ pub struct ClientOptions {
     #[builder(default = "false")]
     local_evaluation_only: bool,
 
+    /// Maximum number of attempts for V1 capture requests (default: 3).
+    /// Includes the initial attempt, so `3` means 1 initial + 2 retries.
+    #[builder(default = "3")]
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) max_capture_attempts: u32,
+
+    /// Initial retry backoff duration in milliseconds (default: 200)
+    #[builder(default = "200")]
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) retry_initial_backoff_ms: u64,
+
+    /// Maximum retry backoff duration in milliseconds (default: 30000)
+    #[builder(default = "30000")]
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) retry_max_backoff_ms: u64,
+
+    /// Optional request-body compression for the V1 capture pipeline. When
+    /// `None` (default), bodies are sent uncompressed. Requires the
+    /// `capture-v1` crate feature to take effect.
+    #[builder(default, setter(strip_option))]
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) capture_compression: Option<CaptureCompression>,
+
     /// Extra HTTP headers injected into every outbound capture request.
     /// Used by the SDK test harness adapter to attach `X-Test-Id` for
     /// parallel test isolation.
@@ -105,7 +158,27 @@ pub struct ClientOptions {
     endpoint_manager: EndpointManager,
 }
 
+/// Resolved client-level default properties for capture requests.
+///
+/// Built once from [`ClientOptions`] and threaded through all event-producing
+/// paths (V0 capture, V0 flag-called host, V1 capture) so each default is
+/// applied in exactly one place with caller-wins (`entry().or_insert`)
+/// semantics.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CaptureDefaults {
+    pub(crate) disable_geoip: bool,
+    pub(crate) is_server: bool,
+}
+
 impl ClientOptions {
+    /// Build the resolved capture defaults for this client configuration.
+    pub(crate) fn capture_defaults(&self) -> CaptureDefaults {
+        CaptureDefaults {
+            disable_geoip: self.disable_geoip,
+            is_server: self.is_server,
+        }
+    }
+
     /// Get the endpoint manager
     pub(crate) fn endpoints(&self) -> &EndpointManager {
         &self.endpoint_manager

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::endpoints::{EndpointManager, DEFAULT_HOST};
 use derive_builder::Builder;
 use tracing::warn;
@@ -106,6 +108,12 @@ pub struct ClientOptions {
     /// Selects the capture pipeline. Defaults to `V0` (legacy `/batch/`).
     #[builder(default)]
     pub(crate) capture_mode: CaptureMode,
+
+    /// Extra HTTP headers injected into every outbound capture request.
+    /// Used by the SDK test harness adapter to attach `X-Test-Id` for
+    /// parallel test isolation.
+    #[builder(default, setter(strip_option))]
+    pub(crate) extra_capture_headers: Option<HashMap<String, String>>,
 
     #[builder(setter(skip))]
     #[builder(default = "EndpointManager::new(DEFAULT_HOST.to_string())")]

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -1,0 +1,81 @@
+//! Shared, runtime-agnostic helpers for the V0 capture pipeline.
+//! Each client keeps only the I/O; this module owns event preparation and
+//! payload construction.
+
+#[cfg(not(feature = "async-client"))]
+use reqwest::blocking::RequestBuilder;
+#[cfg(feature = "async-client")]
+use reqwest::RequestBuilder;
+
+use super::{CaptureDefaults, ClientOptions};
+use crate::error::Error;
+use crate::event::{BatchRequest, Event, InnerEvent};
+
+// ---------------------------------------------------------------------------
+// Event preparation
+// ---------------------------------------------------------------------------
+
+/// Apply client-level default properties (caller-wins) and V0 metadata stamping.
+///
+/// Uses `insert_prop_default` so a caller who explicitly set a property on the
+/// event before calling `capture()` keeps their value.
+pub(crate) fn prepare_event(event: &mut Event, defaults: &CaptureDefaults) {
+    if defaults.disable_geoip {
+        event.insert_prop_default("$geoip_disable", serde_json::Value::Bool(true));
+    }
+    if defaults.is_server {
+        event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
+    }
+    event.prepare_for_v0();
+}
+
+// ---------------------------------------------------------------------------
+// Payload building
+// ---------------------------------------------------------------------------
+
+/// Build the JSON body for a single-event V0 capture request.
+pub(crate) fn build_capture_payload(event: Event, api_key: String) -> Result<String, Error> {
+    let inner_event = InnerEvent::new(event, api_key);
+    serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))
+}
+
+/// Build the JSON body for a V0 batch capture request.
+pub(crate) fn build_batch_payload(
+    events: Vec<Event>,
+    api_key: String,
+    historical_migration: bool,
+    defaults: &CaptureDefaults,
+) -> Result<String, Error> {
+    let inner_events: Vec<InnerEvent> = events
+        .into_iter()
+        .map(|mut event| {
+            prepare_event(&mut event, defaults);
+            InnerEvent::new(event, api_key.clone())
+        })
+        .collect();
+
+    let batch_request = BatchRequest {
+        api_key,
+        historical_migration,
+        batch: inner_events,
+    };
+    serde_json::to_string(&batch_request).map_err(|e| Error::Serialization(e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Header helpers
+// ---------------------------------------------------------------------------
+
+/// Apply test-harness extra headers to a V0 request.
+pub(crate) fn apply_extra_headers(
+    #[allow(unused_variables)] options: &ClientOptions,
+    #[allow(unused_mut)] mut request: RequestBuilder,
+) -> RequestBuilder {
+    #[cfg(feature = "test-harness")]
+    if let Some(ref extra) = options.extra_capture_headers {
+        for (k, v) in extra {
+            request = request.header(k.as_str(), v.as_str());
+        }
+    }
+    request
+}

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -1,0 +1,651 @@
+//! Shared, runtime-agnostic helpers for the V1 capture pipeline.
+//! Each client keeps only the I/O; this module owns everything else.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+pub(crate) const V1_CAPTURE_PATH: &str = "/i/v1/analytics/events";
+
+use chrono::Utc;
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+use tracing::debug;
+use uuid::Uuid;
+
+use super::{CaptureCompression, CaptureDefaults, ClientOptions};
+use crate::error::Error;
+use crate::event::Event;
+use crate::event_v1::{CaptureResponse, EventResult, EventStatus, V1ErrorResponse, V1Event};
+
+// ---------------------------------------------------------------------------
+// Request building
+// ---------------------------------------------------------------------------
+
+pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<V1Event> {
+    events
+        .iter()
+        .map(|event| {
+            let mut v1 = V1Event::from_event(event);
+            if let serde_json::Value::Object(ref mut map) = v1.properties {
+                if defaults.disable_geoip {
+                    map.entry("$geoip_disable")
+                        .or_insert(serde_json::Value::Bool(true));
+                }
+                if defaults.is_server {
+                    map.entry("$is_server")
+                        .or_insert(serde_json::Value::Bool(true));
+                }
+            }
+            v1
+        })
+        .collect()
+}
+
+pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u32) -> HeaderMap {
+    let version = env!("CARGO_PKG_VERSION");
+    let sdk_info = format!("posthog-rust/{version}");
+
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        "authorization",
+        HeaderValue::from_str(&format!("Bearer {}", opts.api_key))
+            .unwrap_or_else(|_| HeaderValue::from_static("Bearer invalid")),
+    );
+    headers.insert(
+        "user-agent",
+        HeaderValue::from_str(&sdk_info)
+            .unwrap_or_else(|_| HeaderValue::from_static("posthog-rust")),
+    );
+    headers.insert(
+        "posthog-sdk-info",
+        HeaderValue::from_str(&sdk_info)
+            .unwrap_or_else(|_| HeaderValue::from_static("posthog-rust")),
+    );
+    headers.insert(
+        "posthog-attempt",
+        HeaderValue::from_str(&attempt.to_string())
+            .unwrap_or_else(|_| HeaderValue::from_static("1")),
+    );
+    headers.insert(
+        "posthog-request-id",
+        HeaderValue::from_str(&request_id.to_string())
+            .unwrap_or_else(|_| HeaderValue::from_static("unknown")),
+    );
+    headers.insert(
+        "posthog-request-timestamp",
+        HeaderValue::from_str(&Utc::now().to_rfc3339())
+            .unwrap_or_else(|_| HeaderValue::from_static("unknown")),
+    );
+    #[cfg(feature = "test-harness")]
+    if let Some(ref extra) = opts.extra_capture_headers {
+        for (k, v) in extra {
+            if let (Ok(name), Ok(val)) = (
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()),
+                HeaderValue::from_str(v),
+            ) {
+                headers.insert(name, val);
+            }
+        }
+    }
+    headers
+}
+
+pub(crate) fn maybe_compress(
+    compression: Option<CaptureCompression>,
+    headers: &mut HeaderMap,
+    payload: Vec<u8>,
+) -> Vec<u8> {
+    if let Some(algo) = compression {
+        if let Some((compressed, encoding)) = crate::compression::compress(algo, &payload) {
+            headers.insert("content-encoding", HeaderValue::from_static(encoding));
+            return compressed;
+        }
+    }
+    payload
+}
+
+// ---------------------------------------------------------------------------
+// Retry helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn is_retryable_status(status: u16) -> bool {
+    matches!(status, 408 | 500 | 502 | 503 | 504)
+}
+
+pub(crate) fn parse_retry_after(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+}
+
+pub(crate) fn backoff_duration(
+    opts: &ClientOptions,
+    attempt: u32,
+    retry_after_secs: Option<u64>,
+) -> Duration {
+    if let Some(secs) = retry_after_secs {
+        Duration::from_secs(secs)
+    } else {
+        let base_ms = opts.retry_initial_backoff_ms;
+        let max_ms = opts.retry_max_backoff_ms;
+        let backoff_ms = base_ms.saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)));
+        Duration::from_millis(backoff_ms.min(max_ms))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response classification
+// ---------------------------------------------------------------------------
+
+pub(crate) fn count_results(resp: &CaptureResponse) -> HashMap<(String, Option<String>), usize> {
+    let mut counts: HashMap<(String, Option<String>), usize> = HashMap::new();
+    for result in resp.results.values() {
+        let key = (
+            format!("{:?}", result.result).to_lowercase(),
+            result.details.clone(),
+        );
+        *counts.entry(key).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// O(n) consuming pass: records terminal results, returns only retry events.
+/// Events absent from `results` are silently dropped.
+pub(crate) fn process_batch_response(
+    pending: Vec<V1Event>,
+    results: &HashMap<Uuid, EventResult>,
+    final_results: &mut HashMap<Uuid, EventResult>,
+    is_final_attempt: bool,
+) -> Vec<V1Event> {
+    let mut next = Vec::new();
+    for v1 in pending {
+        match results.get(&v1.uuid) {
+            Some(r) if r.result == EventStatus::Retry => {
+                if is_final_attempt {
+                    final_results.insert(v1.uuid, r.clone());
+                } else {
+                    next.push(v1);
+                }
+            }
+            Some(r) => {
+                final_results.insert(v1.uuid, r.clone());
+            }
+            None => {}
+        }
+    }
+    next
+}
+
+// ---------------------------------------------------------------------------
+// Sans-IO control flow
+// ---------------------------------------------------------------------------
+
+pub(crate) enum Step {
+    Done,
+    Backoff(Duration),
+    Fail(Error),
+}
+
+pub(crate) fn after_transport_error(
+    opts: &ClientOptions,
+    request_id: &Uuid,
+    attempt: u32,
+    err_msg: String,
+) -> Step {
+    if attempt >= opts.max_capture_attempts {
+        return Step::Fail(Error::Connection(err_msg));
+    }
+    debug!(
+        request_id = %request_id,
+        attempt,
+        error = %err_msg,
+        "V1 capture request failed, will retry"
+    );
+    Step::Backoff(backoff_duration(opts, attempt + 1, None))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn after_response(
+    opts: &ClientOptions,
+    request_id: &Uuid,
+    attempt: u32,
+    status: u16,
+    retry_after: Option<u64>,
+    body: &str,
+    pending: &mut Vec<V1Event>,
+    final_results: &mut HashMap<Uuid, EventResult>,
+) -> Step {
+    if status == 200 {
+        let batch_resp: CaptureResponse = match serde_json::from_str(body) {
+            Ok(r) => r,
+            Err(e) => return Step::Fail(Error::Serialization(e.to_string())),
+        };
+
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let result_counts = count_results(&batch_resp);
+            debug!(
+                request_id = %request_id,
+                attempt,
+                results = ?result_counts,
+                "V1 capture batch response"
+            );
+        }
+
+        let is_final = attempt >= opts.max_capture_attempts;
+        let next = process_batch_response(
+            std::mem::take(pending),
+            &batch_resp.results,
+            final_results,
+            is_final,
+        );
+        *pending = next;
+
+        if pending.is_empty() || is_final {
+            Step::Done
+        } else {
+            Step::Backoff(backoff_duration(opts, attempt + 1, retry_after))
+        }
+    } else if is_retryable_status(status) {
+        let error_desc = serde_json::from_str::<V1ErrorResponse>(body)
+            .ok()
+            .and_then(|e| e.error_description)
+            .unwrap_or_else(|| body.to_string());
+
+        debug!(
+            request_id = %request_id,
+            attempt,
+            status,
+            error = %error_desc,
+            "V1 capture request failed, will retry"
+        );
+
+        if attempt >= opts.max_capture_attempts {
+            Step::Fail(
+                Error::from_http_response(status, body.to_string())
+                    .unwrap_or_else(|| Error::Connection(format!("HTTP {status}"))),
+            )
+        } else {
+            Step::Backoff(backoff_duration(opts, attempt + 1, retry_after))
+        }
+    } else {
+        Step::Fail(
+            Error::from_http_response(status, body.to_string())
+                .unwrap_or_else(|| Error::Connection(format!("HTTP {status}"))),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    use reqwest::header::{HeaderMap, HeaderValue};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::client::ClientOptionsBuilder;
+    use crate::event_v1::{CaptureResponse, EventResult, EventStatus, V1Event};
+
+    fn test_opts() -> ClientOptions {
+        ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .max_capture_attempts(3u32)
+            .retry_initial_backoff_ms(100u64)
+            .retry_max_backoff_ms(5000u64)
+            .build()
+            .unwrap()
+    }
+
+    fn dummy_v1_event() -> V1Event {
+        V1Event {
+            event: "$pageview".into(),
+            uuid: Uuid::now_v7(),
+            distinct_id: "user-1".into(),
+            timestamp: "2026-05-28T12:00:00.000Z".into(),
+            session_id: None,
+            window_id: None,
+            options: Default::default(),
+            properties: serde_json::json!({}),
+        }
+    }
+
+    fn event_result(status: EventStatus, details: Option<&str>) -> EventResult {
+        EventResult {
+            result: status,
+            details: details.map(String::from),
+        }
+    }
+
+    // -- is_retryable_status -------------------------------------------------
+
+    #[test]
+    fn retryable_statuses() {
+        for code in [408, 500, 502, 503, 504] {
+            assert!(
+                is_retryable_status(code),
+                "expected {} to be retryable",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn non_retryable_statuses() {
+        for code in [200, 201, 400, 401, 402, 403, 413, 415, 418, 404] {
+            assert!(
+                !is_retryable_status(code),
+                "expected {} to NOT be retryable",
+                code
+            );
+        }
+    }
+
+    // -- parse_retry_after ---------------------------------------------------
+
+    #[test]
+    fn parse_retry_after_valid() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("5"));
+        assert_eq!(parse_retry_after(&headers), Some(5));
+    }
+
+    #[test]
+    fn parse_retry_after_missing() {
+        let headers = HeaderMap::new();
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn parse_retry_after_non_numeric() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("not-a-number"));
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    // -- backoff_duration ----------------------------------------------------
+
+    #[test]
+    fn backoff_explicit_retry_after_wins() {
+        let opts = test_opts();
+        let d = backoff_duration(&opts, 1, Some(42));
+        assert_eq!(d, Duration::from_secs(42));
+    }
+
+    #[test]
+    fn backoff_exponential_growth() {
+        let opts = test_opts();
+        let d1 = backoff_duration(&opts, 1, None);
+        let d2 = backoff_duration(&opts, 2, None);
+        let d3 = backoff_duration(&opts, 3, None);
+        assert_eq!(d1, Duration::from_millis(100));
+        assert_eq!(d2, Duration::from_millis(200));
+        assert_eq!(d3, Duration::from_millis(400));
+    }
+
+    #[test]
+    fn backoff_clamped_to_max() {
+        let opts = ClientOptionsBuilder::default()
+            .api_key("k".to_string())
+            .retry_initial_backoff_ms(100u64)
+            .retry_max_backoff_ms(150u64)
+            .build()
+            .unwrap();
+        let d = backoff_duration(&opts, 3, None);
+        assert_eq!(d, Duration::from_millis(150));
+    }
+
+    // -- count_results -------------------------------------------------------
+
+    #[test]
+    fn count_results_aggregates() {
+        let u1 = Uuid::now_v7();
+        let u2 = Uuid::now_v7();
+        let u3 = Uuid::now_v7();
+        let resp = CaptureResponse {
+            results: HashMap::from([
+                (u1, event_result(EventStatus::Ok, None)),
+                (u2, event_result(EventStatus::Ok, None)),
+                (u3, event_result(EventStatus::Retry, Some("not_persisted"))),
+            ]),
+        };
+        let counts = count_results(&resp);
+        assert_eq!(counts[&("ok".to_string(), None)], 2);
+        assert_eq!(
+            counts[&("retry".to_string(), Some("not_persisted".to_string()))],
+            1
+        );
+    }
+
+    // -- process_batch_response ----------------------------------------------
+
+    #[test]
+    fn process_batch_retry_kept_when_not_final() {
+        let e1 = dummy_v1_event();
+        let e2 = dummy_v1_event();
+        let results = HashMap::from([
+            (e1.uuid, event_result(EventStatus::Ok, None)),
+            (
+                e2.uuid,
+                event_result(EventStatus::Retry, Some("not_persisted")),
+            ),
+        ]);
+        let mut final_results = HashMap::new();
+        let next = process_batch_response(
+            vec![e1.clone(), e2.clone()],
+            &results,
+            &mut final_results,
+            false,
+        );
+        assert_eq!(next.len(), 1);
+        assert_eq!(next[0].uuid, e2.uuid);
+        assert!(final_results.contains_key(&e1.uuid));
+        assert!(!final_results.contains_key(&e2.uuid));
+    }
+
+    #[test]
+    fn process_batch_retry_finalized_when_final() {
+        let e1 = dummy_v1_event();
+        let results = HashMap::from([(
+            e1.uuid,
+            event_result(EventStatus::Retry, Some("not_persisted")),
+        )]);
+        let mut final_results = HashMap::new();
+        let next = process_batch_response(vec![e1.clone()], &results, &mut final_results, true);
+        assert!(next.is_empty());
+        assert!(final_results.contains_key(&e1.uuid));
+    }
+
+    #[test]
+    fn process_batch_terminal_results_finalized() {
+        let ok_ev = dummy_v1_event();
+        let drop_ev = dummy_v1_event();
+        let warn_ev = dummy_v1_event();
+        let results = HashMap::from([
+            (ok_ev.uuid, event_result(EventStatus::Ok, None)),
+            (
+                drop_ev.uuid,
+                event_result(EventStatus::Drop, Some("billing")),
+            ),
+            (
+                warn_ev.uuid,
+                event_result(EventStatus::Warning, Some("pp_disabled")),
+            ),
+        ]);
+        let mut final_results = HashMap::new();
+        let next = process_batch_response(
+            vec![ok_ev.clone(), drop_ev.clone(), warn_ev.clone()],
+            &results,
+            &mut final_results,
+            false,
+        );
+        assert!(next.is_empty());
+        assert_eq!(final_results.len(), 3);
+    }
+
+    #[test]
+    fn process_batch_missing_uuid_silently_dropped() {
+        let e = dummy_v1_event();
+        let results = HashMap::new();
+        let mut final_results = HashMap::new();
+        let next = process_batch_response(vec![e.clone()], &results, &mut final_results, false);
+        assert!(next.is_empty());
+        assert!(final_results.is_empty());
+    }
+
+    // -- after_transport_error -----------------------------------------------
+
+    #[test]
+    fn after_transport_error_fails_at_max() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let step = after_transport_error(&opts, &rid, 3, "timeout".into());
+        assert!(matches!(step, Step::Fail(Error::Connection(_))));
+    }
+
+    #[test]
+    fn after_transport_error_backs_off_below_max() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let step = after_transport_error(&opts, &rid, 1, "timeout".into());
+        assert!(matches!(step, Step::Backoff(_)));
+    }
+
+    // -- after_response ------------------------------------------------------
+
+    #[test]
+    fn after_response_200_all_ok_is_done() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let e = dummy_v1_event();
+        let body = serde_json::json!({
+            "results": { e.uuid.to_string(): { "result": "ok" } }
+        })
+        .to_string();
+        let mut pending = vec![e];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            1,
+            200,
+            None,
+            &body,
+            &mut pending,
+            &mut final_results,
+        );
+        assert!(matches!(step, Step::Done));
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn after_response_200_partial_retry_backs_off() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let e1 = dummy_v1_event();
+        let e2 = dummy_v1_event();
+        let body = serde_json::json!({
+            "results": {
+                e1.uuid.to_string(): { "result": "ok" },
+                e2.uuid.to_string(): { "result": "retry", "details": "not_persisted" }
+            }
+        })
+        .to_string();
+        let mut pending = vec![e1.clone(), e2.clone()];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            1,
+            200,
+            None,
+            &body,
+            &mut pending,
+            &mut final_results,
+        );
+        assert!(matches!(step, Step::Backoff(_)));
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].uuid, e2.uuid);
+        assert!(final_results.contains_key(&e1.uuid));
+    }
+
+    #[test]
+    fn after_response_retryable_status_backs_off() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let body = r#"{"error":"service_unavailable"}"#;
+        let mut pending = vec![dummy_v1_event()];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            1,
+            503,
+            Some(1),
+            body,
+            &mut pending,
+            &mut final_results,
+        );
+        assert!(matches!(step, Step::Backoff(_)));
+    }
+
+    #[test]
+    fn after_response_retryable_status_fails_at_max() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let body = r#"{"error":"service_unavailable"}"#;
+        let mut pending = vec![dummy_v1_event()];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            3,
+            503,
+            None,
+            body,
+            &mut pending,
+            &mut final_results,
+        );
+        assert!(matches!(step, Step::Fail(_)));
+    }
+
+    #[test]
+    fn after_response_non_retryable_status_fails() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let body = r#"{"error":"billing_limit_exceeded"}"#;
+        let mut pending = vec![dummy_v1_event()];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            1,
+            402,
+            None,
+            body,
+            &mut pending,
+            &mut final_results,
+        );
+        assert!(matches!(step, Step::Fail(Error::BillingLimitExceeded(_))));
+    }
+
+    #[test]
+    fn after_response_malformed_200_body_fails() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let mut pending = vec![dummy_v1_event()];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            1,
+            200,
+            None,
+            "not json",
+            &mut pending,
+            &mut final_results,
+        );
+        assert!(matches!(step, Step::Fail(Error::Serialization(_))));
+    }
+}

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,99 @@
+//! Request-body compression for the V1 capture pipeline.
+//!
+//! This module is only compiled when the `capture-v1` crate feature is enabled.
+
+use crate::client::CaptureCompression;
+
+/// Compress `data` with `algo`, returning the compressed bytes alongside the
+/// HTTP `Content-Encoding` token to advertise. Returns `None` when compression
+/// fails, signalling the caller to send the payload uncompressed without a
+/// `Content-Encoding` header.
+pub(crate) fn compress(algo: CaptureCompression, data: &[u8]) -> Option<(Vec<u8>, &'static str)> {
+    use std::io::Write;
+
+    let encoding = algo.content_encoding();
+    let result: std::io::Result<Vec<u8>> = match algo {
+        CaptureCompression::Gzip => {
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(data).and_then(|_| encoder.finish())
+        }
+        CaptureCompression::Deflate => {
+            let mut encoder =
+                flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(data).and_then(|_| encoder.finish())
+        }
+        CaptureCompression::Br => {
+            let mut out = Vec::new();
+            {
+                let mut encoder = brotli::CompressorWriter::new(&mut out, 4096, 5, 22);
+                if let Err(e) = encoder.write_all(data).and_then(|_| encoder.flush()) {
+                    Err(e)
+                } else {
+                    Ok(())
+                }
+            }
+            .map(|_| out)
+        }
+        CaptureCompression::Zstd => zstd::stream::encode_all(data, 0),
+    };
+
+    match result {
+        Ok(bytes) => Some((bytes, encoding)),
+        Err(e) => {
+            tracing::warn!(error = %e, encoding, "failed to compress V1 capture body; sending uncompressed");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn gzip_roundtrips() {
+        let data = br#"{"hello":"world"}"#;
+        let (compressed, encoding) = compress(CaptureCompression::Gzip, data).unwrap();
+        assert_eq!(encoding, "gzip");
+        assert_ne!(compressed, data);
+
+        let mut decoder = flate2::read::GzDecoder::new(&compressed[..]);
+        let mut out = Vec::new();
+        decoder.read_to_end(&mut out).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn deflate_roundtrips() {
+        let data = br#"{"hello":"world"}"#;
+        let (compressed, encoding) = compress(CaptureCompression::Deflate, data).unwrap();
+        assert_eq!(encoding, "deflate");
+
+        let mut decoder = flate2::read::ZlibDecoder::new(&compressed[..]);
+        let mut out = Vec::new();
+        decoder.read_to_end(&mut out).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn zstd_roundtrips() {
+        let data = br#"{"hello":"world"}"#;
+        let (compressed, encoding) = compress(CaptureCompression::Zstd, data).unwrap();
+        assert_eq!(encoding, "zstd");
+        let out = zstd::stream::decode_all(&compressed[..]).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn brotli_produces_output() {
+        let data = br#"{"hello":"world"}"#;
+        let (compressed, encoding) = compress(CaptureCompression::Br, data).unwrap();
+        assert_eq!(encoding, "br");
+        let mut decoder = brotli::Decompressor::new(&compressed[..], 4096);
+        let mut out = Vec::new();
+        decoder.read_to_end(&mut out).unwrap();
+        assert_eq!(out, data);
+    }
+}

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -16,6 +16,8 @@ pub enum Endpoint {
     Capture,
     /// Batch event capture endpoint
     Batch,
+    /// V1 analytics capture endpoint
+    CaptureV1,
     /// Feature flags endpoint
     Flags,
     /// Local evaluation endpoint
@@ -28,6 +30,7 @@ impl Endpoint {
         match self {
             Endpoint::Capture => "/i/v0/e/",
             Endpoint::Batch => "/batch/",
+            Endpoint::CaptureV1 => "/i/v1/analytics/events/",
             Endpoint::Flags => "/flags/?v=2",
             Endpoint::LocalEvaluation => "/flags/definitions/?send_cohorts",
         }

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -11,6 +11,7 @@ pub const DEFAULT_HOST: &str = US_INGESTION_ENDPOINT;
 
 /// API endpoints used by the SDK for different operations.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum Endpoint {
     /// Event capture endpoint
     Capture,

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -11,14 +11,11 @@ pub const DEFAULT_HOST: &str = US_INGESTION_ENDPOINT;
 
 /// API endpoints used by the SDK for different operations.
 #[derive(Debug, Clone)]
-#[non_exhaustive]
 pub enum Endpoint {
     /// Event capture endpoint
     Capture,
     /// Batch event capture endpoint
     Batch,
-    /// V1 analytics capture endpoint
-    CaptureV1,
     /// Feature flags endpoint
     Flags,
     /// Local evaluation endpoint
@@ -31,7 +28,6 @@ impl Endpoint {
         match self {
             Endpoint::Capture => "/i/v0/e/",
             Endpoint::Batch => "/batch/",
-            Endpoint::CaptureV1 => "/i/v1/analytics/events/",
             Endpoint::Flags => "/flags/?v=2",
             Endpoint::LocalEvaluation => "/flags/definitions/?send_cohorts",
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,10 @@ impl Display for Error {
             Error::ServerError { status, message } => {
                 write!(f, "Server Error (HTTP {status}): {message}")
             }
+            Error::Unauthorized => write!(f, "Unauthorized: invalid or missing API token"),
+            Error::BillingLimitExceeded(msg) => {
+                write!(f, "Billing Limit Exceeded: {msg}")
+            }
         }
     }
 }
@@ -47,6 +51,10 @@ pub enum Error {
         /// Response body or error message returned by the server.
         message: String,
     },
+    /// HTTP 401 — invalid or missing Bearer token
+    Unauthorized,
+    /// HTTP 402 — billing quota exceeded (non-retryable)
+    BillingLimitExceeded(String),
 }
 
 impl Error {
@@ -55,6 +63,8 @@ impl Error {
     pub(crate) fn from_http_response(status: u16, body: String) -> Option<Self> {
         match status {
             200..=299 => None,
+            401 => Some(Error::Unauthorized),
+            402 => Some(Error::BillingLimitExceeded(body)),
             429 => Some(Error::RateLimit),
             400 | 413 => Some(Error::BadRequest(body)),
             500..=599 => Some(Error::ServerError {

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,11 +2,29 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 use semver::Version;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::feature_flag_evaluations::FeatureFlagEvaluations;
 use crate::Error;
+
+/// Per-event V1 capture options. Known fields are typed; unknown keys go into
+/// `extra` via `#[serde(flatten)]` for forward compatibility with new backend
+/// options without requiring an SDK update.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct EventOptions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cookieless_mode: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disable_skew_correction: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub product_tour_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_person_profile: Option<bool>,
+
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub extra: HashMap<String, serde_json::Value>,
+}
 
 /// An [`Event`] represents an interaction a user has with your app or
 /// website. Examples include button clicks, pageviews, query completions, and signups.
@@ -21,6 +39,8 @@ pub struct Event {
     groups: HashMap<String, String>,
     timestamp: Option<NaiveDateTime>,
     uuid: Uuid,
+    #[serde(skip)]
+    options: EventOptions,
 }
 
 impl Event {
@@ -41,6 +61,7 @@ impl Event {
             groups: HashMap::new(),
             timestamp: None,
             uuid: Uuid::now_v7(),
+            options: EventOptions::default(),
         }
     }
 
@@ -57,17 +78,18 @@ impl Event {
     /// Generates a random distinct ID and sets `$process_person_profile` to
     /// `false` so PostHog does not create a person profile for the event.
     pub fn new_anon<S: Into<String>>(event: S) -> Self {
-        let mut res = Self {
+        Self {
             event: event.into(),
             distinct_id: Uuid::now_v7().to_string(),
             properties: HashMap::new(),
             groups: HashMap::new(),
             timestamp: None,
             uuid: Uuid::now_v7(),
-        };
-        res.insert_prop("$process_person_profile", false)
-            .expect("bools are safe for serde");
-        res
+            options: EventOptions {
+                process_person_profile: Some(false),
+                ..EventOptions::default()
+            },
+        }
     }
 
     /// Add a property to the event.
@@ -106,9 +128,7 @@ impl Event {
     /// include person profile processing if they were anonymous. This might lead
     /// to "empty" person profiles being created.
     pub fn add_group(&mut self, group_name: &str, group_id: &str) {
-        // You cannot disable person profile processing for groups
-        self.insert_prop("$process_person_profile", true)
-            .expect("bools are safe for serde");
+        self.options.process_person_profile = Some(true);
         self.groups.insert(group_name.into(), group_id.into());
     }
 
@@ -159,6 +179,128 @@ impl Event {
         }
         self
     }
+
+    /// Set or reset a V1 capture option by key. Known keys route to typed
+    /// fields; unknown keys go into the forward-compatible overflow map.
+    #[cfg(feature = "capture-v1")]
+    pub fn set_option<V: Serialize>(&mut self, key: &str, value: V) -> Result<(), Error> {
+        let val = serde_json::to_value(value).map_err(|e| Error::Serialization(e.to_string()))?;
+        match key {
+            "cookieless_mode" => self.options.cookieless_mode = val.as_bool(),
+            "disable_skew_correction" => self.options.disable_skew_correction = val.as_bool(),
+            "process_person_profile" => self.options.process_person_profile = val.as_bool(),
+            "product_tour_id" => self.options.product_tour_id = val.as_str().map(|s| s.to_string()),
+            _ => {
+                self.options.extra.insert(key.to_owned(), val);
+            }
+        }
+        Ok(())
+    }
+
+    /// Access the event options.
+    #[cfg(feature = "capture-v1")]
+    pub fn options(&self) -> &EventOptions {
+        &self.options
+    }
+
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) fn event_name(&self) -> &str {
+        &self.event
+    }
+
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) fn distinct_id(&self) -> &str {
+        &self.distinct_id
+    }
+
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) fn timestamp(&self) -> Option<NaiveDateTime> {
+        self.timestamp
+    }
+
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) fn properties(&self) -> &HashMap<String, serde_json::Value> {
+        &self.properties
+    }
+
+    /// Insert a default property only if the caller hasn't already set it.
+    ///
+    /// This gives caller-wins semantics: SDK-level defaults (like `$is_server`)
+    /// are injected without overriding an explicit value the user placed on the
+    /// event before calling `capture()`.
+    pub(crate) fn insert_prop_default<K: Into<String>>(
+        &mut self,
+        key: K,
+        value: serde_json::Value,
+    ) {
+        self.properties.entry(key.into()).or_insert(value);
+    }
+
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) fn groups(&self) -> &HashMap<String, String> {
+        &self.groups
+    }
+
+    /// Translate `options` and `groups` into V0 properties and inject SDK
+    /// metadata. Call this before constructing [`InnerEvent`] so that the
+    /// wire payload matches what the V0 `/capture` and `/batch` endpoints expect.
+    #[cfg_attr(feature = "capture-v1", allow(dead_code))]
+    pub(crate) fn prepare_for_v0(&mut self) {
+        if !self.properties.contains_key("$lib") {
+            self.properties.insert(
+                "$lib".into(),
+                serde_json::Value::String("posthog-rs".into()),
+            );
+        }
+
+        let version_str = env!("CARGO_PKG_VERSION");
+        if !self.properties.contains_key("$lib_version") {
+            self.properties.insert(
+                "$lib_version".into(),
+                serde_json::Value::String(version_str.into()),
+            );
+        }
+
+        if !self.properties.contains_key("$lib_version__major") {
+            if let Ok(version) = version_str.parse::<Version>() {
+                self.properties.insert(
+                    "$lib_version__major".into(),
+                    serde_json::Value::Number(version.major.into()),
+                );
+                self.properties.insert(
+                    "$lib_version__minor".into(),
+                    serde_json::Value::Number(version.minor.into()),
+                );
+                self.properties.insert(
+                    "$lib_version__patch".into(),
+                    serde_json::Value::Number(version.patch.into()),
+                );
+            }
+        }
+
+        if let Some(ppp) = self.options.process_person_profile {
+            self.properties
+                .entry("$process_person_profile".into())
+                .or_insert_with(|| serde_json::Value::Bool(ppp));
+        }
+
+        if !self.groups.is_empty() {
+            self.properties.insert(
+                "$groups".into(),
+                serde_json::Value::Object(
+                    self.groups
+                        .iter()
+                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                        .collect(),
+                ),
+            );
+        }
+    }
 }
 
 /// Wrapper for the `/batch/` endpoint that includes the API key and options
@@ -184,65 +326,15 @@ pub struct InnerEvent {
 }
 
 impl InnerEvent {
-    /// Build an [`InnerEvent`] from an [`Event`], stamping the SDK metadata
-    /// (`$lib`, `$lib_version`).
+    /// Construct the V0 wire event. Expects that [`Event::prepare_for_v0`] has
+    /// already been called so properties are fully decorated.
     pub fn new(event: Event, api_key: String) -> Self {
-        let uuid = event.uuid;
-        let mut properties = event.properties;
-
-        // Set $lib and $lib_version if not already present, so callers
-        // forwarding events from other SDKs can preserve the original values.
-        if !properties.contains_key("$lib") {
-            properties.insert(
-                "$lib".into(),
-                serde_json::Value::String("posthog-rs".into()),
-            );
-        }
-
-        let version_str = env!("CARGO_PKG_VERSION");
-        if !properties.contains_key("$lib_version") {
-            properties.insert(
-                "$lib_version".into(),
-                serde_json::Value::String(version_str.into()),
-            );
-        }
-
-        if !properties.contains_key("$lib_version__major") {
-            if let Ok(version) = version_str.parse::<Version>() {
-                properties.insert(
-                    "$lib_version__major".into(),
-                    serde_json::Value::Number(version.major.into()),
-                );
-                properties.insert(
-                    "$lib_version__minor".into(),
-                    serde_json::Value::Number(version.minor.into()),
-                );
-                properties.insert(
-                    "$lib_version__patch".into(),
-                    serde_json::Value::Number(version.patch.into()),
-                );
-            }
-        }
-
-        if !event.groups.is_empty() {
-            properties.insert(
-                "$groups".into(),
-                serde_json::Value::Object(
-                    event
-                        .groups
-                        .into_iter()
-                        .map(|(k, v)| (k, serde_json::Value::String(v)))
-                        .collect(),
-                ),
-            );
-        }
-
         Self {
             api_key,
-            uuid,
+            uuid: event.uuid,
             event: event.event,
             distinct_id: event.distinct_id,
-            properties,
+            properties: event.properties,
             timestamp: event.timestamp,
         }
     }
@@ -254,29 +346,28 @@ pub mod tests {
 
     use crate::{event::InnerEvent, Event};
 
+    /// Helper: prepares an event for V0 and constructs the InnerEvent.
+    fn build_v0(mut event: Event) -> InnerEvent {
+        event.prepare_for_v0();
+        InnerEvent::new(event, "test_api_key".to_string())
+    }
+
     #[test]
-    fn inner_event_adds_lib_properties_correctly() {
-        // Arrange
+    fn v0_adds_lib_properties() {
         let mut event = Event::new("unit test event", "1234");
         event.insert_prop("key1", "value1").unwrap();
-        let api_key = "test_api_key".to_string();
 
-        // Act
-        let inner_event = InnerEvent::new(event, api_key);
-
-        // Assert
-        let props = &inner_event.properties;
+        let inner = build_v0(event);
         assert_eq!(
-            props.get("$lib"),
+            inner.properties.get("$lib"),
             Some(&serde_json::Value::String("posthog-rs".to_string()))
         );
     }
 
     #[test]
-    fn inner_event_includes_auto_generated_uuid() {
+    fn v0_includes_auto_generated_uuid() {
         let event = Event::new("test", "user1");
-
-        let inner = InnerEvent::new(event, "key".to_string());
+        let inner = build_v0(event);
         let json = serde_json::to_value(&inner).unwrap();
 
         let uuid_str = json["uuid"].as_str().expect("uuid should be present");
@@ -284,25 +375,24 @@ pub mod tests {
     }
 
     #[test]
-    fn inner_event_preserves_overridden_uuid() {
+    fn v0_preserves_overridden_uuid() {
         let uuid = Uuid::now_v7();
         let mut event = Event::new("test", "user1");
         event.set_uuid(uuid);
 
-        let inner = InnerEvent::new(event, "key".to_string());
+        let inner = build_v0(event);
         let json = serde_json::to_value(&inner).unwrap();
-
         assert_eq!(json["uuid"], uuid.to_string());
     }
 
     #[test]
-    fn inner_event_preserves_existing_lib_properties() {
+    fn v0_preserves_existing_lib_properties() {
         let mut event = Event::new("forwarded event", "user1");
         event.insert_prop("$lib", "posthog-js").unwrap();
         event.insert_prop("$lib_version", "1.42.0").unwrap();
         event.insert_prop("$lib_version__major", 1u64).unwrap();
 
-        let inner = InnerEvent::new(event, "key".to_string());
+        let inner = build_v0(event);
         let props = &inner.properties;
 
         assert_eq!(
@@ -316,6 +406,45 @@ pub mod tests {
         assert_eq!(
             props.get("$lib_version__major"),
             Some(&serde_json::Value::Number(1u64.into()))
+        );
+    }
+
+    #[test]
+    fn v0_injects_process_person_profile_for_anon() {
+        let event = Event::new_anon("anon_test");
+        let inner = build_v0(event);
+        assert_eq!(
+            inner.properties.get("$process_person_profile"),
+            Some(&serde_json::Value::Bool(false))
+        );
+    }
+
+    #[test]
+    fn v0_injects_process_person_profile_for_group() {
+        let mut event = Event::new("test", "user1");
+        event.add_group("company", "acme");
+        let inner = build_v0(event);
+        assert_eq!(
+            inner.properties.get("$process_person_profile"),
+            Some(&serde_json::Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn v0_no_process_person_profile_when_unset() {
+        let event = Event::new("test", "user1");
+        let inner = build_v0(event);
+        assert!(!inner.properties.contains_key("$process_person_profile"));
+    }
+
+    #[test]
+    fn v0_user_property_wins_over_options_injection() {
+        let mut event = Event::new_anon("test");
+        event.insert_prop("$process_person_profile", true).unwrap();
+        let inner = build_v0(event);
+        assert_eq!(
+            inner.properties.get("$process_person_profile"),
+            Some(&serde_json::Value::Bool(true)),
         );
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -163,6 +163,7 @@ impl Event {
 
 /// Wrapper for the `/batch/` endpoint that includes the API key and options
 /// alongside the event array.
+#[cfg(not(feature = "capture-v1"))]
 #[derive(Serialize)]
 pub struct BatchRequest {
     pub api_key: String,

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -1,0 +1,56 @@
+//! Wire format types for the V1 capture protocol (`POST /i/v1/analytics/events/`).
+//!
+//! These are placeholder shells that will be fleshed out as the V1 pipeline is
+//! implemented. The types mirror the server-side definitions in
+//! `posthog/rust/capture/src/v1/analytics/types.rs`.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A single event in the V1 wire format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct V1Event {
+    pub event: String,
+    pub uuid: Uuid,
+    pub distinct_id: String,
+    pub timestamp: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub options: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// The batch request body for V1 capture.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct V1BatchRequest {
+    pub created_at: String,
+    pub batch: Vec<V1Event>,
+}
+
+/// Per-event result status returned by the V1 endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum V1EventStatus {
+    Ok,
+    Drop,
+    Limited,
+    Retry,
+}
+
+/// Per-event result entry in the V1 response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct V1EventResult {
+    pub result: V1EventStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+}
+
+/// The V1 batch response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct V1BatchResponse {
+    pub results: HashMap<String, V1EventResult>,
+}

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -1,17 +1,11 @@
-//! Wire format types for the V1 capture protocol (`POST /i/v1/analytics/events/`).
-//!
-//! These are placeholder shells that will be fleshed out as the V1 pipeline is
-//! implemented. The types mirror the server-side definitions in
-//! `posthog/rust/capture/src/v1/analytics/types.rs`.
-
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// A single event in the V1 wire format.
+use crate::event::{Event, EventOptions};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct V1Event {
     pub event: String,
@@ -19,38 +13,363 @@ pub struct V1Event {
     pub distinct_id: String,
     pub timestamp: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub options: Option<serde_json::Value>,
+    pub session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub properties: Option<serde_json::Value>,
+    pub window_id: Option<String>,
+    pub options: EventOptions,
+    pub properties: serde_json::Value,
 }
 
-/// The batch request body for V1 capture.
+impl V1Event {
+    pub fn from_event(event: &Event) -> Self {
+        let mut properties = event.properties().clone();
+
+        if !event.groups().is_empty() {
+            properties.insert(
+                "$groups".into(),
+                serde_json::Value::Object(
+                    event
+                        .groups()
+                        .iter()
+                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                        .collect(),
+                ),
+            );
+        }
+
+        let timestamp = event
+            .timestamp()
+            .map(|ts| ts.and_utc().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+            .unwrap_or_else(|| Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string());
+
+        // V1 carries process_person_profile in options; strip the property
+        // duplicate in case a caller manually inserted it.
+        if event.options().process_person_profile.is_some() {
+            properties.remove("$process_person_profile");
+        }
+
+        let session_id = properties
+            .remove("$session_id")
+            .and_then(|v| v.as_str().map(String::from));
+        let window_id = properties
+            .remove("$window_id")
+            .and_then(|v| v.as_str().map(String::from));
+
+        Self {
+            event: event.event_name().to_string(),
+            uuid: event.uuid(),
+            distinct_id: event.distinct_id().to_string(),
+            timestamp,
+            session_id,
+            window_id,
+            options: event.options().clone(),
+            properties: serde_json::to_value(properties)
+                .unwrap_or(serde_json::Value::Object(Default::default())),
+        }
+    }
+}
+
+/// Owned variant used by tests; the capture pipeline uses [`V1BatchRequestRef`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct V1BatchRequest {
     pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub historical_migration: Option<bool>,
     pub batch: Vec<V1Event>,
 }
 
-/// Per-event result status returned by the V1 endpoint.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum V1EventStatus {
-    Ok,
-    Drop,
-    Limited,
-    Retry,
+/// Serialize-only borrowed twin of [`V1BatchRequest`]; avoids per-attempt clones.
+#[derive(Debug, Serialize)]
+pub(crate) struct V1BatchRequestRef<'a> {
+    pub created_at: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub historical_migration: Option<bool>,
+    pub batch: &'a [V1Event],
 }
 
-/// Per-event result entry in the V1 response.
+/// Only `Retry` is resent; all other variants are terminal.
+/// `Unknown` (`#[serde(other)]`) is a forward-compat catch-all that deserializes
+/// unrecognised statuses as terminal rather than failing the parse.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum EventStatus {
+    Ok,
+    Drop,
+    Warning,
+    Retry,
+    #[serde(other)]
+    Unknown,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct V1EventResult {
-    pub result: V1EventStatus,
+pub struct EventResult {
+    pub result: EventStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub details: Option<String>,
 }
 
-/// The V1 batch response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct V1BatchResponse {
-    pub results: HashMap<String, V1EventResult>,
+pub struct CaptureResponse {
+    pub results: HashMap<Uuid, EventResult>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct V1ErrorResponse {
+    pub error: String,
+    #[serde(default)]
+    pub error_description: Option<String>,
+    #[serde(default)]
+    pub error_uri: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Event;
+
+    #[test]
+    fn v1_event_from_event_basic() {
+        let event = Event::new("test_event", "user-1");
+        let v1 = V1Event::from_event(&event);
+
+        assert_eq!(v1.event, "test_event");
+        assert_eq!(v1.distinct_id, "user-1");
+        assert_eq!(v1.options.process_person_profile, None);
+        assert_eq!(v1.options.cookieless_mode, None);
+        assert_eq!(v1.options.disable_skew_correction, None);
+        assert!(v1.session_id.is_none());
+        assert!(v1.window_id.is_none());
+    }
+
+    #[test]
+    fn v1_event_from_event_anon() {
+        let event = Event::new_anon("anon_event");
+        let v1 = V1Event::from_event(&event);
+
+        assert_eq!(v1.event, "anon_event");
+        assert_eq!(v1.options.process_person_profile, Some(false));
+        let props = v1.properties.as_object().unwrap();
+        assert!(!props.contains_key("$process_person_profile"));
+    }
+
+    #[test]
+    fn v1_event_options_overrides_serialize_and_unset_are_omitted() {
+        let mut event = Event::new("test_event", "user-1");
+        event.set_option("cookieless_mode", true).unwrap();
+        event.set_option("process_person_profile", false).unwrap();
+        event.set_option("product_tour_id", "tour-42").unwrap();
+
+        let v1 = V1Event::from_event(&event);
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+
+        assert_eq!(
+            options.get("cookieless_mode"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(
+            options.get("process_person_profile"),
+            Some(&serde_json::json!(false))
+        );
+        assert_eq!(
+            options.get("product_tour_id"),
+            Some(&serde_json::json!("tour-42"))
+        );
+        assert!(!options.contains_key("disable_skew_correction"));
+    }
+
+    #[test]
+    fn v1_event_extracts_session_window_from_properties() {
+        let mut event = Event::new("test", "user-1");
+        event.insert_prop("$session_id", "sess-123").unwrap();
+        event.insert_prop("$window_id", "win-456").unwrap();
+
+        let v1 = V1Event::from_event(&event);
+
+        assert_eq!(v1.session_id, Some("sess-123".to_string()));
+        assert_eq!(v1.window_id, Some("win-456".to_string()));
+        let props = v1.properties.as_object().unwrap();
+        assert!(!props.contains_key("$session_id"));
+        assert!(!props.contains_key("$window_id"));
+    }
+
+    #[test]
+    fn v1_event_groups_in_properties() {
+        let mut event = Event::new("test", "user-1");
+        event.add_group("company", "acme");
+
+        let v1 = V1Event::from_event(&event);
+
+        let props = v1.properties.as_object().unwrap();
+        let groups = props.get("$groups").unwrap().as_object().unwrap();
+        assert_eq!(groups.get("company").unwrap().as_str().unwrap(), "acme");
+        assert_eq!(v1.options.process_person_profile, Some(true));
+    }
+
+    #[test]
+    fn v1_batch_request_serializes() {
+        let event = Event::new("test", "user-1");
+        let batch = V1BatchRequest {
+            created_at: "2026-05-28T15:00:00Z".to_string(),
+            historical_migration: None,
+            batch: vec![V1Event::from_event(&event)],
+        };
+
+        let json = serde_json::to_value(&batch).unwrap();
+        assert_eq!(json["created_at"], "2026-05-28T15:00:00Z");
+        assert!(json.get("historical_migration").is_none());
+        assert_eq!(json["batch"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn v1_batch_response_deserializes() {
+        let json = r#"{
+            "results": {
+                "550e8400-e29b-41d4-a716-446655440000": {"result": "ok"},
+                "550e8400-e29b-41d4-a716-446655440001": {"result": "retry", "details": "not_persisted"},
+                "550e8400-e29b-41d4-a716-446655440002": {"result": "drop", "details": "billing_limit_exceeded"}
+            }
+        }"#;
+
+        let u0 = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let u1 = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
+
+        let resp: CaptureResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.results.len(), 3);
+        assert_eq!(resp.results[&u0].result, EventStatus::Ok);
+        assert_eq!(resp.results[&u1].result, EventStatus::Retry);
+        assert_eq!(resp.results[&u1].details, Some("not_persisted".to_string()));
+    }
+
+    #[test]
+    fn v1_warning_status_deserializes_as_warning() {
+        let json = r#"{
+            "results": {
+                "550e8400-e29b-41d4-a716-446655440000": {"result": "warning", "details": "person_processing_disabled"}
+            }
+        }"#;
+
+        let u = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let resp: CaptureResponse = serde_json::from_str(json).unwrap();
+        let entry = &resp.results[&u];
+        assert_eq!(entry.result, EventStatus::Warning);
+        assert_eq!(
+            entry.details,
+            Some("person_processing_disabled".to_string())
+        );
+    }
+
+    #[test]
+    fn v1_unknown_status_deserializes_as_unknown() {
+        let json = r#"{
+            "results": {
+                "550e8400-e29b-41d4-a716-446655440000": {"result": "ok"},
+                "550e8400-e29b-41d4-a716-446655440001": {"result": "some_future_status", "details": "new_detail"}
+            }
+        }"#;
+
+        let u1 = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
+        let resp: CaptureResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.results.len(), 2);
+        assert_eq!(resp.results[&u1].result, EventStatus::Unknown);
+    }
+
+    #[test]
+    fn v1_limited_status_deserializes_as_unknown() {
+        let json = r#"{
+            "results": {
+                "550e8400-e29b-41d4-a716-446655440000": {"result": "limited"}
+            }
+        }"#;
+
+        let u = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let resp: CaptureResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.results[&u].result, EventStatus::Unknown);
+    }
+
+    #[test]
+    fn v1_error_response_deserializes() {
+        let json = r#"{
+            "error": "billing_limit_exceeded",
+            "error_description": "Billing quota exceeded.",
+            "error_uri": "https://posthog.com/docs/billing/limits"
+        }"#;
+
+        let err: V1ErrorResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(err.error, "billing_limit_exceeded");
+        assert_eq!(
+            err.error_description,
+            Some("Billing quota exceeded.".to_string())
+        );
+    }
+
+    #[test]
+    fn v1_extra_options_serialize_as_top_level_keys() {
+        let mut event = Event::new("test", "user-1");
+        event.set_option("cookieless_mode", true).unwrap();
+        event.set_option("future_flag", true).unwrap();
+        event.set_option("routing_key", "us-east").unwrap();
+
+        let v1 = V1Event::from_event(&event);
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+
+        assert_eq!(
+            options.get("cookieless_mode"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(options.get("future_flag"), Some(&serde_json::json!(true)));
+        assert_eq!(
+            options.get("routing_key"),
+            Some(&serde_json::json!("us-east"))
+        );
+        assert!(!options.contains_key("disable_skew_correction"));
+    }
+
+    #[test]
+    fn v1_extra_options_empty_map_omitted_from_wire() {
+        let event = Event::new("test", "user-1");
+        let v1 = V1Event::from_event(&event);
+        let json_str = serde_json::to_string(&v1).unwrap();
+        assert!(!json_str.contains("extra"));
+    }
+
+    #[test]
+    fn v1_set_option_routes_unknown_keys_to_extra() {
+        let mut event = Event::new("test", "user-1");
+        event.set_option("new_backend_flag", true).unwrap();
+        event.set_option("batch_priority", 5u32).unwrap();
+
+        let v1 = V1Event::from_event(&event);
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+
+        assert_eq!(
+            options.get("new_backend_flag"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(options.get("batch_priority"), Some(&serde_json::json!(5)));
+    }
+
+    #[test]
+    fn v1_anon_event_no_process_person_profile_in_properties() {
+        let event = Event::new_anon("test");
+        let v1 = V1Event::from_event(&event);
+        assert_eq!(v1.options.process_person_profile, Some(false));
+        let props = v1.properties.as_object().unwrap();
+        assert!(!props.contains_key("$process_person_profile"));
+    }
+
+    #[test]
+    fn v1_strips_duplicate_process_person_profile_property() {
+        let mut event = Event::new_anon("test");
+        event.insert_prop("$process_person_profile", false).unwrap();
+        let v1 = V1Event::from_event(&event);
+        assert_eq!(v1.options.process_person_profile, Some(false));
+        let props = v1.properties.as_object().unwrap();
+        assert!(!props.contains_key("$process_person_profile"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ mod client;
 mod endpoints;
 mod error;
 mod event;
+mod event_v1;
 mod feature_flag_evaluations;
 mod feature_flags;
 mod global;
@@ -80,6 +81,7 @@ mod local_evaluation;
 // Public interface - any change to this is breaking!
 // Client
 pub use client::client;
+pub use client::CaptureMode;
 pub use client::Client;
 pub use client::ClientOptions;
 pub use client::ClientOptionsBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,12 @@
 //! }
 //! ```
 mod client;
+#[cfg(feature = "capture-v1")]
+mod compression;
 mod endpoints;
 mod error;
 mod event;
+#[cfg(feature = "capture-v1")]
 mod event_v1;
 mod feature_flag_evaluations;
 mod feature_flags;
@@ -81,6 +84,7 @@ mod local_evaluation;
 // Public interface - any change to this is breaking!
 // Client
 pub use client::client;
+pub use client::CaptureCompression;
 pub use client::Client;
 pub use client::ClientOptions;
 pub use client::ClientOptionsBuilder;
@@ -96,6 +100,12 @@ pub use error::Error;
 
 // Event
 pub use event::Event;
+#[cfg(feature = "capture-v1")]
+pub use event::EventOptions;
+
+// V1 Capture types
+#[cfg(feature = "capture-v1")]
+pub use event_v1::{CaptureResponse, EventResult, EventStatus};
 
 // Feature Flags
 pub use feature_flag_evaluations::{EvaluateFlagsOptions, FeatureFlagEvaluations};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,6 @@ mod local_evaluation;
 // Public interface - any change to this is breaking!
 // Client
 pub use client::client;
-pub use client::CaptureMode;
 pub use client::Client;
 pub use client::ClientOptions;
 pub use client::ClientOptionsBuilder;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -57,3 +57,37 @@ fn get_client_blocking() {
 
     client.capture(event).unwrap();
 }
+
+#[cfg(all(feature = "e2e-test", feature = "capture-v1", feature = "async-client"))]
+#[tokio::test]
+async fn get_client_v1_async() {
+    use dotenv::dotenv;
+    dotenv().ok();
+
+    use posthog_rs::{ClientOptionsBuilder, Event};
+    use std::collections::HashMap;
+
+    let api_key = match std::env::var("POSTHOG_RS_E2E_TEST_API_KEY") {
+        Ok(key) if !key.is_empty() => key,
+        _ => {
+            eprintln!("Skipping e2e test: POSTHOG_RS_E2E_TEST_API_KEY not set");
+            return;
+        }
+    };
+
+    let options = ClientOptionsBuilder::default()
+        .api_key(api_key)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    let mut child_map = HashMap::new();
+    child_map.insert("child_key1", "child_value1");
+
+    let mut event = Event::new("e2e v1 test event", "1234");
+    event.insert_prop("key1", "value1").unwrap();
+    event.insert_prop("key2", vec!["a", "b"]).unwrap();
+    event.insert_prop("key3", child_map).unwrap();
+
+    client.capture(event).await.unwrap();
+}

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -406,6 +406,7 @@ async fn test_groups_parameter() {
     flags_mock.assert();
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
 async fn test_client_with_empty_api_key_is_noop() {
     for api_key in [None, Some(" \n\t ")] {
@@ -496,6 +497,7 @@ async fn test_capture_batch_sends_to_batch_endpoint() {
     batch_mock.assert();
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
 async fn test_capture_batch_historical_migration() {
     let server = MockServer::start();
@@ -516,6 +518,7 @@ async fn test_capture_batch_historical_migration() {
     batch_mock.assert();
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
 async fn test_capture_batch_rate_limit() {
     let server = MockServer::start();
@@ -535,6 +538,7 @@ async fn test_capture_batch_rate_limit() {
     batch_mock.assert();
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
 async fn test_capture_batch_bad_request() {
     let server = MockServer::start();

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -477,6 +477,7 @@ async fn assert_disabled_client_is_noop(api_key: Option<&str>) {
     flags_mock.assert_hits(0);
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
 async fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();
@@ -560,6 +561,43 @@ async fn test_capture_batch_bad_request() {
         other => panic!("expected BadRequest, got: {:?}", other),
     }
     batch_mock.assert();
+}
+
+#[cfg(not(feature = "capture-v1"))]
+#[tokio::test]
+async fn v0_capture_injects_is_server_by_default() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v0/e/")
+            .body_contains("\"$is_server\":true");
+        then.status(200).body("ok");
+    });
+
+    let client = create_test_client(server.base_url()).await;
+    let event = posthog_rs::Event::new("test_event", "user-1");
+    client.capture(event).await.unwrap();
+    mock.assert();
+}
+
+#[cfg(not(feature = "capture-v1"))]
+#[tokio::test]
+async fn v0_capture_caller_override_wins_for_is_server() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v0/e/")
+            .body_contains("\"$is_server\":false");
+        then.status(200).body("ok");
+    });
+
+    let client = create_test_client(server.base_url()).await;
+    let mut event = posthog_rs::Event::new("test_event", "user-1");
+    event.insert_prop("$is_server", false).unwrap();
+    client.capture(event).await.unwrap();
+    mock.assert();
 }
 
 #[tokio::test]

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -227,6 +227,7 @@ fn test_api_error_handling() {
     error_mock.assert();
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[test]
 fn test_client_with_empty_api_key_is_noop() {
     for api_key in [None, Some(" \n\t ")] {
@@ -313,6 +314,7 @@ fn test_capture_batch_sends_to_batch_endpoint() {
     batch_mock.assert();
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[test]
 fn test_capture_batch_historical_migration() {
     let server = MockServer::start();
@@ -333,6 +335,7 @@ fn test_capture_batch_historical_migration() {
     batch_mock.assert();
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[test]
 fn test_capture_batch_rate_limit() {
     let server = MockServer::start();
@@ -352,6 +355,7 @@ fn test_capture_batch_rate_limit() {
     batch_mock.assert();
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[test]
 fn test_capture_batch_bad_request() {
     let server = MockServer::start();

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -294,6 +294,7 @@ fn assert_disabled_client_is_noop(api_key: Option<&str>) {
     flags_mock.assert_hits(0);
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[test]
 fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();
@@ -377,4 +378,41 @@ fn test_capture_batch_bad_request() {
         other => panic!("expected BadRequest, got: {:?}", other),
     }
     batch_mock.assert();
+}
+
+#[cfg(not(feature = "capture-v1"))]
+#[test]
+fn v0_capture_injects_is_server_by_default() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v0/e/")
+            .body_contains("\"$is_server\":true");
+        then.status(200).body("ok");
+    });
+
+    let client = create_test_client(server.base_url());
+    let event = posthog_rs::Event::new("test_event", "user-1");
+    client.capture(event).unwrap();
+    mock.assert();
+}
+
+#[cfg(not(feature = "capture-v1"))]
+#[test]
+fn v0_capture_caller_override_wins_for_is_server() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v0/e/")
+            .body_contains("\"$is_server\":false");
+        then.status(200).body("ok");
+    });
+
+    let client = create_test_client(server.base_url());
+    let mut event = posthog_rs::Event::new("test_event", "user-1");
+    event.insert_prop("$is_server", false).unwrap();
+    client.capture(event).unwrap();
+    mock.assert();
 }

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -308,6 +308,7 @@ mod blocking {
         capture_mock.assert_hits(0);
     }
 
+    #[cfg(not(feature = "capture-v1"))]
     #[test]
     fn event_with_flags_attaches_properties_without_extra_request() {
         let server = MockServer::start();
@@ -490,7 +491,9 @@ mod blocking {
 #[cfg(feature = "async-client")]
 mod async_tests {
     use super::*;
-    use posthog_rs::{EvaluateFlagsOptions, Event, FlagValue};
+    #[cfg(not(feature = "capture-v1"))]
+    use posthog_rs::Event;
+    use posthog_rs::{EvaluateFlagsOptions, FlagValue};
 
     async fn create_test_client(base_url: String) -> posthog_rs::Client {
         let options: posthog_rs::ClientOptions = ("test_api_key", base_url.as_str()).into();
@@ -611,6 +614,7 @@ mod async_tests {
         capture_mock.assert_hits(0);
     }
 
+    #[cfg(not(feature = "capture-v1"))]
     #[tokio::test]
     async fn event_with_flags_attaches_properties_without_extra_request() {
         let server = MockServer::start();

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -550,6 +550,31 @@ mod async_tests {
         capture_mock.assert_hits(2);
     }
 
+    #[cfg(not(feature = "capture-v1"))]
+    #[tokio::test]
+    async fn flag_called_event_contains_is_server_and_lib() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v0/e/")
+                .body_contains("\"$is_server\":true")
+                .body_contains("\"$lib\":\"posthog-rs\"");
+            then.status(200);
+        });
+        let client = create_test_client(server.base_url()).await;
+        let snapshot = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .await
+            .unwrap();
+        assert!(snapshot.is_enabled("alpha"));
+        flush_spawned_events().await;
+        capture_mock.assert_hits(1);
+    }
+
     #[tokio::test]
     async fn get_flag_payload_does_not_fire_event() {
         let server = MockServer::start();

--- a/tests/test_v1_blocking.rs
+++ b/tests/test_v1_blocking.rs
@@ -1,0 +1,636 @@
+#![cfg(all(not(feature = "async-client"), feature = "capture-v1"))]
+
+use httpmock::prelude::*;
+use posthog_rs::{ClientOptionsBuilder, Event};
+use serde_json::json;
+
+fn create_v1_client(base_url: String) -> posthog_rs::Client {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(base_url)
+        .max_capture_attempts(3u32)
+        .retry_initial_backoff_ms(10u64)
+        .retry_max_backoff_ms(50u64)
+        .build()
+        .unwrap();
+    posthog_rs::client(options)
+}
+
+// Constants required because httpmock `matches` takes bare fn pointers (no captures).
+const PARTIAL_UUID_OK: &str = "01920000-0000-7000-8000-0000000000a1";
+const PARTIAL_UUID_RETRY: &str = "01920000-0000-7000-8000-0000000000a2";
+const PARTIAL_UUID_DROP: &str = "01920000-0000-7000-8000-0000000000a3";
+
+fn body_string(req: &HttpMockRequest) -> String {
+    req.body
+        .as_ref()
+        .map(|b| String::from_utf8_lossy(b).into_owned())
+        .unwrap_or_default()
+}
+
+/// Matcher: retry event present, ok event pruned.
+fn retry_body_only_contains_retry_event(req: &HttpMockRequest) -> bool {
+    let body = body_string(req);
+    body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_OK)
+}
+
+/// Matcher: retry event present; the dropped (terminal) event is pruned.
+fn retry_body_prunes_terminal_events(req: &HttpMockRequest) -> bool {
+    let body = body_string(req);
+    body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_DROP)
+}
+
+#[test]
+fn v1_blocking_capture_success() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("authorization", "Bearer phc_test_token")
+            .header_exists("posthog-request-id")
+            .header_exists("posthog-attempt");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test_event", "user-1"));
+    assert!(result.is_ok());
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_retries_on_server_error() {
+    let server = MockServer::start();
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1");
+        then.status(500).json_body(json!({
+            "error": "internal_error",
+            "error_description": "Internal Server Error"
+        }));
+    });
+
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test", "user-1"));
+
+    assert!(result.is_ok());
+    fail_mock.assert();
+    success_mock.assert();
+}
+
+#[test]
+fn v1_blocking_does_not_retry_on_401() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(401).body("Unauthorized");
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test", "user-1"));
+
+    assert!(result.is_err());
+    mock.assert_hits(1);
+}
+
+#[test]
+fn v1_blocking_partial_batch_retry() {
+    let server = MockServer::start();
+
+    let mut event1 = Event::new("event_1", "user-1");
+    let mut event2 = Event::new("event_2", "user-1");
+
+    let uuid1 = uuid::Uuid::parse_str(PARTIAL_UUID_OK).unwrap();
+    let uuid2 = uuid::Uuid::parse_str(PARTIAL_UUID_RETRY).unwrap();
+    event1.set_uuid(uuid1);
+    event2.set_uuid(uuid2);
+
+    let first_resp = json!({
+        "results": {
+            PARTIAL_UUID_OK: { "result": "ok" },
+            PARTIAL_UUID_RETRY: { "result": "retry", "details": "not_persisted" }
+        }
+    });
+
+    let retry_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "ok" }
+        }
+    });
+
+    let first_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(PARTIAL_UUID_OK)
+            .body_contains(PARTIAL_UUID_RETRY);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(first_resp);
+    });
+
+    // Uses `matches` to assert the ok event was pruned (body_contains can't negate).
+    let retry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(retry_body_only_contains_retry_event);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(retry_resp);
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture_batch(vec![event1, event2], false);
+
+    assert!(result.is_ok());
+    first_mock.assert();
+    retry_mock.assert();
+}
+
+#[test]
+fn v1_blocking_does_not_retry_terminal_results() {
+    let server = MockServer::start();
+
+    let mut ev_ok = Event::new("ev_ok", "user-1");
+    let mut ev_drop = Event::new("ev_drop", "user-1");
+    let mut ev_warning = Event::new("ev_warning", "user-1");
+
+    let uuid_ok = uuid::Uuid::now_v7();
+    let uuid_drop = uuid::Uuid::now_v7();
+    let uuid_warning = uuid::Uuid::now_v7();
+    ev_ok.set_uuid(uuid_ok);
+    ev_drop.set_uuid(uuid_drop);
+    ev_warning.set_uuid(uuid_warning);
+
+    let resp = json!({
+        "results": {
+            uuid_ok.to_string(): { "result": "ok" },
+            uuid_drop.to_string(): { "result": "drop", "details": "billing_limit_exceeded" },
+            uuid_warning.to_string(): { "result": "warning", "details": "person_processing_disabled" }
+        }
+    });
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(resp);
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture_batch(vec![ev_ok, ev_drop, ev_warning], false);
+
+    assert!(result.is_ok());
+    mock.assert_hits(1);
+}
+
+#[test]
+fn v1_blocking_whole_batch_resent_on_retryable_status() {
+    for status in [408u16, 500, 502, 503, 504] {
+        let server = MockServer::start();
+
+        let mut event1 = Event::new("event_1", "user-1");
+        let mut event2 = Event::new("event_2", "user-2");
+
+        let uuid1 = uuid::Uuid::now_v7();
+        let uuid2 = uuid::Uuid::now_v7();
+        event1.set_uuid(uuid1);
+        event2.set_uuid(uuid2);
+
+        let ts = "2024-01-01T00:00:00.000Z";
+        event1
+            .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            .unwrap();
+        event2
+            .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            .unwrap();
+
+        let uuid1_str = uuid1.to_string();
+        let uuid2_str = uuid2.to_string();
+
+        let fail_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "1");
+            then.status(status)
+                .header("content-type", "application/json")
+                .header("retry-after", "0")
+                .json_body(json!({
+                    "error": "server_error",
+                    "error_description": "transient"
+                }));
+        });
+
+        let success_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "2")
+                .body_contains(&uuid1_str)
+                .body_contains(&uuid2_str)
+                .body_contains(ts);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": {
+                        uuid1_str: { "result": "ok" },
+                        uuid2_str: { "result": "ok" }
+                    }
+                }));
+        });
+
+        let client = create_v1_client(server.base_url());
+        let result = client.capture_batch(vec![event1, event2], false);
+
+        assert!(
+            result.is_ok(),
+            "status {} should retry then succeed",
+            status
+        );
+        fail_mock.assert();
+        success_mock.assert();
+    }
+}
+
+#[test]
+fn v1_blocking_prunes_terminal_events_on_partial_retry() {
+    let server = MockServer::start();
+
+    let mut ev_retry = Event::new("ev_retry", "user-1");
+    let mut ev_drop = Event::new("ev_drop", "user-1");
+
+    let uuid_retry = uuid::Uuid::parse_str(PARTIAL_UUID_RETRY).unwrap();
+    let uuid_drop = uuid::Uuid::parse_str(PARTIAL_UUID_DROP).unwrap();
+    ev_retry.set_uuid(uuid_retry);
+    ev_drop.set_uuid(uuid_drop);
+
+    let first_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "retry", "details": "not_persisted" },
+            PARTIAL_UUID_DROP: { "result": "drop", "details": "billing_limit_exceeded" }
+        }
+    });
+
+    let retry_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "ok" }
+        }
+    });
+
+    let first_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(PARTIAL_UUID_RETRY)
+            .body_contains(PARTIAL_UUID_DROP);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(first_resp);
+    });
+
+    let retry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(retry_body_prunes_terminal_events);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(retry_resp);
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture_batch(vec![ev_retry, ev_drop], false);
+
+    assert!(result.is_ok());
+    first_mock.assert();
+    retry_mock.assert();
+}
+
+#[test]
+fn v1_blocking_partial_retry_exhausts_attempts() {
+    let server = MockServer::start();
+
+    let mut event = Event::new("test", "user-1");
+    let uuid = uuid::Uuid::now_v7();
+    event.set_uuid(uuid);
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "results": {
+                    uuid.to_string(): { "result": "retry", "details": "not_persisted" }
+                }
+            }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(event);
+
+    // 200 path returns Ok even when retries are exhausted.
+    assert!(result.is_ok());
+    mock.assert_hits(3);
+}
+
+static CAPTURED_REQUEST_IDS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+fn capture_request_id(req: &HttpMockRequest) -> bool {
+    if let Some(headers) = req.headers.as_ref() {
+        for (key, value) in headers {
+            if key.eq_ignore_ascii_case("posthog-request-id") {
+                CAPTURED_REQUEST_IDS.lock().unwrap().push(value.clone());
+                break;
+            }
+        }
+    }
+    true
+}
+
+#[test]
+fn v1_blocking_request_id_stable_across_retries() {
+    CAPTURED_REQUEST_IDS.lock().unwrap().clear();
+
+    let server = MockServer::start();
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .matches(capture_request_id);
+        then.status(503)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "error": "service_unavailable",
+                "error_description": "transient"
+            }));
+    });
+
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(capture_request_id);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    client.capture(Event::new("test", "user-1")).unwrap();
+
+    fail_mock.assert();
+    success_mock.assert();
+
+    let ids = CAPTURED_REQUEST_IDS.lock().unwrap();
+    assert_eq!(ids.len(), 2, "expected exactly 2 captured request-ids");
+    assert_eq!(
+        ids[0], ids[1],
+        "posthog-request-id must be stable across retries"
+    );
+}
+
+#[test]
+fn v1_blocking_does_not_retry_on_402() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(402)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "billing_limit_exceeded",
+                "error_description": "Billing quota exceeded."
+            }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test", "user-1"));
+
+    assert!(matches!(
+        result,
+        Err(posthog_rs::Error::BillingLimitExceeded(_))
+    ));
+    mock.assert_hits(1);
+}
+
+#[test]
+fn v1_blocking_exhausts_retries() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(500)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "internal_error",
+                "error_description": "Internal Server Error"
+            }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test", "user-1"));
+
+    assert!(result.is_err());
+    mock.assert_hits(3);
+}
+
+#[test]
+fn v1_blocking_sends_event_options() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"cookieless_mode\":true")
+            .body_contains("\"process_person_profile\":false");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let mut event = Event::new("test", "user-1");
+    event.set_option("cookieless_mode", true).unwrap();
+    event.set_option("process_person_profile", false).unwrap();
+
+    client.capture(event).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_injects_geoip_disable_when_configured() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$geoip_disable\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .disable_geoip(true)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options);
+
+    client.capture(Event::new("test", "user-1")).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_injects_is_server_by_default() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$is_server\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    client.capture(Event::new("test", "user-1")).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_caller_override_wins_for_is_server() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$is_server\":false");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let mut event = Event::new("test", "user-1");
+    event.insert_prop("$is_server", false).unwrap();
+    client.capture(event).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_batch_sets_historical_migration() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"historical_migration\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let events = vec![Event::new("a", "user-1"), Event::new("b", "user-1")];
+    client.capture_batch(events, true).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_sends_gzip_content_encoding() {
+    use posthog_rs::CaptureCompression;
+
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("content-encoding", "gzip");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .capture_compression(CaptureCompression::Gzip)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options);
+
+    client.capture(Event::new("test", "user-1")).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_preserves_uuid_and_timestamp_across_retries() {
+    let server = MockServer::start();
+    let uuid = uuid::Uuid::now_v7();
+    let ts = "2024-01-01T00:00:00.000Z";
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(uuid.to_string())
+            .body_contains(ts);
+        then.status(503)
+            .header("retry-after", "0")
+            .json_body(json!({ "error": "service_unavailable" }));
+    });
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .body_contains(uuid.to_string())
+            .body_contains(ts);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let mut event = Event::new("test", "user-1");
+    event.set_uuid(uuid);
+    event
+        .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+        .unwrap();
+
+    client.capture(event).unwrap();
+    fail_mock.assert();
+    success_mock.assert();
+}
+
+#[test]
+fn v1_blocking_disabled_client_noop() {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test".to_string())
+        .disabled(true)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options);
+
+    let result = client.capture(Event::new("test", "user-1"));
+    assert!(result.is_ok());
+}

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -1,0 +1,680 @@
+#![cfg(all(feature = "async-client", feature = "capture-v1"))]
+
+use httpmock::prelude::*;
+use posthog_rs::{ClientOptionsBuilder, Event};
+use serde_json::json;
+
+async fn create_v1_client(base_url: String) -> posthog_rs::Client {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(base_url)
+        .max_capture_attempts(3u32)
+        .retry_initial_backoff_ms(10u64)
+        .retry_max_backoff_ms(50u64)
+        .build()
+        .unwrap();
+    posthog_rs::client(options).await
+}
+
+// Constants required because httpmock `matches` takes bare fn pointers (no captures).
+const PARTIAL_UUID_OK: &str = "01920000-0000-7000-8000-0000000000a1";
+const PARTIAL_UUID_RETRY: &str = "01920000-0000-7000-8000-0000000000a2";
+const PARTIAL_UUID_DROP: &str = "01920000-0000-7000-8000-0000000000a3";
+
+fn body_string(req: &HttpMockRequest) -> String {
+    req.body
+        .as_ref()
+        .map(|b| String::from_utf8_lossy(b).into_owned())
+        .unwrap_or_default()
+}
+
+/// Matcher: retry event present, ok event pruned.
+fn retry_body_only_contains_retry_event(req: &HttpMockRequest) -> bool {
+    let body = body_string(req);
+    body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_OK)
+}
+
+/// Matcher: retry event present; the dropped (terminal) event is pruned.
+fn retry_body_prunes_terminal_events(req: &HttpMockRequest) -> bool {
+    let body = body_string(req);
+    body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_DROP)
+}
+
+#[tokio::test]
+async fn v1_capture_single_event_success() {
+    let server = MockServer::start();
+
+    let uuid = uuid::Uuid::now_v7();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header_exists("authorization")
+            .header_exists("posthog-request-id")
+            .header_exists("posthog-attempt")
+            .header_exists("posthog-request-timestamp")
+            .header_exists("posthog-sdk-info");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {
+                    uuid.to_string(): { "result": "ok" }
+                }
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test_event", "user-1");
+    event.set_uuid(uuid);
+
+    let result = client.capture(event).await;
+    assert!(result.is_ok());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_bearer_auth_header() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("authorization", "Bearer phc_test_token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {}
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_retries_on_server_error() {
+    let server = MockServer::start();
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1");
+        then.status(503)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "error": "service_unavailable",
+                "error_description": "Service Unavailable"
+            }));
+    });
+
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {}
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(Event::new("test", "user-1")).await;
+
+    assert!(result.is_ok());
+    fail_mock.assert();
+    success_mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_does_not_retry_on_401() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(401)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "invalid_api_token",
+                "error_description": "The provided API token is not valid."
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(Event::new("test", "user-1")).await;
+
+    assert!(result.is_err());
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn v1_capture_does_not_retry_on_402() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(402)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "billing_limit_exceeded",
+                "error_description": "Billing quota exceeded."
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(Event::new("test", "user-1")).await;
+
+    assert!(matches!(
+        result,
+        Err(posthog_rs::Error::BillingLimitExceeded(_))
+    ));
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn v1_capture_partial_batch_retry() {
+    let server = MockServer::start();
+
+    let mut event1 = Event::new("event_1", "user-1");
+    let mut event2 = Event::new("event_2", "user-1");
+
+    let uuid1 = uuid::Uuid::parse_str(PARTIAL_UUID_OK).unwrap();
+    let uuid2 = uuid::Uuid::parse_str(PARTIAL_UUID_RETRY).unwrap();
+    event1.set_uuid(uuid1);
+    event2.set_uuid(uuid2);
+
+    let first_resp = json!({
+        "results": {
+            PARTIAL_UUID_OK: { "result": "ok" },
+            PARTIAL_UUID_RETRY: { "result": "retry", "details": "not_persisted" }
+        }
+    });
+
+    let retry_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "ok" }
+        }
+    });
+
+    let first_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(PARTIAL_UUID_OK)
+            .body_contains(PARTIAL_UUID_RETRY);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(first_resp);
+    });
+
+    // Uses `matches` to assert the ok event was pruned (body_contains can't negate).
+    let retry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(retry_body_only_contains_retry_event);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(retry_resp);
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture_batch(vec![event1, event2], false).await;
+
+    assert!(result.is_ok());
+    first_mock.assert();
+    retry_mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_does_not_retry_terminal_results() {
+    let server = MockServer::start();
+
+    let mut ev_ok = Event::new("ev_ok", "user-1");
+    let mut ev_drop = Event::new("ev_drop", "user-1");
+    let mut ev_warning = Event::new("ev_warning", "user-1");
+
+    let uuid_ok = uuid::Uuid::now_v7();
+    let uuid_drop = uuid::Uuid::now_v7();
+    let uuid_warning = uuid::Uuid::now_v7();
+    ev_ok.set_uuid(uuid_ok);
+    ev_drop.set_uuid(uuid_drop);
+    ev_warning.set_uuid(uuid_warning);
+
+    let resp = json!({
+        "results": {
+            uuid_ok.to_string(): { "result": "ok" },
+            uuid_drop.to_string(): { "result": "drop", "details": "billing_limit_exceeded" },
+            uuid_warning.to_string(): { "result": "warning", "details": "person_processing_disabled" }
+        }
+    });
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(resp);
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client
+        .capture_batch(vec![ev_ok, ev_drop, ev_warning], false)
+        .await;
+
+    assert!(result.is_ok());
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn v1_capture_whole_batch_resent_on_retryable_status() {
+    for status in [408u16, 500, 502, 503, 504] {
+        let server = MockServer::start();
+
+        let mut event1 = Event::new("event_1", "user-1");
+        let mut event2 = Event::new("event_2", "user-2");
+
+        let uuid1 = uuid::Uuid::now_v7();
+        let uuid2 = uuid::Uuid::now_v7();
+        event1.set_uuid(uuid1);
+        event2.set_uuid(uuid2);
+
+        let ts = "2024-01-01T00:00:00.000Z";
+        event1
+            .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            .unwrap();
+        event2
+            .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            .unwrap();
+
+        let uuid1_str = uuid1.to_string();
+        let uuid2_str = uuid2.to_string();
+
+        let fail_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "1");
+            then.status(status)
+                .header("content-type", "application/json")
+                .header("retry-after", "0")
+                .json_body(json!({
+                    "error": "server_error",
+                    "error_description": "transient"
+                }));
+        });
+
+        let success_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "2")
+                .body_contains(&uuid1_str)
+                .body_contains(&uuid2_str)
+                .body_contains(ts);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": {
+                        uuid1_str: { "result": "ok" },
+                        uuid2_str: { "result": "ok" }
+                    }
+                }));
+        });
+
+        let client = create_v1_client(server.base_url()).await;
+        let result = client.capture_batch(vec![event1, event2], false).await;
+
+        assert!(
+            result.is_ok(),
+            "status {} should retry then succeed",
+            status
+        );
+        fail_mock.assert();
+        success_mock.assert();
+    }
+}
+
+#[tokio::test]
+async fn v1_capture_partial_retry_exhausts_attempts() {
+    let server = MockServer::start();
+
+    let mut event = Event::new("test", "user-1");
+    let uuid = uuid::Uuid::now_v7();
+    event.set_uuid(uuid);
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "results": {
+                    uuid.to_string(): { "result": "retry", "details": "not_persisted" }
+                }
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(event).await;
+
+    // 200 path returns Ok even when retries are exhausted.
+    assert!(result.is_ok());
+    mock.assert_hits(3);
+}
+
+#[tokio::test]
+async fn v1_capture_exhausts_retries() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(500)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "internal_error",
+                "error_description": "Internal Server Error"
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(Event::new("test", "user-1")).await;
+
+    assert!(result.is_err());
+    mock.assert_hits(3);
+}
+
+#[tokio::test]
+async fn v1_capture_sends_event_options() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"cookieless_mode\":true")
+            .body_contains("\"process_person_profile\":false");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {}
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test", "user-1");
+    event.set_option("cookieless_mode", true).unwrap();
+    event.set_option("process_person_profile", false).unwrap();
+
+    client.capture(event).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_injects_geoip_disable_when_configured() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$geoip_disable\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .disable_geoip(true)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_injects_is_server_by_default() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$is_server\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_caller_override_wins_for_is_server() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$is_server\":false");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test", "user-1");
+    event.insert_prop("$is_server", false).unwrap();
+    client.capture(event).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_batch_sets_historical_migration() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"historical_migration\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let events = vec![Event::new("a", "user-1"), Event::new("b", "user-1")];
+    client.capture_batch(events, true).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_preserves_uuid_and_timestamp_across_retries() {
+    let server = MockServer::start();
+    let uuid = uuid::Uuid::now_v7();
+    let ts = "2024-01-01T00:00:00.000Z";
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(uuid.to_string())
+            .body_contains(ts);
+        then.status(503)
+            .header("retry-after", "0")
+            .json_body(json!({ "error": "service_unavailable" }));
+    });
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .body_contains(uuid.to_string())
+            .body_contains(ts);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test", "user-1");
+    event.set_uuid(uuid);
+    event
+        .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+        .unwrap();
+
+    client.capture(event).await.unwrap();
+    fail_mock.assert();
+    success_mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_sends_gzip_content_encoding() {
+    use posthog_rs::CaptureCompression;
+
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("content-encoding", "gzip");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .capture_compression(CaptureCompression::Gzip)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_prunes_terminal_events_on_partial_retry() {
+    let server = MockServer::start();
+
+    let mut ev_retry = Event::new("ev_retry", "user-1");
+    let mut ev_drop = Event::new("ev_drop", "user-1");
+
+    let uuid_retry = uuid::Uuid::parse_str(PARTIAL_UUID_RETRY).unwrap();
+    let uuid_drop = uuid::Uuid::parse_str(PARTIAL_UUID_DROP).unwrap();
+    ev_retry.set_uuid(uuid_retry);
+    ev_drop.set_uuid(uuid_drop);
+
+    let first_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "retry", "details": "not_persisted" },
+            PARTIAL_UUID_DROP: { "result": "drop", "details": "billing_limit_exceeded" }
+        }
+    });
+
+    let retry_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "ok" }
+        }
+    });
+
+    let first_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(PARTIAL_UUID_RETRY)
+            .body_contains(PARTIAL_UUID_DROP);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(first_resp);
+    });
+
+    let retry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(retry_body_prunes_terminal_events);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(retry_resp);
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture_batch(vec![ev_retry, ev_drop], false).await;
+
+    assert!(result.is_ok());
+    first_mock.assert();
+    retry_mock.assert();
+}
+
+static CAPTURED_REQUEST_IDS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+fn capture_request_id(req: &HttpMockRequest) -> bool {
+    if let Some(headers) = req.headers.as_ref() {
+        for (key, value) in headers {
+            if key.eq_ignore_ascii_case("posthog-request-id") {
+                CAPTURED_REQUEST_IDS.lock().unwrap().push(value.clone());
+                break;
+            }
+        }
+    }
+    true
+}
+
+#[tokio::test]
+async fn v1_capture_request_id_stable_across_retries() {
+    CAPTURED_REQUEST_IDS.lock().unwrap().clear();
+
+    let server = MockServer::start();
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .matches(capture_request_id);
+        then.status(503)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "error": "service_unavailable",
+                "error_description": "transient"
+            }));
+    });
+
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(capture_request_id);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+
+    fail_mock.assert();
+    success_mock.assert();
+
+    let ids = CAPTURED_REQUEST_IDS.lock().unwrap();
+    assert_eq!(ids.len(), 2, "expected exactly 2 captured request-ids");
+    assert_eq!(
+        ids[0], ids[1],
+        "posthog-request-id must be stable across retries"
+    );
+}
+
+#[tokio::test]
+async fn v1_capture_disabled_client_noop() {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test".to_string())
+        .disabled(true)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    let result = client.capture(Event::new("test", "user-1")).await;
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Integrate the [SDK test harness](https://github.com/PostHog/posthog-sdk-test-harness) library into `posthog-rs`, including SDK wrapper for capture V0 and V1 test suite, Docker-based test harness, Actions etc.

The "legacy" capture suite should run as expected, with compliant functionality passing. The v1 suite will fail at first: I'm stubbing a 5xx-only endpoint and will implement the new v1 capture submission functionality in a follow on PR.

The new test harness integration will land initially without being required in CI; we can enable that in a follow on once it's smoke-tested as well

## :green_heart: How did you test it?
Locally and in CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
