### PR TITLE
Wire compliance adapter to V1 and run workspace tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,14 @@ jobs:
     - name: Build
       run: cargo build --verbose
 
-    - name: Unit test
+    - name: Unit test (default features)
       run: cargo test --verbose
 
+    - name: Unit test (workspace, includes capture-v1)
+      run: cargo test --workspace --verbose
+
+    # TODO: when v1 endpoint ships, remove the capture-v1 feature gate;
+    # v1 e2e test (get_client_v1_async) will then run here automatically.
     - name: E2E test
       run: cargo test --verbose --features e2e-test --no-default-features
       env:

--- a/.sampo/changesets/add-v1-capture-pipeline.md
+++ b/.sampo/changesets/add-v1-capture-pipeline.md
@@ -2,4 +2,4 @@
 cargo/posthog-rs: minor
 ---
 
-Add V1 capture pipeline (`/i/v1/analytics/events/`) with gzip/deflate/br/zstd compression, automatic partial-batch retry with exponential backoff, per-event options (cookieless mode, skew correction, person profile, product tour), historical migration support, and SDK test harness integration with parallel test execution.
+Add V1 capture pipeline (`/i/v1/analytics/events/`) behind the unstable `capture-v1` Cargo feature (off by default). Includes gzip/deflate/br/zstd compression, automatic partial-batch retry with exponential backoff, per-event options (cookieless mode, skew correction, person profile, product tour), and historical migration support. A separate `test-harness` feature enables injecting extra request headers for compliance test isolation.

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -195,7 +195,7 @@ async fn init(
 
 /// Drain pending events from the buffer under the lock, then send the batch
 /// without holding the lock, and finally re-acquire the lock to record the
-/// outcome. Returns the total number of events sent.
+/// outcome. Returns the number of events flushed in this call.
 async fn flush_buffer(instances: &Mutex<HashMap<String, AdapterState>>, key: &str) -> u64 {
     let (client, events, historical_migration) = {
         let mut map = instances.lock().await;
@@ -217,21 +217,26 @@ async fn flush_buffer(instances: &Mutex<HashMap<String, AdapterState>>, key: &st
     let count = events.len() as u64;
     let result = client.capture_batch(events, historical_migration).await;
 
-    let total_sent = {
+    let flushed = {
         let mut map = instances.lock().await;
         if let Some(s) = map.get_mut(key) {
-            s.pending_events = (s.pending_events - count as i64).max(0);
             match result {
-                Ok(()) => s.total_events_sent += count,
-                Err(e) => s.last_error = Some(e.to_string()),
+                Ok(()) => {
+                    s.pending_events = (s.pending_events - count as i64).max(0);
+                    s.total_events_sent += count;
+                    count
+                }
+                Err(e) => {
+                    s.last_error = Some(e.to_string());
+                    0
+                }
             }
-            s.total_events_sent
         } else {
             0
         }
     };
 
-    total_sent
+    flushed
 }
 
 async fn capture_event(
@@ -313,11 +318,11 @@ async fn flush(
         }
     }
 
-    let total_sent = flush_buffer(&state.instances, &key).await;
+    let flushed = flush_buffer(&state.instances, &key).await;
 
     Json(serde_json::json!({
         "success": true,
-        "events_flushed": total_sent
+        "events_flushed": flushed
     }))
     .into_response()
 }

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -11,13 +11,14 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
-use posthog_rs::{Client, ClientOptionsBuilder, Event};
+use posthog_rs::{CaptureCompression, Client, ClientOptionsBuilder, Event};
 
 const SUPPORTS_PARALLEL: bool = true;
 
 #[derive(Clone)]
 struct AppState {
     instances: Arc<Mutex<HashMap<String, AdapterState>>>,
+    compression: Option<CaptureCompression>,
 }
 
 const DEFAULT_TEST_ID: &str = "_global";
@@ -26,6 +27,8 @@ const DEFAULT_TEST_ID: &str = "_global";
 struct AdapterState {
     client: Option<Arc<Client>>,
     historical_migration: bool,
+    buffer: Vec<Event>,
+    flush_at: Option<u32>,
     total_events_captured: u64,
     total_events_sent: u64,
     last_error: Option<String>,
@@ -36,16 +39,13 @@ struct AdapterState {
 struct InitRequest {
     api_key: String,
     host: String,
-    #[allow(dead_code)]
     #[serde(default)]
     flush_at: Option<u32>,
     #[allow(dead_code)]
     #[serde(default)]
     flush_interval_ms: Option<u64>,
-    #[allow(dead_code)]
     #[serde(default)]
     max_retries: Option<u32>,
-    #[allow(dead_code)]
     #[serde(default)]
     enable_compression: Option<bool>,
     #[serde(default)]
@@ -62,6 +62,7 @@ struct CaptureRequest {
     properties: Option<serde_json::Value>,
     #[serde(default)]
     timestamp: Option<String>,
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
     #[serde(default)]
     options: Option<serde_json::Value>,
 }
@@ -83,7 +84,7 @@ struct HealthResponse {
     sdk_name: &'static str,
     sdk_version: &'static str,
     adapter_version: &'static str,
-    capabilities: Vec<&'static str>,
+    capabilities: Vec<String>,
     supports_parallel: bool,
 }
 
@@ -92,21 +93,45 @@ struct StateResponse {
     pending_events: i64,
     total_events_captured: u64,
     total_events_sent: u64,
+    // Always 0: capture API does not expose retry counts; retries are validated at the wire level.
     total_retries: u64,
     last_error: Option<String>,
 }
 
-async fn health() -> Json<HealthResponse> {
-    let capability = if cfg!(feature = "capture-v1") {
-        "capture_v1"
+fn parse_compression() -> Option<CaptureCompression> {
+    match std::env::var("COMPRESSION").as_deref() {
+        Ok("gzip") => Some(CaptureCompression::Gzip),
+        Ok("deflate") => Some(CaptureCompression::Deflate),
+        Ok("br") => Some(CaptureCompression::Br),
+        Ok("zstd") => Some(CaptureCompression::Zstd),
+        _ => None,
+    }
+}
+
+fn compression_capability(c: CaptureCompression) -> &'static str {
+    match c {
+        CaptureCompression::Gzip => "encoding_gzip",
+        CaptureCompression::Deflate => "encoding_deflate",
+        CaptureCompression::Br => "encoding_br",
+        CaptureCompression::Zstd => "encoding_zstd",
+    }
+}
+
+async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
+    let mut capabilities: Vec<String> = Vec::new();
+    if cfg!(feature = "capture-v1") {
+        capabilities.push("capture_v1".to_string());
+        if let Some(algo) = state.compression {
+            capabilities.push(compression_capability(algo).to_string());
+        }
     } else {
-        "capture_v0"
-    };
+        capabilities.push("capture_v0".to_string());
+    }
     Json(HealthResponse {
         sdk_name: "posthog-rs",
         sdk_version: env!("CARGO_PKG_VERSION"),
         adapter_version: env!("CARGO_PKG_VERSION"),
-        capabilities: vec![capability],
+        capabilities,
         supports_parallel: SUPPORTS_PARALLEL,
     })
 }
@@ -121,9 +146,22 @@ async fn init(
 
     *s = AdapterState::default();
     s.historical_migration = req.historical_migration.unwrap_or(false);
+    s.flush_at = req.flush_at;
 
     let mut builder = ClientOptionsBuilder::default();
     builder.api_key(req.api_key).host(req.host);
+
+    // The harness `max_retries` counts retries; the SDK option counts total
+    // attempts (initial + retries), so add one.
+    if let Some(retries) = req.max_retries {
+        builder.max_capture_attempts(retries.saturating_add(1));
+    }
+
+    if req.enable_compression.unwrap_or(false) {
+        if let Some(algo) = state.compression {
+            builder.capture_compression(algo);
+        }
+    }
 
     if req.disable_geoip.unwrap_or(false) {
         builder.disable_geoip(true);
@@ -155,6 +193,47 @@ async fn init(
     }
 }
 
+/// Drain pending events from the buffer under the lock, then send the batch
+/// without holding the lock, and finally re-acquire the lock to record the
+/// outcome. Returns the total number of events sent.
+async fn flush_buffer(instances: &Mutex<HashMap<String, AdapterState>>, key: &str) -> u64 {
+    let (client, events, historical_migration) = {
+        let mut map = instances.lock().await;
+        let s = match map.get_mut(key) {
+            Some(s) => s,
+            None => return 0,
+        };
+        if s.buffer.is_empty() {
+            return 0;
+        }
+        let client = match &s.client {
+            Some(c) => c.clone(),
+            None => return 0,
+        };
+        let events = std::mem::take(&mut s.buffer);
+        (client, events, s.historical_migration)
+    };
+
+    let count = events.len() as u64;
+    let result = client.capture_batch(events, historical_migration).await;
+
+    let total_sent = {
+        let mut map = instances.lock().await;
+        if let Some(s) = map.get_mut(key) {
+            s.pending_events = (s.pending_events - count as i64).max(0);
+            match result {
+                Ok(()) => s.total_events_sent += count,
+                Err(e) => s.last_error = Some(e.to_string()),
+            }
+            s.total_events_sent
+        } else {
+            0
+        }
+    };
+
+    total_sent
+}
+
 async fn capture_event(
     State(state): State<AppState>,
     Query(params): Query<TestIdParam>,
@@ -162,17 +241,69 @@ async fn capture_event(
 ) -> impl IntoResponse {
     let key = params.key().to_string();
 
-    // Phase 1: short lock — clone Arc<Client>, bump in-flight counter
-    let client = {
+    let needs_flush = {
         let mut instances = state.instances.lock().await;
         let s = instances.entry(key.clone()).or_default();
-        match &s.client {
-            Some(c) => {
-                s.total_events_captured += 1;
-                s.pending_events += 1;
-                c.clone()
+
+        if s.client.is_none() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "SDK not initialized" })),
+            )
+                .into_response();
+        }
+
+        let mut event = Event::new(req.event, req.distinct_id);
+
+        if let Some(props) = req.properties {
+            if let Some(obj) = props.as_object() {
+                for (k, v) in obj {
+                    let _ = event.insert_prop(k.clone(), v.clone());
+                }
             }
-            None => {
+        }
+
+        if let Some(ts_str) = req.timestamp {
+            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&ts_str) {
+                let _ = event.set_timestamp(ts);
+            }
+        }
+
+        #[cfg(feature = "capture-v1")]
+        if let Some(opts_val) = req.options {
+            if let Some(obj) = opts_val.as_object() {
+                for (k, v) in obj {
+                    let _ = event.set_option(k, v.clone());
+                }
+            }
+        }
+
+        s.total_events_captured += 1;
+        s.pending_events += 1;
+        s.buffer.push(event);
+
+        matches!(s.flush_at, Some(threshold) if s.buffer.len() as u32 >= threshold)
+    };
+
+    if needs_flush {
+        flush_buffer(&state.instances, &key).await;
+    }
+
+    let uuid = uuid::Uuid::now_v7().to_string();
+    Json(serde_json::json!({ "success": true, "uuid": uuid })).into_response()
+}
+
+async fn flush(
+    State(state): State<AppState>,
+    Query(params): Query<TestIdParam>,
+) -> impl IntoResponse {
+    let key = params.key().to_string();
+
+    {
+        let instances = state.instances.lock().await;
+        match instances.get(&key) {
+            Some(s) if s.client.is_some() => {}
+            _ => {
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(serde_json::json!({ "error": "SDK not initialized" })),
@@ -180,87 +311,13 @@ async fn capture_event(
                     .into_response();
             }
         }
-    };
-
-    // Build event outside the lock
-    let mut event = Event::new(req.event, req.distinct_id);
-
-    if let Some(props) = req.properties {
-        if let Some(obj) = props.as_object() {
-            for (k, v) in obj {
-                let _ = event.insert_prop(k.clone(), v.clone());
-            }
-        }
     }
 
-    if let Some(ts_str) = req.timestamp {
-        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&ts_str) {
-            let _ = event.set_timestamp(ts);
-        }
-    }
-
-    // EventOptions wiring (set_options) is applied in the V1 capture
-    // implementation branch where EventOptions exists on Event.
-    let _ = req.options;
-
-    let uuid = uuid::Uuid::now_v7().to_string();
-
-    // Phase 2: network call without holding the lock
-    let result = client.capture(event).await;
-
-    // Phase 3: short lock — record outcome
-    {
-        let mut instances = state.instances.lock().await;
-        if let Some(s) = instances.get_mut(&key) {
-            s.pending_events = (s.pending_events - 1).max(0);
-            match &result {
-                Ok(()) => {
-                    s.total_events_sent += 1;
-                }
-                Err(e) => {
-                    s.last_error = Some(e.to_string());
-                }
-            }
-        }
-    }
-
-    match result {
-        Ok(()) => Json(serde_json::json!({ "success": true, "uuid": uuid })).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": e.to_string() })),
-        )
-            .into_response(),
-    }
-}
-
-async fn flush(
-    State(state): State<AppState>,
-    Query(params): Query<TestIdParam>,
-) -> impl IntoResponse {
-    let instances = state.instances.lock().await;
-    let s = match instances.get(params.key()) {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "error": "SDK not initialized" })),
-            )
-                .into_response();
-        }
-    };
-
-    if s.client.is_none() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "SDK not initialized" })),
-        )
-            .into_response();
-    }
+    let total_sent = flush_buffer(&state.instances, &key).await;
 
     Json(serde_json::json!({
         "success": true,
-        "events_flushed": s.total_events_sent
+        "events_flushed": total_sent
     }))
     .into_response()
 }
@@ -270,9 +327,7 @@ async fn get_state(
     Query(params): Query<TestIdParam>,
 ) -> impl IntoResponse {
     let instances = state.instances.lock().await;
-    let s = instances.get(params.key());
-
-    match s {
+    match instances.get(params.key()) {
         Some(s) => Json(serde_json::json!(StateResponse {
             pending_events: s.pending_events,
             total_events_captured: s.total_events_captured,
@@ -303,15 +358,23 @@ async fn reset(
 
 #[tokio::main]
 async fn main() {
+    let compression = parse_compression();
     let mode_str = if cfg!(feature = "capture-v1") {
         "v1"
     } else {
         "v0"
     };
-    eprintln!("Starting posthog-rs SDK adapter (capture={mode_str}, parallel={SUPPORTS_PARALLEL})");
+    let compression_str = match compression {
+        Some(algo) => compression_capability(algo),
+        None => "none",
+    };
+    eprintln!(
+        "Starting posthog-rs SDK adapter (capture={mode_str}, compression={compression_str}, parallel={SUPPORTS_PARALLEL})"
+    );
 
     let state = AppState {
         instances: Arc::new(Mutex::new(HashMap::new())),
+        compression,
     };
 
     let app = Router::new()

--- a/compliance/v1/docker-compose.yml
+++ b/compliance/v1/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ../..
       dockerfile: compliance/v1/Dockerfile
+    environment:
+      - COMPRESSION=gzip
     ports:
       - "8080:8080"
     networks:

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -57,3 +57,37 @@ fn get_client_blocking() {
 
     client.capture(event).unwrap();
 }
+
+#[cfg(all(feature = "e2e-test", feature = "capture-v1", feature = "async-client"))]
+#[tokio::test]
+async fn get_client_v1_async() {
+    use dotenv::dotenv;
+    dotenv().ok();
+
+    use posthog_rs::{ClientOptionsBuilder, Event};
+    use std::collections::HashMap;
+
+    let api_key = match std::env::var("POSTHOG_RS_E2E_TEST_API_KEY") {
+        Ok(key) if !key.is_empty() => key,
+        _ => {
+            eprintln!("Skipping e2e test: POSTHOG_RS_E2E_TEST_API_KEY not set");
+            return;
+        }
+    };
+
+    let options = ClientOptionsBuilder::default()
+        .api_key(api_key)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    let mut child_map = HashMap::new();
+    child_map.insert("child_key1", "child_value1");
+
+    let mut event = Event::new("e2e v1 test event", "1234");
+    event.insert_prop("key1", "value1").unwrap();
+    event.insert_prop("key2", vec!["a", "b"]).unwrap();
+    event.insert_prop("key3", child_map).unwrap();
+
+    client.capture(event).await.unwrap();
+}

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -477,6 +477,7 @@ async fn assert_disabled_client_is_noop(api_key: Option<&str>) {
     flags_mock.assert_hits(0);
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
 async fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -294,6 +294,7 @@ fn assert_disabled_client_is_noop(api_key: Option<&str>) {
     flags_mock.assert_hits(0);
 }
 
+#[cfg(not(feature = "capture-v1"))]
 #[test]
 fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();

--- a/tests/test_v1_blocking.rs
+++ b/tests/test_v1_blocking.rs
@@ -1,0 +1,636 @@
+#![cfg(all(not(feature = "async-client"), feature = "capture-v1"))]
+
+use httpmock::prelude::*;
+use posthog_rs::{ClientOptionsBuilder, Event};
+use serde_json::json;
+
+fn create_v1_client(base_url: String) -> posthog_rs::Client {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(base_url)
+        .max_capture_attempts(3u32)
+        .retry_initial_backoff_ms(10u64)
+        .retry_max_backoff_ms(50u64)
+        .build()
+        .unwrap();
+    posthog_rs::client(options)
+}
+
+// Constants required because httpmock `matches` takes bare fn pointers (no captures).
+const PARTIAL_UUID_OK: &str = "01920000-0000-7000-8000-0000000000a1";
+const PARTIAL_UUID_RETRY: &str = "01920000-0000-7000-8000-0000000000a2";
+const PARTIAL_UUID_DROP: &str = "01920000-0000-7000-8000-0000000000a3";
+
+fn body_string(req: &HttpMockRequest) -> String {
+    req.body
+        .as_ref()
+        .map(|b| String::from_utf8_lossy(b).into_owned())
+        .unwrap_or_default()
+}
+
+/// Matcher: retry event present, ok event pruned.
+fn retry_body_only_contains_retry_event(req: &HttpMockRequest) -> bool {
+    let body = body_string(req);
+    body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_OK)
+}
+
+/// Matcher: retry event present; the dropped (terminal) event is pruned.
+fn retry_body_prunes_terminal_events(req: &HttpMockRequest) -> bool {
+    let body = body_string(req);
+    body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_DROP)
+}
+
+#[test]
+fn v1_blocking_capture_success() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("authorization", "Bearer phc_test_token")
+            .header_exists("posthog-request-id")
+            .header_exists("posthog-attempt");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test_event", "user-1"));
+    assert!(result.is_ok());
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_retries_on_server_error() {
+    let server = MockServer::start();
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1");
+        then.status(500).json_body(json!({
+            "error": "internal_error",
+            "error_description": "Internal Server Error"
+        }));
+    });
+
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test", "user-1"));
+
+    assert!(result.is_ok());
+    fail_mock.assert();
+    success_mock.assert();
+}
+
+#[test]
+fn v1_blocking_does_not_retry_on_401() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(401).body("Unauthorized");
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test", "user-1"));
+
+    assert!(result.is_err());
+    mock.assert_hits(1);
+}
+
+#[test]
+fn v1_blocking_partial_batch_retry() {
+    let server = MockServer::start();
+
+    let mut event1 = Event::new("event_1", "user-1");
+    let mut event2 = Event::new("event_2", "user-1");
+
+    let uuid1 = uuid::Uuid::parse_str(PARTIAL_UUID_OK).unwrap();
+    let uuid2 = uuid::Uuid::parse_str(PARTIAL_UUID_RETRY).unwrap();
+    event1.set_uuid(uuid1);
+    event2.set_uuid(uuid2);
+
+    let first_resp = json!({
+        "results": {
+            PARTIAL_UUID_OK: { "result": "ok" },
+            PARTIAL_UUID_RETRY: { "result": "retry", "details": "not_persisted" }
+        }
+    });
+
+    let retry_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "ok" }
+        }
+    });
+
+    let first_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(PARTIAL_UUID_OK)
+            .body_contains(PARTIAL_UUID_RETRY);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(first_resp);
+    });
+
+    // Uses `matches` to assert the ok event was pruned (body_contains can't negate).
+    let retry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(retry_body_only_contains_retry_event);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(retry_resp);
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture_batch(vec![event1, event2], false);
+
+    assert!(result.is_ok());
+    first_mock.assert();
+    retry_mock.assert();
+}
+
+#[test]
+fn v1_blocking_does_not_retry_terminal_results() {
+    let server = MockServer::start();
+
+    let mut ev_ok = Event::new("ev_ok", "user-1");
+    let mut ev_drop = Event::new("ev_drop", "user-1");
+    let mut ev_warning = Event::new("ev_warning", "user-1");
+
+    let uuid_ok = uuid::Uuid::now_v7();
+    let uuid_drop = uuid::Uuid::now_v7();
+    let uuid_warning = uuid::Uuid::now_v7();
+    ev_ok.set_uuid(uuid_ok);
+    ev_drop.set_uuid(uuid_drop);
+    ev_warning.set_uuid(uuid_warning);
+
+    let resp = json!({
+        "results": {
+            uuid_ok.to_string(): { "result": "ok" },
+            uuid_drop.to_string(): { "result": "drop", "details": "billing_limit_exceeded" },
+            uuid_warning.to_string(): { "result": "warning", "details": "person_processing_disabled" }
+        }
+    });
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(resp);
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture_batch(vec![ev_ok, ev_drop, ev_warning], false);
+
+    assert!(result.is_ok());
+    mock.assert_hits(1);
+}
+
+#[test]
+fn v1_blocking_whole_batch_resent_on_retryable_status() {
+    for status in [408u16, 500, 502, 503, 504] {
+        let server = MockServer::start();
+
+        let mut event1 = Event::new("event_1", "user-1");
+        let mut event2 = Event::new("event_2", "user-2");
+
+        let uuid1 = uuid::Uuid::now_v7();
+        let uuid2 = uuid::Uuid::now_v7();
+        event1.set_uuid(uuid1);
+        event2.set_uuid(uuid2);
+
+        let ts = "2024-01-01T00:00:00.000Z";
+        event1
+            .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            .unwrap();
+        event2
+            .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            .unwrap();
+
+        let uuid1_str = uuid1.to_string();
+        let uuid2_str = uuid2.to_string();
+
+        let fail_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "1");
+            then.status(status)
+                .header("content-type", "application/json")
+                .header("retry-after", "0")
+                .json_body(json!({
+                    "error": "server_error",
+                    "error_description": "transient"
+                }));
+        });
+
+        let success_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "2")
+                .body_contains(&uuid1_str)
+                .body_contains(&uuid2_str)
+                .body_contains(ts);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": {
+                        uuid1_str: { "result": "ok" },
+                        uuid2_str: { "result": "ok" }
+                    }
+                }));
+        });
+
+        let client = create_v1_client(server.base_url());
+        let result = client.capture_batch(vec![event1, event2], false);
+
+        assert!(
+            result.is_ok(),
+            "status {} should retry then succeed",
+            status
+        );
+        fail_mock.assert();
+        success_mock.assert();
+    }
+}
+
+#[test]
+fn v1_blocking_prunes_terminal_events_on_partial_retry() {
+    let server = MockServer::start();
+
+    let mut ev_retry = Event::new("ev_retry", "user-1");
+    let mut ev_drop = Event::new("ev_drop", "user-1");
+
+    let uuid_retry = uuid::Uuid::parse_str(PARTIAL_UUID_RETRY).unwrap();
+    let uuid_drop = uuid::Uuid::parse_str(PARTIAL_UUID_DROP).unwrap();
+    ev_retry.set_uuid(uuid_retry);
+    ev_drop.set_uuid(uuid_drop);
+
+    let first_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "retry", "details": "not_persisted" },
+            PARTIAL_UUID_DROP: { "result": "drop", "details": "billing_limit_exceeded" }
+        }
+    });
+
+    let retry_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "ok" }
+        }
+    });
+
+    let first_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(PARTIAL_UUID_RETRY)
+            .body_contains(PARTIAL_UUID_DROP);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(first_resp);
+    });
+
+    let retry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(retry_body_prunes_terminal_events);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(retry_resp);
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture_batch(vec![ev_retry, ev_drop], false);
+
+    assert!(result.is_ok());
+    first_mock.assert();
+    retry_mock.assert();
+}
+
+#[test]
+fn v1_blocking_partial_retry_exhausts_attempts() {
+    let server = MockServer::start();
+
+    let mut event = Event::new("test", "user-1");
+    let uuid = uuid::Uuid::now_v7();
+    event.set_uuid(uuid);
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "results": {
+                    uuid.to_string(): { "result": "retry", "details": "not_persisted" }
+                }
+            }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(event);
+
+    // 200 path returns Ok even when retries are exhausted.
+    assert!(result.is_ok());
+    mock.assert_hits(3);
+}
+
+static CAPTURED_REQUEST_IDS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+fn capture_request_id(req: &HttpMockRequest) -> bool {
+    if let Some(headers) = req.headers.as_ref() {
+        for (key, value) in headers {
+            if key.eq_ignore_ascii_case("posthog-request-id") {
+                CAPTURED_REQUEST_IDS.lock().unwrap().push(value.clone());
+                break;
+            }
+        }
+    }
+    true
+}
+
+#[test]
+fn v1_blocking_request_id_stable_across_retries() {
+    CAPTURED_REQUEST_IDS.lock().unwrap().clear();
+
+    let server = MockServer::start();
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .matches(capture_request_id);
+        then.status(503)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "error": "service_unavailable",
+                "error_description": "transient"
+            }));
+    });
+
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(capture_request_id);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    client.capture(Event::new("test", "user-1")).unwrap();
+
+    fail_mock.assert();
+    success_mock.assert();
+
+    let ids = CAPTURED_REQUEST_IDS.lock().unwrap();
+    assert_eq!(ids.len(), 2, "expected exactly 2 captured request-ids");
+    assert_eq!(
+        ids[0], ids[1],
+        "posthog-request-id must be stable across retries"
+    );
+}
+
+#[test]
+fn v1_blocking_does_not_retry_on_402() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(402)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "billing_limit_exceeded",
+                "error_description": "Billing quota exceeded."
+            }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test", "user-1"));
+
+    assert!(matches!(
+        result,
+        Err(posthog_rs::Error::BillingLimitExceeded(_))
+    ));
+    mock.assert_hits(1);
+}
+
+#[test]
+fn v1_blocking_exhausts_retries() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(500)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "internal_error",
+                "error_description": "Internal Server Error"
+            }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture(Event::new("test", "user-1"));
+
+    assert!(result.is_err());
+    mock.assert_hits(3);
+}
+
+#[test]
+fn v1_blocking_sends_event_options() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"cookieless_mode\":true")
+            .body_contains("\"process_person_profile\":false");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let mut event = Event::new("test", "user-1");
+    event.set_option("cookieless_mode", true).unwrap();
+    event.set_option("process_person_profile", false).unwrap();
+
+    client.capture(event).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_injects_geoip_disable_when_configured() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$geoip_disable\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .disable_geoip(true)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options);
+
+    client.capture(Event::new("test", "user-1")).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_injects_is_server_by_default() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$is_server\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    client.capture(Event::new("test", "user-1")).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_caller_override_wins_for_is_server() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$is_server\":false");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let mut event = Event::new("test", "user-1");
+    event.insert_prop("$is_server", false).unwrap();
+    client.capture(event).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_batch_sets_historical_migration() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"historical_migration\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let events = vec![Event::new("a", "user-1"), Event::new("b", "user-1")];
+    client.capture_batch(events, true).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_sends_gzip_content_encoding() {
+    use posthog_rs::CaptureCompression;
+
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("content-encoding", "gzip");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .capture_compression(CaptureCompression::Gzip)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options);
+
+    client.capture(Event::new("test", "user-1")).unwrap();
+    mock.assert();
+}
+
+#[test]
+fn v1_blocking_preserves_uuid_and_timestamp_across_retries() {
+    let server = MockServer::start();
+    let uuid = uuid::Uuid::now_v7();
+    let ts = "2024-01-01T00:00:00.000Z";
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(uuid.to_string())
+            .body_contains(ts);
+        then.status(503)
+            .header("retry-after", "0")
+            .json_body(json!({ "error": "service_unavailable" }));
+    });
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .body_contains(uuid.to_string())
+            .body_contains(ts);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let mut event = Event::new("test", "user-1");
+    event.set_uuid(uuid);
+    event
+        .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+        .unwrap();
+
+    client.capture(event).unwrap();
+    fail_mock.assert();
+    success_mock.assert();
+}
+
+#[test]
+fn v1_blocking_disabled_client_noop() {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test".to_string())
+        .disabled(true)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options);
+
+    let result = client.capture(Event::new("test", "user-1"));
+    assert!(result.is_ok());
+}

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -1,0 +1,680 @@
+#![cfg(all(feature = "async-client", feature = "capture-v1"))]
+
+use httpmock::prelude::*;
+use posthog_rs::{ClientOptionsBuilder, Event};
+use serde_json::json;
+
+async fn create_v1_client(base_url: String) -> posthog_rs::Client {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(base_url)
+        .max_capture_attempts(3u32)
+        .retry_initial_backoff_ms(10u64)
+        .retry_max_backoff_ms(50u64)
+        .build()
+        .unwrap();
+    posthog_rs::client(options).await
+}
+
+// Constants required because httpmock `matches` takes bare fn pointers (no captures).
+const PARTIAL_UUID_OK: &str = "01920000-0000-7000-8000-0000000000a1";
+const PARTIAL_UUID_RETRY: &str = "01920000-0000-7000-8000-0000000000a2";
+const PARTIAL_UUID_DROP: &str = "01920000-0000-7000-8000-0000000000a3";
+
+fn body_string(req: &HttpMockRequest) -> String {
+    req.body
+        .as_ref()
+        .map(|b| String::from_utf8_lossy(b).into_owned())
+        .unwrap_or_default()
+}
+
+/// Matcher: retry event present, ok event pruned.
+fn retry_body_only_contains_retry_event(req: &HttpMockRequest) -> bool {
+    let body = body_string(req);
+    body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_OK)
+}
+
+/// Matcher: retry event present; the dropped (terminal) event is pruned.
+fn retry_body_prunes_terminal_events(req: &HttpMockRequest) -> bool {
+    let body = body_string(req);
+    body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_DROP)
+}
+
+#[tokio::test]
+async fn v1_capture_single_event_success() {
+    let server = MockServer::start();
+
+    let uuid = uuid::Uuid::now_v7();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header_exists("authorization")
+            .header_exists("posthog-request-id")
+            .header_exists("posthog-attempt")
+            .header_exists("posthog-request-timestamp")
+            .header_exists("posthog-sdk-info");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {
+                    uuid.to_string(): { "result": "ok" }
+                }
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test_event", "user-1");
+    event.set_uuid(uuid);
+
+    let result = client.capture(event).await;
+    assert!(result.is_ok());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_bearer_auth_header() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("authorization", "Bearer phc_test_token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {}
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_retries_on_server_error() {
+    let server = MockServer::start();
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1");
+        then.status(503)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "error": "service_unavailable",
+                "error_description": "Service Unavailable"
+            }));
+    });
+
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {}
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(Event::new("test", "user-1")).await;
+
+    assert!(result.is_ok());
+    fail_mock.assert();
+    success_mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_does_not_retry_on_401() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(401)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "invalid_api_token",
+                "error_description": "The provided API token is not valid."
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(Event::new("test", "user-1")).await;
+
+    assert!(result.is_err());
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn v1_capture_does_not_retry_on_402() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(402)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "billing_limit_exceeded",
+                "error_description": "Billing quota exceeded."
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(Event::new("test", "user-1")).await;
+
+    assert!(matches!(
+        result,
+        Err(posthog_rs::Error::BillingLimitExceeded(_))
+    ));
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn v1_capture_partial_batch_retry() {
+    let server = MockServer::start();
+
+    let mut event1 = Event::new("event_1", "user-1");
+    let mut event2 = Event::new("event_2", "user-1");
+
+    let uuid1 = uuid::Uuid::parse_str(PARTIAL_UUID_OK).unwrap();
+    let uuid2 = uuid::Uuid::parse_str(PARTIAL_UUID_RETRY).unwrap();
+    event1.set_uuid(uuid1);
+    event2.set_uuid(uuid2);
+
+    let first_resp = json!({
+        "results": {
+            PARTIAL_UUID_OK: { "result": "ok" },
+            PARTIAL_UUID_RETRY: { "result": "retry", "details": "not_persisted" }
+        }
+    });
+
+    let retry_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "ok" }
+        }
+    });
+
+    let first_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(PARTIAL_UUID_OK)
+            .body_contains(PARTIAL_UUID_RETRY);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(first_resp);
+    });
+
+    // Uses `matches` to assert the ok event was pruned (body_contains can't negate).
+    let retry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(retry_body_only_contains_retry_event);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(retry_resp);
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture_batch(vec![event1, event2], false).await;
+
+    assert!(result.is_ok());
+    first_mock.assert();
+    retry_mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_does_not_retry_terminal_results() {
+    let server = MockServer::start();
+
+    let mut ev_ok = Event::new("ev_ok", "user-1");
+    let mut ev_drop = Event::new("ev_drop", "user-1");
+    let mut ev_warning = Event::new("ev_warning", "user-1");
+
+    let uuid_ok = uuid::Uuid::now_v7();
+    let uuid_drop = uuid::Uuid::now_v7();
+    let uuid_warning = uuid::Uuid::now_v7();
+    ev_ok.set_uuid(uuid_ok);
+    ev_drop.set_uuid(uuid_drop);
+    ev_warning.set_uuid(uuid_warning);
+
+    let resp = json!({
+        "results": {
+            uuid_ok.to_string(): { "result": "ok" },
+            uuid_drop.to_string(): { "result": "drop", "details": "billing_limit_exceeded" },
+            uuid_warning.to_string(): { "result": "warning", "details": "person_processing_disabled" }
+        }
+    });
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(resp);
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client
+        .capture_batch(vec![ev_ok, ev_drop, ev_warning], false)
+        .await;
+
+    assert!(result.is_ok());
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn v1_capture_whole_batch_resent_on_retryable_status() {
+    for status in [408u16, 500, 502, 503, 504] {
+        let server = MockServer::start();
+
+        let mut event1 = Event::new("event_1", "user-1");
+        let mut event2 = Event::new("event_2", "user-2");
+
+        let uuid1 = uuid::Uuid::now_v7();
+        let uuid2 = uuid::Uuid::now_v7();
+        event1.set_uuid(uuid1);
+        event2.set_uuid(uuid2);
+
+        let ts = "2024-01-01T00:00:00.000Z";
+        event1
+            .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            .unwrap();
+        event2
+            .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            .unwrap();
+
+        let uuid1_str = uuid1.to_string();
+        let uuid2_str = uuid2.to_string();
+
+        let fail_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "1");
+            then.status(status)
+                .header("content-type", "application/json")
+                .header("retry-after", "0")
+                .json_body(json!({
+                    "error": "server_error",
+                    "error_description": "transient"
+                }));
+        });
+
+        let success_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "2")
+                .body_contains(&uuid1_str)
+                .body_contains(&uuid2_str)
+                .body_contains(ts);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": {
+                        uuid1_str: { "result": "ok" },
+                        uuid2_str: { "result": "ok" }
+                    }
+                }));
+        });
+
+        let client = create_v1_client(server.base_url()).await;
+        let result = client.capture_batch(vec![event1, event2], false).await;
+
+        assert!(
+            result.is_ok(),
+            "status {} should retry then succeed",
+            status
+        );
+        fail_mock.assert();
+        success_mock.assert();
+    }
+}
+
+#[tokio::test]
+async fn v1_capture_partial_retry_exhausts_attempts() {
+    let server = MockServer::start();
+
+    let mut event = Event::new("test", "user-1");
+    let uuid = uuid::Uuid::now_v7();
+    event.set_uuid(uuid);
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "results": {
+                    uuid.to_string(): { "result": "retry", "details": "not_persisted" }
+                }
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(event).await;
+
+    // 200 path returns Ok even when retries are exhausted.
+    assert!(result.is_ok());
+    mock.assert_hits(3);
+}
+
+#[tokio::test]
+async fn v1_capture_exhausts_retries() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(500)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": "internal_error",
+                "error_description": "Internal Server Error"
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture(Event::new("test", "user-1")).await;
+
+    assert!(result.is_err());
+    mock.assert_hits(3);
+}
+
+#[tokio::test]
+async fn v1_capture_sends_event_options() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"cookieless_mode\":true")
+            .body_contains("\"process_person_profile\":false");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {}
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test", "user-1");
+    event.set_option("cookieless_mode", true).unwrap();
+    event.set_option("process_person_profile", false).unwrap();
+
+    client.capture(event).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_injects_geoip_disable_when_configured() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$geoip_disable\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .disable_geoip(true)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_injects_is_server_by_default() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$is_server\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_caller_override_wins_for_is_server() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$is_server\":false");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test", "user-1");
+    event.insert_prop("$is_server", false).unwrap();
+    client.capture(event).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_batch_sets_historical_migration() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"historical_migration\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let events = vec![Event::new("a", "user-1"), Event::new("b", "user-1")];
+    client.capture_batch(events, true).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_preserves_uuid_and_timestamp_across_retries() {
+    let server = MockServer::start();
+    let uuid = uuid::Uuid::now_v7();
+    let ts = "2024-01-01T00:00:00.000Z";
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(uuid.to_string())
+            .body_contains(ts);
+        then.status(503)
+            .header("retry-after", "0")
+            .json_body(json!({ "error": "service_unavailable" }));
+    });
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .body_contains(uuid.to_string())
+            .body_contains(ts);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test", "user-1");
+    event.set_uuid(uuid);
+    event
+        .set_timestamp(chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z").unwrap())
+        .unwrap();
+
+    client.capture(event).await.unwrap();
+    fail_mock.assert();
+    success_mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_sends_gzip_content_encoding() {
+    use posthog_rs::CaptureCompression;
+
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("content-encoding", "gzip");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .capture_compression(CaptureCompression::Gzip)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_prunes_terminal_events_on_partial_retry() {
+    let server = MockServer::start();
+
+    let mut ev_retry = Event::new("ev_retry", "user-1");
+    let mut ev_drop = Event::new("ev_drop", "user-1");
+
+    let uuid_retry = uuid::Uuid::parse_str(PARTIAL_UUID_RETRY).unwrap();
+    let uuid_drop = uuid::Uuid::parse_str(PARTIAL_UUID_DROP).unwrap();
+    ev_retry.set_uuid(uuid_retry);
+    ev_drop.set_uuid(uuid_drop);
+
+    let first_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "retry", "details": "not_persisted" },
+            PARTIAL_UUID_DROP: { "result": "drop", "details": "billing_limit_exceeded" }
+        }
+    });
+
+    let retry_resp = json!({
+        "results": {
+            PARTIAL_UUID_RETRY: { "result": "ok" }
+        }
+    });
+
+    let first_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .body_contains(PARTIAL_UUID_RETRY)
+            .body_contains(PARTIAL_UUID_DROP);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(first_resp);
+    });
+
+    let retry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(retry_body_prunes_terminal_events);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(retry_resp);
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture_batch(vec![ev_retry, ev_drop], false).await;
+
+    assert!(result.is_ok());
+    first_mock.assert();
+    retry_mock.assert();
+}
+
+static CAPTURED_REQUEST_IDS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+fn capture_request_id(req: &HttpMockRequest) -> bool {
+    if let Some(headers) = req.headers.as_ref() {
+        for (key, value) in headers {
+            if key.eq_ignore_ascii_case("posthog-request-id") {
+                CAPTURED_REQUEST_IDS.lock().unwrap().push(value.clone());
+                break;
+            }
+        }
+    }
+    true
+}
+
+#[tokio::test]
+async fn v1_capture_request_id_stable_across_retries() {
+    CAPTURED_REQUEST_IDS.lock().unwrap().clear();
+
+    let server = MockServer::start();
+
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1")
+            .matches(capture_request_id);
+        then.status(503)
+            .header("content-type", "application/json")
+            .header("retry-after", "0")
+            .json_body(json!({
+                "error": "service_unavailable",
+                "error_description": "transient"
+            }));
+    });
+
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2")
+            .matches(capture_request_id);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+
+    fail_mock.assert();
+    success_mock.assert();
+
+    let ids = CAPTURED_REQUEST_IDS.lock().unwrap();
+    assert_eq!(ids.len(), 2, "expected exactly 2 captured request-ids");
+    assert_eq!(
+        ids[0], ids[1],
+        "posthog-request-id must be stable across retries"
+    );
+}
+
+#[tokio::test]
+async fn v1_capture_disabled_client_noop() {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test".to_string())
+        .disabled(true)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    let result = client.capture(Event::new("test", "user-1")).await;
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Updates the SDK test harness adapter to use the V1 capture API and enables the `capture-v1` feature, plus a CI step that runs the workspace tests.

Stacked on #119.