### PR TITLE
fix: empty API key initialization

### DIFF
--- a/.sampo/changesets/noop-empty-api-key.md
+++ b/.sampo/changesets/noop-empty-api-key.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Disable the client instead of sending requests when the API key is missing or blank.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -185,7 +185,9 @@ pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
         .build()
         .unwrap(); // Unwrap here is as safe as `HttpClient::new`
 
-    let (local_evaluator, flag_poller) = if options.enable_local_evaluation {
+    let (local_evaluator, flag_poller) = if options.enable_local_evaluation
+        && !options.is_disabled()
+    {
         if let Some(ref personal_key) = options.personal_api_key {
             let cache = FlagCache::new();
 
@@ -310,6 +312,11 @@ impl Client {
         ),
         Error,
     > {
+        if self.options.is_disabled() {
+            trace!("Client is disabled, skipping feature flags request");
+            return Ok((HashMap::new(), HashMap::new()));
+        }
+
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 
         let mut payload = json!({
@@ -476,6 +483,11 @@ impl Client {
         key: K,
         distinct_id: D,
     ) -> Result<Option<serde_json::Value>, Error> {
+        if self.options.is_disabled() {
+            trace!("Client is disabled, skipping feature flag payload request");
+            return Ok(None);
+        }
+
         let key_str = key.into();
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -169,7 +169,9 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
         .build()
         .unwrap(); // Unwrap here is as safe as `HttpClient::new`
 
-    let (local_evaluator, flag_poller) = if options.enable_local_evaluation {
+    let (local_evaluator, flag_poller) = if options.enable_local_evaluation
+        && !options.is_disabled()
+    {
         if let Some(ref personal_key) = options.personal_api_key {
             let cache = FlagCache::new();
 
@@ -293,6 +295,11 @@ impl Client {
         ),
         Error,
     > {
+        if self.options.is_disabled() {
+            trace!("Client is disabled, skipping feature flags request");
+            return Ok((HashMap::new(), HashMap::new()));
+        }
+
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 
         let mut payload = json!({
@@ -454,6 +461,11 @@ impl Client {
         key: K,
         distinct_id: D,
     ) -> Result<Option<serde_json::Value>, Error> {
+        if self.options.is_disabled() {
+            trace!("Client is disabled, skipping feature flag payload request");
+            return Ok(None);
+        }
+
         let key_str = key.into();
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -126,11 +126,6 @@ impl ClientOptions {
         );
         self
     }
-
-    /// Create ClientOptions with properly initialized endpoint_manager
-    fn with_endpoint_manager(self) -> Self {
-        self.sanitize()
-    }
 }
 
 impl ClientOptionsBuilder {
@@ -150,7 +145,6 @@ impl From<&str> for ClientOptions {
             .api_key(api_key.to_string())
             .build()
             .expect("We always set the API key, so this is infallible")
-            .with_endpoint_manager()
     }
 }
 
@@ -162,7 +156,6 @@ impl From<(&str, &str)> for ClientOptions {
             .host(host.to_string())
             .build()
             .expect("We always set the API key, so this is infallible")
-            .with_endpoint_manager()
     }
 }
 
@@ -178,8 +171,7 @@ mod tests {
             .host(" \nhttps://eu.posthog.com/\t ")
             .personal_api_key(" \n\t ")
             .build()
-            .unwrap()
-            .sanitize();
+            .unwrap();
 
         assert_eq!(options.api_key, "test-api-key");
         assert_eq!(options.host.as_deref(), Some("https://eu.posthog.com/"));
@@ -193,8 +185,7 @@ mod tests {
             .api_key("test-api-key".to_string())
             .host(" \n\t ")
             .build()
-            .unwrap()
-            .sanitize();
+            .unwrap();
 
         assert_eq!(options.host.as_deref(), Some(US_INGESTION_ENDPOINT));
         assert_eq!(options.endpoints().api_host(), US_INGESTION_ENDPOINT);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,12 +33,14 @@ pub use async_client::Client;
 ///     .unwrap();
 /// ```
 #[derive(Builder, Clone)]
+#[builder(build_fn(name = "build_unchecked", private))]
 pub struct ClientOptions {
     /// Host URL for the PostHog API (defaults to US ingestion endpoint)
     #[builder(setter(into, strip_option), default)]
     host: Option<String>,
 
-    /// Project API key (required)
+    /// Project API key. If missing or blank, the client is disabled.
+    #[builder(default)]
     api_key: String,
 
     /// Request timeout in seconds
@@ -95,7 +97,8 @@ impl ClientOptions {
     fn sanitize(mut self) -> Self {
         self.api_key = self.api_key.trim().to_string();
         if self.api_key.is_empty() {
-            warn!("api_key is empty after trimming whitespace; check your project API key");
+            warn!("api_key is empty after trimming whitespace; disabling PostHog client");
+            self.disabled = true;
         }
         self.host = Some(match self.host {
             Some(host) => {
@@ -127,6 +130,17 @@ impl ClientOptions {
     /// Create ClientOptions with properly initialized endpoint_manager
     fn with_endpoint_manager(self) -> Self {
         self.sanitize()
+    }
+}
+
+impl ClientOptionsBuilder {
+    /// Build sanitized [`ClientOptions`].
+    ///
+    /// Missing or whitespace-only API keys are allowed and disable the client so
+    /// SDK initialization remains infallible while avoiding requests with an
+    /// empty API key.
+    pub fn build(&self) -> Result<ClientOptions, ClientOptionsBuilderError> {
+        Ok(self.build_unchecked()?.sanitize())
     }
 }
 
@@ -184,5 +198,24 @@ mod tests {
 
         assert_eq!(options.host.as_deref(), Some(US_INGESTION_ENDPOINT));
         assert_eq!(options.endpoints().api_host(), US_INGESTION_ENDPOINT);
+    }
+
+    #[test]
+    fn builder_allows_missing_api_key_and_disables_client() {
+        let options = ClientOptionsBuilder::default().build().unwrap();
+
+        assert_eq!(options.api_key, "");
+        assert!(options.is_disabled());
+    }
+
+    #[test]
+    fn builder_disables_client_for_trim_empty_api_key() {
+        let options = ClientOptionsBuilder::default()
+            .api_key(" \n\t ".to_string())
+            .build()
+            .unwrap();
+
+        assert_eq!(options.api_key, "");
+        assert!(options.is_disabled());
     }
 }

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -407,6 +407,99 @@ async fn test_groups_parameter() {
 }
 
 #[tokio::test]
+async fn test_client_with_missing_api_key_is_noop() {
+    let server = MockServer::start();
+
+    let capture_mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v0/e/");
+        then.status(200);
+    });
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/batch/");
+        then.status(200);
+    });
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .build()
+        .unwrap();
+    assert!(options.is_disabled());
+
+    let client = posthog_rs::client(options).await;
+    let event = posthog_rs::Event::new("test_event", "user1");
+
+    assert!(client.capture(event.clone()).await.is_ok());
+    assert!(client.capture_batch(vec![event], false).await.is_ok());
+
+    let (feature_flags, payloads) = client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .await
+        .unwrap();
+    assert!(feature_flags.is_empty());
+    assert!(payloads.is_empty());
+
+    assert_eq!(
+        client
+            .get_feature_flag("test-flag", "test-user", None, None, None)
+            .await
+            .unwrap(),
+        None
+    );
+    assert!(!client
+        .is_feature_enabled("test-flag", "test-user", None, None, None)
+        .await
+        .unwrap());
+    assert_eq!(
+        client
+            .get_feature_flag_payload("test-flag", "test-user")
+            .await
+            .unwrap(),
+        None
+    );
+
+    capture_mock.assert_hits(0);
+    batch_mock.assert_hits(0);
+    flags_mock.assert_hits(0);
+}
+
+#[tokio::test]
+async fn test_client_with_whitespace_api_key_is_noop() {
+    let server = MockServer::start();
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .api_key(" \n\t ".to_string())
+        .host(server.base_url())
+        .build()
+        .unwrap();
+    assert!(options.is_disabled());
+
+    let client = posthog_rs::client(options).await;
+
+    assert!(client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .await
+        .unwrap()
+        .0
+        .is_empty());
+    flags_mock.assert_hits(0);
+}
+
+#[tokio::test]
 async fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();
 

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -407,7 +407,13 @@ async fn test_groups_parameter() {
 }
 
 #[tokio::test]
-async fn test_client_with_missing_api_key_is_noop() {
+async fn test_client_with_empty_api_key_is_noop() {
+    for api_key in [None, Some(" \n\t ")] {
+        assert_disabled_client_is_noop(api_key).await;
+    }
+}
+
+async fn assert_disabled_client_is_noop(api_key: Option<&str>) {
     let server = MockServer::start();
 
     let capture_mock = server.mock(|when, then| {
@@ -426,10 +432,11 @@ async fn test_client_with_missing_api_key_is_noop() {
         }));
     });
 
-    let options = posthog_rs::ClientOptionsBuilder::default()
-        .host(server.base_url())
-        .build()
-        .unwrap();
+    let mut options_builder = posthog_rs::ClientOptionsBuilder::default();
+    if let Some(api_key) = api_key {
+        options_builder.api_key(api_key.to_string());
+    }
+    let options = options_builder.host(server.base_url()).build().unwrap();
     assert!(options.is_disabled());
 
     let client = posthog_rs::client(options).await;
@@ -466,36 +473,6 @@ async fn test_client_with_missing_api_key_is_noop() {
 
     capture_mock.assert_hits(0);
     batch_mock.assert_hits(0);
-    flags_mock.assert_hits(0);
-}
-
-#[tokio::test]
-async fn test_client_with_whitespace_api_key_is_noop() {
-    let server = MockServer::start();
-
-    let flags_mock = server.mock(|when, then| {
-        when.method(POST).path("/flags/").query_param("v", "2");
-        then.status(200).json_body(json!({
-            "featureFlags": {},
-            "featureFlagPayloads": {}
-        }));
-    });
-
-    let options = posthog_rs::ClientOptionsBuilder::default()
-        .api_key(" \n\t ".to_string())
-        .host(server.base_url())
-        .build()
-        .unwrap();
-    assert!(options.is_disabled());
-
-    let client = posthog_rs::client(options).await;
-
-    assert!(client
-        .get_feature_flags("test-user".to_string(), None, None, None)
-        .await
-        .unwrap()
-        .0
-        .is_empty());
     flags_mock.assert_hits(0);
 }
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -228,6 +228,94 @@ fn test_api_error_handling() {
 }
 
 #[test]
+fn test_client_with_missing_api_key_is_noop() {
+    let server = MockServer::start();
+
+    let capture_mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v0/e/");
+        then.status(200);
+    });
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/batch/");
+        then.status(200);
+    });
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .build()
+        .unwrap();
+    assert!(options.is_disabled());
+
+    let client = posthog_rs::client(options);
+    let event = posthog_rs::Event::new("test_event", "user1");
+
+    assert!(client.capture(event.clone()).is_ok());
+    assert!(client.capture_batch(vec![event], false).is_ok());
+
+    let (feature_flags, payloads) = client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .unwrap();
+    assert!(feature_flags.is_empty());
+    assert!(payloads.is_empty());
+
+    assert_eq!(
+        client
+            .get_feature_flag("test-flag", "test-user", None, None, None)
+            .unwrap(),
+        None
+    );
+    assert!(!client
+        .is_feature_enabled("test-flag", "test-user", None, None, None)
+        .unwrap());
+    assert_eq!(
+        client
+            .get_feature_flag_payload("test-flag", "test-user")
+            .unwrap(),
+        None
+    );
+
+    capture_mock.assert_hits(0);
+    batch_mock.assert_hits(0);
+    flags_mock.assert_hits(0);
+}
+
+#[test]
+fn test_client_with_whitespace_api_key_is_noop() {
+    let server = MockServer::start();
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .api_key(" \n\t ".to_string())
+        .host(server.base_url())
+        .build()
+        .unwrap();
+    assert!(options.is_disabled());
+
+    let client = posthog_rs::client(options);
+
+    assert!(client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .unwrap()
+        .0
+        .is_empty());
+    flags_mock.assert_hits(0);
+}
+
+#[test]
 fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -228,7 +228,13 @@ fn test_api_error_handling() {
 }
 
 #[test]
-fn test_client_with_missing_api_key_is_noop() {
+fn test_client_with_empty_api_key_is_noop() {
+    for api_key in [None, Some(" \n\t ")] {
+        assert_disabled_client_is_noop(api_key);
+    }
+}
+
+fn assert_disabled_client_is_noop(api_key: Option<&str>) {
     let server = MockServer::start();
 
     let capture_mock = server.mock(|when, then| {
@@ -247,10 +253,11 @@ fn test_client_with_missing_api_key_is_noop() {
         }));
     });
 
-    let options = posthog_rs::ClientOptionsBuilder::default()
-        .host(server.base_url())
-        .build()
-        .unwrap();
+    let mut options_builder = posthog_rs::ClientOptionsBuilder::default();
+    if let Some(api_key) = api_key {
+        options_builder.api_key(api_key.to_string());
+    }
+    let options = options_builder.host(server.base_url()).build().unwrap();
     assert!(options.is_disabled());
 
     let client = posthog_rs::client(options);
@@ -283,35 +290,6 @@ fn test_client_with_missing_api_key_is_noop() {
 
     capture_mock.assert_hits(0);
     batch_mock.assert_hits(0);
-    flags_mock.assert_hits(0);
-}
-
-#[test]
-fn test_client_with_whitespace_api_key_is_noop() {
-    let server = MockServer::start();
-
-    let flags_mock = server.mock(|when, then| {
-        when.method(POST).path("/flags/").query_param("v", "2");
-        then.status(200).json_body(json!({
-            "featureFlags": {},
-            "featureFlagPayloads": {}
-        }));
-    });
-
-    let options = posthog_rs::ClientOptionsBuilder::default()
-        .api_key(" \n\t ".to_string())
-        .host(server.base_url())
-        .build()
-        .unwrap();
-    assert!(options.is_disabled());
-
-    let client = posthog_rs::client(options);
-
-    assert!(client
-        .get_feature_flags("test-user".to_string(), None, None, None)
-        .unwrap()
-        .0
-        .is_empty());
     flags_mock.assert_hits(0);
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Initializing the Rust SDK without a project API key, or with a whitespace-only key, should be safe and should not send requests with an empty key.

This change disables the client when the API key is missing or blank so capture, batch capture, and feature flag calls become no-ops instead of making outbound requests. It also keeps option sanitization centralized in the builder and consolidates the noop API-key coverage across both missing and whitespace-only cases.

## :green_heart: How did you test it?

- `cargo test`
- `cargo test --no-default-features`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
