### PR TITLE
docs: improve public API documentation

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -201,7 +201,21 @@ fn pct(s: &str) -> String {
         .replace(';', "%3B")
 }
 
-/// This function constructs a new client using the options provided.
+/// Construct an async PostHog client from an API key or [`ClientOptions`].
+///
+/// # Parameters
+///
+/// - `options`: Either a project API key (for example `"phc_..."`) or a
+///   configured [`ClientOptions`] value.
+///
+/// # Returns
+///
+/// A [`Client`] that performs capture and feature flag requests asynchronously.
+///
+/// # Remarks
+///
+/// This constructor is available with the default `async-client` feature and
+/// must be awaited. Passing a blank API key creates a disabled client.
 pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
     let options = options.into().sanitize();
     let client = HttpClient::builder()
@@ -246,6 +260,22 @@ pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
 
 impl Client {
     /// Capture the provided event, sending it to PostHog.
+    ///
+    /// # Parameters
+    ///
+    /// - `event`: Event name, distinct ID, properties, timestamp, groups, and
+    ///   optional feature flag state to send.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if the event cannot be serialized,
+    /// [`Error::Connection`] for transport or unexpected HTTP failures,
+    /// [`Error::RateLimit`] for HTTP 429, [`Error::BadRequest`] for HTTP 400 or
+    /// 413, and [`Error::ServerError`] for HTTP 5xx.
+    ///
+    /// # Remarks
+    ///
+    /// Disabled clients skip the request and return `Ok(())`.
     #[instrument(skip(self, event), level = "debug")]
     pub async fn capture(&self, mut event: Event) -> Result<(), Error> {
         if self.options.is_disabled() {
@@ -277,9 +307,19 @@ impl Client {
         check_response(response).await
     }
 
-    /// Capture a collection of events with a single request. Events are sent to
-    /// the `/batch/` endpoint. Set `historical_migration` to `true` to route
-    /// events to the historical ingestion topic, bypassing the main pipeline.
+    /// Capture a collection of events with a single request.
+    ///
+    /// Events are sent to the `/batch/` endpoint.
+    ///
+    /// # Parameters
+    ///
+    /// - `events`: Events to send in the batch.
+    /// - `historical_migration`: Set to `true` to route events to the
+    ///   historical ingestion topic, bypassing the main pipeline.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same error categories as [`Client::capture`].
     pub async fn capture_batch(
         &self,
         events: Vec<Event>,
@@ -321,7 +361,31 @@ impl Client {
         check_response(response).await
     }
 
-    /// Get all feature flags for a user
+    /// Get all remote feature flags and payloads for a user.
+    ///
+    /// For new code, prefer [`Client::evaluate_flags`] so flag reads are
+    /// deduplicated and can be attached to captured events with
+    /// [`Event::with_flags`](crate::Event::with_flags).
+    ///
+    /// # Parameters
+    ///
+    /// - `distinct_id`: User distinct ID.
+    /// - `groups`: Optional group keys for group-targeted flags.
+    /// - `person_properties`: Optional person properties for release
+    ///   conditions.
+    /// - `group_properties`: Optional group properties for group-targeted
+    ///   release conditions.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(feature_flags, feature_flag_payloads)`, each keyed by flag
+    /// key. Disabled clients return two empty maps.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Connection`] for request failures or non-success HTTP
+    /// statuses, and [`Error::Serialization`] when the response cannot be
+    /// parsed.
     #[must_use = "feature flags result should be used"]
     pub async fn get_feature_flags<S: Into<String>>(
         &self,
@@ -396,6 +460,25 @@ impl Client {
     }
 
     /// Get a specific feature flag value for a user.
+    ///
+    /// # Parameters
+    ///
+    /// - `key`: Feature flag key.
+    /// - `distinct_id`: User distinct ID.
+    /// - `groups`: Optional group keys for group-targeted flags.
+    /// - `person_properties`: Optional person properties for release
+    ///   conditions.
+    /// - `group_properties`: Optional group properties for group-targeted
+    ///   release conditions.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(value))` when the flag is returned, `Ok(None)` when it is not
+    /// returned or local-only evaluation cannot resolve it.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from remote `/flags` requests or response parsing.
     #[must_use = "feature flag result should be used"]
     #[instrument(skip_all, level = "debug")]
     #[deprecated(
@@ -461,6 +544,15 @@ impl Client {
     }
 
     /// Check if a feature flag is enabled for a user.
+    ///
+    /// # Returns
+    ///
+    /// `true` for `FlagValue::Boolean(true)` or any multivariate variant,
+    /// `false` for disabled or missing flags.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from [`Client::get_feature_flag`].
     #[must_use = "feature flag enabled check result should be used"]
     #[deprecated(
         since = "0.6.0",
@@ -494,6 +586,21 @@ impl Client {
     }
 
     /// Get a feature flag payload for a user.
+    ///
+    /// # Parameters
+    ///
+    /// - `key`: Feature flag key.
+    /// - `distinct_id`: User distinct ID.
+    ///
+    /// # Returns
+    ///
+    /// The JSON payload for the flag, if one was returned. This method does not
+    /// emit `$feature_flag_called` events.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Connection`] for request failures and
+    /// [`Error::Serialization`] when the response cannot be parsed.
     #[must_use = "feature flag payload result should be used"]
     #[deprecated(
         since = "0.6.0",
@@ -550,10 +657,25 @@ impl Client {
         Ok(payloads.get(&key_str).cloned())
     }
 
-    /// Evaluate a feature flag locally (requires feature flags to be loaded).
+    /// Evaluate a supplied feature flag definition locally.
     ///
     /// `groups` and `group_properties` are only consulted when the flag (or one
     /// of its conditions) targets a group; pass empty maps for person flags.
+    ///
+    /// # Parameters
+    ///
+    /// - `flag`: Feature flag definition to evaluate.
+    /// - `distinct_id`: User distinct ID.
+    /// - `person_properties`: Person properties available to release
+    ///   conditions.
+    /// - `groups`: Group keys for group-targeted flags.
+    /// - `group_properties`: Group properties for group-targeted release
+    ///   conditions.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InconclusiveMatch`] when the flag cannot be evaluated
+    /// locally with the supplied context.
     #[allow(clippy::too_many_arguments)]
     pub fn evaluate_feature_flag_locally(
         &self,
@@ -579,14 +701,26 @@ impl Client {
         .map_err(|e| Error::InconclusiveMatch(e.message))
     }
 
-    /// Evaluate every feature flag for `distinct_id` in a single round-trip,
-    /// returning a [`FeatureFlagEvaluations`] snapshot.
+    /// Evaluate feature flags for `distinct_id`, returning a
+    /// [`FeatureFlagEvaluations`] snapshot.
     ///
     /// Each `is_enabled` / `get_flag` call on the returned snapshot fires a
     /// dedup-aware `$feature_flag_called` event with full metadata, and the
     /// snapshot can be passed to [`Event::with_flags`] so a downstream
     /// [`Client::capture`] inherits `$feature/<key>` and `$active_feature_flags`
     /// without an extra `/flags` request.
+    ///
+    /// # Parameters
+    ///
+    /// - `distinct_id`: User distinct ID. Empty values return an empty snapshot.
+    /// - `options`: Optional groups, properties, GeoIP override, local-only
+    ///   mode, and flag-key filtering.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Connection`] or [`Error::Serialization`] when remote
+    /// evaluation is required and the `/flags` request fails before any local
+    /// results are available.
     ///
     /// [`Event::with_flags`]: crate::Event::with_flags
     pub async fn evaluate_flags<S: Into<String>>(

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -185,7 +185,21 @@ fn pct(s: &str) -> String {
         .replace(';', "%3B")
 }
 
-/// This function constructs a new client using the options provided.
+/// Construct a blocking PostHog client from an API key or [`ClientOptions`].
+///
+/// # Parameters
+///
+/// - `options`: Either a project API key (for example `"phc_..."`) or a
+///   configured [`ClientOptions`] value.
+///
+/// # Returns
+///
+/// A [`Client`] that performs capture and feature flag requests synchronously.
+///
+/// # Remarks
+///
+/// Passing a blank API key creates a disabled client. Enable the default
+/// `async-client` feature to use the async client instead.
 pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
     let options = options.into().sanitize();
     let client = HttpClient::builder()
@@ -230,6 +244,22 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
 
 impl Client {
     /// Capture the provided event, sending it to PostHog.
+    ///
+    /// # Parameters
+    ///
+    /// - `event`: Event name, distinct ID, properties, timestamp, groups, and
+    ///   optional feature flag state to send.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if the event cannot be serialized,
+    /// [`Error::Connection`] for transport or unexpected HTTP failures,
+    /// [`Error::RateLimit`] for HTTP 429, [`Error::BadRequest`] for HTTP 400 or
+    /// 413, and [`Error::ServerError`] for HTTP 5xx.
+    ///
+    /// # Remarks
+    ///
+    /// Disabled clients skip the request and return `Ok(())`.
     #[instrument(skip(self, event), level = "debug")]
     pub fn capture(&self, mut event: Event) -> Result<(), Error> {
         if self.options.is_disabled() {
@@ -259,9 +289,19 @@ impl Client {
         check_response(response)
     }
 
-    /// Capture a collection of events with a single request. Events are sent to
-    /// the `/batch/` endpoint. Set `historical_migration` to `true` to route
-    /// events to the historical ingestion topic, bypassing the main pipeline.
+    /// Capture a collection of events with a single request.
+    ///
+    /// Events are sent to the `/batch/` endpoint.
+    ///
+    /// # Parameters
+    ///
+    /// - `events`: Events to send in the batch.
+    /// - `historical_migration`: Set to `true` to route events to the
+    ///   historical ingestion topic, bypassing the main pipeline.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same error categories as [`Client::capture`].
     #[instrument(skip(self, events), fields(event_count = events.len()), level = "debug")]
     pub fn capture_batch(
         &self,
@@ -304,7 +344,31 @@ impl Client {
         check_response(response)
     }
 
-    /// Get all feature flags for a user
+    /// Get all remote feature flags and payloads for a user.
+    ///
+    /// For new code, prefer [`Client::evaluate_flags`] so flag reads are
+    /// deduplicated and can be attached to captured events with
+    /// [`Event::with_flags`](crate::Event::with_flags).
+    ///
+    /// # Parameters
+    ///
+    /// - `distinct_id`: User distinct ID.
+    /// - `groups`: Optional group keys for group-targeted flags.
+    /// - `person_properties`: Optional person properties for release
+    ///   conditions.
+    /// - `group_properties`: Optional group properties for group-targeted
+    ///   release conditions.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(feature_flags, feature_flag_payloads)`, each keyed by flag
+    /// key. Disabled clients return two empty maps.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Connection`] for request failures or non-success HTTP
+    /// statuses, and [`Error::Serialization`] when the response cannot be
+    /// parsed.
     #[must_use = "feature flags result should be used"]
     pub fn get_feature_flags<S: Into<String>>(
         &self,
@@ -377,6 +441,25 @@ impl Client {
     }
 
     /// Get a specific feature flag value for a user.
+    ///
+    /// # Parameters
+    ///
+    /// - `key`: Feature flag key.
+    /// - `distinct_id`: User distinct ID.
+    /// - `groups`: Optional group keys for group-targeted flags.
+    /// - `person_properties`: Optional person properties for release
+    ///   conditions.
+    /// - `group_properties`: Optional group properties for group-targeted
+    ///   release conditions.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(value))` when the flag is returned, `Ok(None)` when it is not
+    /// returned or local-only evaluation cannot resolve it.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from remote `/flags` requests or response parsing.
     #[must_use = "feature flag result should be used"]
     #[instrument(skip_all, level = "debug")]
     #[deprecated(
@@ -441,6 +524,15 @@ impl Client {
     }
 
     /// Check if a feature flag is enabled for a user.
+    ///
+    /// # Returns
+    ///
+    /// `true` for `FlagValue::Boolean(true)` or any multivariate variant,
+    /// `false` for disabled or missing flags.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from [`Client::get_feature_flag`].
     #[must_use = "feature flag enabled check result should be used"]
     #[deprecated(
         since = "0.6.0",
@@ -472,6 +564,21 @@ impl Client {
     }
 
     /// Get a feature flag payload for a user.
+    ///
+    /// # Parameters
+    ///
+    /// - `key`: Feature flag key.
+    /// - `distinct_id`: User distinct ID.
+    ///
+    /// # Returns
+    ///
+    /// The JSON payload for the flag, if one was returned. This method does not
+    /// emit `$feature_flag_called` events.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Connection`] for request failures and
+    /// [`Error::Serialization`] when the response cannot be parsed.
     #[must_use = "feature flag payload result should be used"]
     #[deprecated(
         since = "0.6.0",
@@ -526,10 +633,25 @@ impl Client {
         Ok(payloads.get(&key_str).cloned())
     }
 
-    /// Evaluate a feature flag locally (requires feature flags to be loaded).
+    /// Evaluate a supplied feature flag definition locally.
     ///
     /// `groups` and `group_properties` are only consulted when the flag (or one
     /// of its conditions) targets a group; pass empty maps for person flags.
+    ///
+    /// # Parameters
+    ///
+    /// - `flag`: Feature flag definition to evaluate.
+    /// - `distinct_id`: User distinct ID.
+    /// - `person_properties`: Person properties available to release
+    ///   conditions.
+    /// - `groups`: Group keys for group-targeted flags.
+    /// - `group_properties`: Group properties for group-targeted release
+    ///   conditions.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InconclusiveMatch`] when the flag cannot be evaluated
+    /// locally with the supplied context.
     #[allow(clippy::too_many_arguments)]
     pub fn evaluate_feature_flag_locally(
         &self,
@@ -555,14 +677,26 @@ impl Client {
         .map_err(|e| Error::InconclusiveMatch(e.message))
     }
 
-    /// Evaluate every feature flag for `distinct_id` in a single round-trip,
-    /// returning a [`FeatureFlagEvaluations`] snapshot.
+    /// Evaluate feature flags for `distinct_id`, returning a
+    /// [`FeatureFlagEvaluations`] snapshot.
     ///
     /// Each `is_enabled` / `get_flag` call on the returned snapshot fires a
     /// dedup-aware `$feature_flag_called` event with full metadata, and the
     /// snapshot can be passed to [`Event::with_flags`] so a downstream
     /// [`Client::capture`] inherits `$feature/<key>` and `$active_feature_flags`
     /// without an extra `/flags` request.
+    ///
+    /// # Parameters
+    ///
+    /// - `distinct_id`: User distinct ID. Empty values return an empty snapshot.
+    /// - `options`: Optional groups, properties, GeoIP override, local-only
+    ///   mode, and flag-key filtering.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Connection`] or [`Error::Serialization`] when remote
+    /// evaluation is required and the `/flags` request fails before any local
+    /// results are available.
     ///
     /// [`Event::with_flags`]: crate::Event::with_flags
     pub fn evaluate_flags<S: Into<String>>(

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,8 +18,9 @@ pub use async_client::Client;
 
 /// Configuration options for the PostHog client.
 ///
-/// Use [`ClientOptionsBuilder`] to construct options with custom settings,
-/// or create directly from an API key using `ClientOptions::from("your-api-key")`.
+/// Use [`ClientOptionsBuilder`] to construct options with custom settings, or
+/// create options directly from a project API key with
+/// `ClientOptions::from("your-api-key")`.
 ///
 /// # Example
 ///
@@ -27,7 +28,7 @@ pub use async_client::Client;
 /// use posthog_rs::ClientOptionsBuilder;
 ///
 /// let options = ClientOptionsBuilder::default()
-///     .api_key("your-api-key".to_string())
+///     .api_key("your-project-api-key".to_string())
 ///     .host("https://eu.posthog.com")
 ///     .build()
 ///     .unwrap();
@@ -35,39 +36,46 @@ pub use async_client::Client;
 #[derive(Builder, Clone)]
 #[builder(build_fn(name = "build_unchecked", private))]
 pub struct ClientOptions {
-    /// Host URL for the PostHog API (defaults to US ingestion endpoint)
+    /// Host URL for the PostHog API. Defaults to the US ingestion endpoint.
+    /// App hosts such as `https://eu.posthog.com` are normalized to ingestion
+    /// hosts before requests are sent.
     #[builder(setter(into, strip_option), default)]
     host: Option<String>,
 
-    /// Project API key. If missing or blank, the client is disabled.
+    /// PostHog project API key (project token). If missing or blank, the client
+    /// is disabled.
     #[builder(default)]
     api_key: String,
 
-    /// Request timeout in seconds
+    /// Request timeout in seconds for capture, batch, and local evaluation
+    /// definition requests. Defaults to `30`.
     #[builder(default = "30")]
     request_timeout_seconds: u64,
 
-    /// Personal API key for fetching flag definitions (required for local evaluation)
+    /// Personal API key for fetching flag definitions. Required when
+    /// `enable_local_evaluation` is `true`.
     #[builder(setter(into, strip_option), default)]
     personal_api_key: Option<String>,
 
-    /// Enable local evaluation of feature flags
+    /// Enable local evaluation of feature flags using a background definitions
+    /// poller.
     #[builder(default = "false")]
     enable_local_evaluation: bool,
 
-    /// Interval for polling flag definitions (in seconds)
+    /// Interval for polling flag definitions, in seconds. Defaults to `30`.
     #[builder(default = "30")]
     poll_interval_seconds: u64,
 
-    /// Disable tracking (useful for development)
+    /// Disable tracking and remote flag requests. Useful for development and
+    /// tests.
     #[builder(default = "false")]
     disabled: bool,
 
-    /// Disable automatic geoip enrichment
+    /// Disable automatic GeoIP enrichment for capture and flag requests.
     #[builder(default = "false")]
     disable_geoip: bool,
 
-    /// Feature flags request timeout in seconds
+    /// Timeout in seconds for remote `/flags` requests. Defaults to `3`.
     #[builder(default = "3")]
     feature_flags_request_timeout_seconds: u64,
 
@@ -89,7 +97,10 @@ impl ClientOptions {
         &self.endpoint_manager
     }
 
-    /// Check if the client is disabled
+    /// Check whether the client is disabled.
+    ///
+    /// A client is disabled when configured with `disabled(true)` or when the
+    /// project API key is missing or blank after trimming.
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
@@ -134,12 +145,18 @@ impl ClientOptionsBuilder {
     /// Missing or whitespace-only API keys are allowed and disable the client so
     /// SDK initialization remains infallible while avoiding requests with an
     /// empty API key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientOptionsBuilderError`] if a required builder value is
+    /// invalid according to the generated builder.
     pub fn build(&self) -> Result<ClientOptions, ClientOptionsBuilderError> {
         Ok(self.build_unchecked()?.sanitize())
     }
 }
 
 impl From<&str> for ClientOptions {
+    /// Create options from a PostHog project API key.
     fn from(api_key: &str) -> Self {
         ClientOptionsBuilder::default()
             .api_key(api_key.to_string())
@@ -149,7 +166,7 @@ impl From<&str> for ClientOptions {
 }
 
 impl From<(&str, &str)> for ClientOptions {
-    /// Create options from API key and host
+    /// Create options from a PostHog project API key and host URL.
     fn from((api_key, host): (&str, &str)) -> Self {
         ClientOptionsBuilder::default()
             .api_key(api_key.to_string())

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -3,13 +3,13 @@ use std::fmt;
 /// US ingestion endpoint
 pub const US_INGESTION_ENDPOINT: &str = "https://us.i.posthog.com";
 
-/// EU ingestion endpoint  
+/// EU ingestion endpoint
 pub const EU_INGESTION_ENDPOINT: &str = "https://eu.i.posthog.com";
 
 /// Default host (US by default)
 pub const DEFAULT_HOST: &str = US_INGESTION_ENDPOINT;
 
-/// API endpoints for different operations
+/// API endpoints used by the SDK for different operations.
 #[derive(Debug, Clone)]
 pub enum Endpoint {
     /// Event capture endpoint
@@ -23,7 +23,7 @@ pub enum Endpoint {
 }
 
 impl Endpoint {
-    /// Get the path for this endpoint
+    /// Get the URL path for this endpoint.
     pub fn path(&self) -> &str {
         match self {
             Endpoint::Capture => "/i/v0/e/",
@@ -40,7 +40,11 @@ impl fmt::Display for Endpoint {
     }
 }
 
-/// Manages PostHog API endpoints and host configuration
+/// Manages PostHog API endpoints and host configuration.
+///
+/// This low-level helper normalizes app hosts such as
+/// `https://us.posthog.com` to ingestion hosts such as
+/// [`US_INGESTION_ENDPOINT`].
 #[derive(Debug, Clone)]
 pub struct EndpointManager {
     base_host: String,
@@ -48,7 +52,10 @@ pub struct EndpointManager {
 }
 
 impl EndpointManager {
-    /// Create a new endpoint manager with the given normalized host
+    /// Create a new endpoint manager for `host`.
+    ///
+    /// `host` may be an app host (for example `https://eu.posthog.com`), an
+    /// ingestion host, or a custom reverse-proxy host.
     pub fn new(host: String) -> Self {
         let base_host = Self::determine_server_host(&host);
 
@@ -58,8 +65,11 @@ impl EndpointManager {
         }
     }
 
-    /// Determine the actual server host based on the provided normalized host
-    /// Similar to posthog-python's determine_server_host function
+    /// Determine the ingestion host used for API calls.
+    ///
+    /// Maps PostHog app hosts to their ingestion equivalents and removes a
+    /// trailing slash. Custom hosts are returned unchanged except for the
+    /// trailing slash.
     pub fn determine_server_host(host: &str) -> String {
         let trimmed_host = host.trim_end_matches('/');
 
@@ -72,17 +82,17 @@ impl EndpointManager {
         }
     }
 
-    /// Get the base host URL (for constructing endpoints)
+    /// Get the normalized base host URL used for API calls.
     pub fn base_host(&self) -> &str {
         &self.base_host
     }
 
-    /// Get the raw host (as provided by the user, used for session replay URLs)
+    /// Get the raw host as provided by the user.
     pub fn raw_host(&self) -> &str {
         &self.raw_host
     }
 
-    /// Build a full URL for a given endpoint
+    /// Build a full URL for a given SDK endpoint.
     pub fn build_url(&self, endpoint: Endpoint) -> String {
         format!(
             "{}{}",
@@ -91,7 +101,9 @@ impl EndpointManager {
         )
     }
 
-    /// Build a URL with a custom path
+    /// Build a URL with a custom path relative to the base host.
+    ///
+    /// The path may be passed with or without a leading `/`.
     pub fn build_custom_url(&self, path: &str) -> String {
         let normalized_path = if path.starts_with('/') {
             path.to_string()
@@ -105,7 +117,10 @@ impl EndpointManager {
         )
     }
 
-    /// Build the local evaluation URL with a token
+    /// Build the local evaluation definitions URL with a project token.
+    ///
+    /// The token is included as a query parameter, so avoid logging this URL in
+    /// production diagnostics.
     pub fn build_local_eval_url(&self, token: &str) -> String {
         format!(
             "{}/flags/definitions/?token={}&send_cohorts",
@@ -114,7 +129,7 @@ impl EndpointManager {
         )
     }
 
-    /// Get the base host for API operations (without the path)
+    /// Get the base host for API operations without a trailing slash or path.
     pub fn api_host(&self) -> String {
         self.base_host.trim_end_matches('/').to_string()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,12 @@ pub enum Error {
     /// HTTP 400 or 413 — the request was malformed or too large
     BadRequest(String),
     /// HTTP 5xx — the server encountered an error
-    ServerError { status: u16, message: String },
+    ServerError {
+        /// HTTP status code returned by the server.
+        status: u16,
+        /// Response body or error message returned by the server.
+        message: String,
+    },
 }
 
 impl Error {

--- a/src/event.rs
+++ b/src/event.rs
@@ -24,8 +24,15 @@ pub struct Event {
 }
 
 impl Event {
-    /// Capture a new identified [`Event`]. Unless you have a distinct ID you can
-    /// associate with a user, you probably want to use [`new_anon`] instead.
+    /// Create a new identified [`Event`]. Unless you have a distinct ID you can
+    /// associate with a user, you probably want to use [`Event::new_anon`]
+    /// instead.
+    ///
+    /// # Parameters
+    ///
+    /// - `event`: Event name, such as `"user_signed_up"`.
+    /// - `distinct_id`: Stable user or account identifier. For backend events,
+    ///   use the same distinct ID your frontend passes to `posthog.identify()`.
     pub fn new<S: Into<String>>(event: S, distinct_id: S) -> Self {
         Self {
             event: event.into(),
@@ -37,8 +44,18 @@ impl Event {
         }
     }
 
-    /// Capture a new anonymous event.
-    /// See https://posthog.com/docs/data/anonymous-vs-identified-events#how-to-capture-anonymous-events
+    /// Create a new anonymous event.
+    ///
+    /// See <https://posthog.com/docs/data/anonymous-vs-identified-events#how-to-capture-anonymous-events>.
+    ///
+    /// # Parameters
+    ///
+    /// - `event`: Event name.
+    ///
+    /// # Remarks
+    ///
+    /// Generates a random distinct ID and sets `$process_person_profile` to
+    /// `false` so PostHog does not create a person profile for the event.
     pub fn new_anon<S: Into<String>>(event: S) -> Self {
         let mut res = Self {
             event: event.into(),
@@ -53,9 +70,16 @@ impl Event {
         res
     }
 
-    /// Add a property to the event
+    /// Add a property to the event.
     ///
-    /// Errors if `prop` fails to serialize
+    /// # Parameters
+    ///
+    /// - `key`: Property name.
+    /// - `prop`: Any value that can be serialized to JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if `prop` cannot be serialized.
     pub fn insert_prop<K: Into<String>, P: Serialize>(
         &mut self,
         key: K,
@@ -67,9 +91,20 @@ impl Event {
         Ok(())
     }
 
-    /// Capture this as a group event. See https://posthog.com/docs/product-analytics/group-analytics#how-to-capture-group-events
-    /// Note that group events cannot be personless, and will be automatically upgraded to include person profile processing if
-    /// they were anonymous. This might lead to "empty" person profiles being created.
+    /// Capture this as a group event.
+    ///
+    /// See <https://posthog.com/docs/product-analytics/group-analytics#how-to-capture-group-events>.
+    ///
+    /// # Parameters
+    ///
+    /// - `group_name`: Group type, such as `"company"`.
+    /// - `group_id`: Stable identifier for the group.
+    ///
+    /// # Remarks
+    ///
+    /// Group events cannot be personless, and will be automatically upgraded to
+    /// include person profile processing if they were anonymous. This might lead
+    /// to "empty" person profiles being created.
     pub fn add_group(&mut self, group_name: &str, group_id: &str) {
         // You cannot disable person profile processing for groups
         self.insert_prop("$process_person_profile", true)
@@ -79,7 +114,14 @@ impl Event {
 
     /// Set the event timestamp, for events that happened in the past.
     ///
-    /// Errors if the timestamp is in the future.
+    /// # Parameters
+    ///
+    /// - `timestamp`: Timestamp to send with the event. It is converted to UTC
+    ///   before serialization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidTimestamp`] if the timestamp is in the future.
     pub fn set_timestamp<Tz>(&mut self, timestamp: DateTime<Tz>) -> Result<(), Error>
     where
         Tz: TimeZone,
@@ -93,17 +135,24 @@ impl Event {
         Ok(())
     }
 
-    /// Override the auto-generated UUID for this event. Useful for
-    /// deduplication when re-importing historical data.
+    /// Override the auto-generated UUID for this event.
+    ///
+    /// Useful for deduplication when re-importing historical data.
     pub fn set_uuid(&mut self, uuid: Uuid) {
         self.uuid = uuid;
     }
 
     /// Attach the flag state captured by a [`FeatureFlagEvaluations`] snapshot
-    /// to this event. Adds `$feature/<key>` for every evaluated flag plus a
-    /// sorted `$active_feature_flags` list of enabled keys, mirroring what
+    /// to this event.
+    ///
+    /// Adds `$feature/<key>` for every evaluated flag plus a sorted
+    /// `$active_feature_flags` list of enabled keys, mirroring what
     /// `send_feature_flags` would otherwise fetch — but without making an
     /// extra `/flags` request.
+    ///
+    /// # Returns
+    ///
+    /// Returns `self` so calls can be chained before capture.
     pub fn with_flags(&mut self, flags: &FeatureFlagEvaluations) -> &mut Self {
         for (key, value) in flags.event_properties() {
             self.properties.insert(key, value);

--- a/src/feature_flag_evaluations.rs
+++ b/src/feature_flag_evaluations.rs
@@ -56,10 +56,23 @@ pub(crate) trait FeatureFlagEvaluationsHost: Send + Sync {
 /// Optional inputs for [`Client::evaluate_flags`](crate::Client::evaluate_flags).
 #[derive(Default, Clone, Debug)]
 pub struct EvaluateFlagsOptions {
+    /// Group keys for group-targeted feature flags, keyed by group type (for
+    /// example `{ "company": "company_123" }`). These groups are also
+    /// attached to `$feature_flag_called` events emitted by the returned
+    /// snapshot.
     pub groups: Option<HashMap<String, String>>,
+    /// Person properties used by remote or local flag evaluation. Provide any
+    /// properties referenced by release conditions when using local evaluation.
     pub person_properties: Option<HashMap<String, Value>>,
+    /// Group properties used by group-targeted or mixed-targeting flags, keyed
+    /// first by group type and then by property name.
     pub group_properties: Option<HashMap<String, HashMap<String, Value>>>,
+    /// When `true`, skip the remote `/flags` request and return only locally
+    /// evaluated results. If local evaluation is not configured, the snapshot is
+    /// empty.
     pub only_evaluate_locally: bool,
+    /// Per-call override for GeoIP behavior on `/flags` and
+    /// `$feature_flag_called` requests. `None` uses the client-level setting.
     pub disable_geoip: Option<bool>,
     /// Optional list of flag keys. When provided, only these flags are
     /// evaluated — the underlying `/flags` request asks the server for just
@@ -141,13 +154,21 @@ impl FeatureFlagEvaluations {
 
     /// Whether `key` is enabled. Records the access and fires (deduplicated)
     /// `$feature_flag_called`.
+    ///
+    /// # Returns
+    ///
+    /// `true` for enabled boolean flags or matched multivariate variants, and
+    /// `false` for disabled or missing flags.
     #[must_use]
     pub fn is_enabled(&self, key: &str) -> bool {
         self.record_access(key);
         self.flags.get(key).is_some_and(|f| f.enabled)
     }
 
-    /// Look up the value of `key`. Returns:
+    /// Look up the value of `key`.
+    ///
+    /// # Returns
+    ///
     /// - `None` when the flag is not in the snapshot,
     /// - `Some(FlagValue::Boolean(false))` when disabled,
     /// - `Some(FlagValue::String(variant))` for a multivariate match,
@@ -161,8 +182,12 @@ impl FeatureFlagEvaluations {
         Some(flag_value_for(flag))
     }
 
-    /// Return the JSON payload associated with `key`, if any. This call does
-    /// **not** count as an access and does **not** fire any event.
+    /// Return the JSON payload associated with `key`, if any.
+    ///
+    /// # Remarks
+    ///
+    /// This call does **not** count as an access and does **not** fire any
+    /// event, matching the behavior documented for server-side SDKs.
     #[must_use]
     pub fn get_flag_payload(&self, key: &str) -> Option<Value> {
         self.flags.get(key).and_then(|f| f.payload.clone())
@@ -194,6 +219,9 @@ impl FeatureFlagEvaluations {
 
     /// A clone of the snapshot containing only the listed `keys` (preserving
     /// records). Unknown keys are dropped and surfaced via a single warning.
+    ///
+    /// Use this before [`Event::with_flags`](crate::Event::with_flags) to limit
+    /// the `$feature/<key>` properties attached to a captured event.
     #[must_use]
     pub fn only(&self, keys: &[&str]) -> Self {
         let mut filtered: HashMap<String, EvaluatedFlagRecord> = HashMap::new();

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -67,6 +67,7 @@ pub struct InconclusiveMatchError {
 }
 
 impl InconclusiveMatchError {
+    /// Create an inconclusive-match error with a human-readable message.
     pub fn new(message: &str) -> Self {
         Self {
             message: message.to_string(),
@@ -150,12 +151,15 @@ pub struct Property {
     pub key: String,
     /// The value to compare against
     pub value: serde_json::Value,
-    /// Comparison operator: "exact", "is_not", "icontains", "not_icontains",
-    /// "regex", "not_regex", "gt", "gte", "lt", "lte", "is_set", "is_not_set",
-    /// "is_date_before", "is_date_after"
+    /// Comparison operator. Supported property operators include `"exact"`,
+    /// `"is_not"`, `"icontains"`, `"not_icontains"`, `"regex"`,
+    /// `"not_regex"`, `"gt"`, `"gte"`, `"lt"`, `"lte"`, `"is_set"`,
+    /// `"is_not_set"`, `"is_date_before"`, `"is_date_after"`, and the
+    /// `"semver_*"` operators used by PostHog version targeting.
     #[serde(default = "default_operator")]
     pub operator: String,
-    /// Property type, e.g., "cohort" for cohort membership checks
+    /// Property type. Use `Some("cohort")` for cohort membership checks; flag
+    /// dependency checks use a property key that starts with `$feature/`.
     #[serde(rename = "type")]
     pub property_type: Option<String>,
 }
@@ -167,16 +171,22 @@ fn default_operator() -> String {
 /// Definition of a cohort for local evaluation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CohortDefinition {
+    /// Unique identifier for the cohort.
     pub id: String,
     /// Properties can be either:
     /// - A JSON object with "type" and "values" for complex property groups
-    /// - Or a direct Vec<Property> for simple cases
+    /// - Or a direct `Vec<Property>` for simple cases
     #[serde(default)]
     pub properties: serde_json::Value,
 }
 
 impl CohortDefinition {
-    /// Create a new cohort definition with simple property list
+    /// Create a new cohort definition with a simple property list.
+    ///
+    /// # Parameters
+    ///
+    /// - `id`: Cohort identifier.
+    /// - `properties`: Property filters that define cohort membership.
     pub fn new(id: String, properties: Vec<Property>) -> Self {
         Self {
             id,
@@ -184,9 +194,10 @@ impl CohortDefinition {
         }
     }
 
-    /// Parse the properties from the JSON structure
+    /// Parse the properties from the JSON structure.
+    ///
     /// PostHog cohort properties come in format:
-    /// {"type": "AND", "values": [{"type": "property", "key": "...", "value": "...", "operator": "..."}]}
+    /// `{"type": "AND", "values": [{"type": "property", "key": "...", "value": "...", "operator": "..."}]}`.
     pub fn parse_properties(&self) -> Vec<Property> {
         // If it's an array, treat it as direct property list
         if let Some(arr) = self.properties.as_array() {
@@ -236,11 +247,19 @@ impl CohortDefinition {
 /// is bucketed on the group key and matched against group properties looked up
 /// via the group type mapping.
 pub struct EvaluationContext<'a> {
+    /// Cohort definitions available to local evaluation, keyed by cohort ID.
     pub cohorts: &'a HashMap<String, CohortDefinition>,
+    /// Feature flag definitions available to evaluate flag dependencies, keyed
+    /// by flag key.
     pub flags: &'a HashMap<String, FeatureFlag>,
+    /// Distinct ID used for person-targeted flag bucketing.
     pub distinct_id: &'a str,
+    /// Group keys for group-targeted flags, keyed by group type.
     pub groups: &'a HashMap<String, String>,
+    /// Group properties for group-targeted flags, keyed by group type and then
+    /// property name.
     pub group_properties: &'a HashMap<String, HashMap<String, serde_json::Value>>,
+    /// Mapping from PostHog group type index to group type name.
     pub group_type_mapping: &'a HashMap<String, String>,
 }
 
@@ -303,7 +322,12 @@ pub enum FeatureFlagsResponse {
 }
 
 impl FeatureFlagsResponse {
-    /// Convert the response to a normalized format
+    /// Convert the response to normalized flag values and payloads.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(feature_flags, feature_flag_payloads)`, each keyed by flag
+    /// key.
     pub fn normalize(
         self,
     ) -> (
@@ -346,8 +370,8 @@ impl FeatureFlagsResponse {
 
 /// Detailed information about a feature flag evaluation result.
 ///
-/// Returned by the `/decide` endpoint with extended information about
-/// why a flag evaluated to a particular value.
+/// Returned by the `/flags/?v=2` endpoint with extended information about why a
+/// flag evaluated to a particular value.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlagDetail {
     /// The feature flag key
@@ -483,6 +507,29 @@ fn resolve_condition_target<'a>(
     }
 }
 
+/// Evaluate a feature flag definition against person and optional group
+/// context.
+///
+/// # Parameters
+///
+/// - `flag`: Feature flag definition to evaluate.
+/// - `distinct_id`: Distinct ID used for person bucketing.
+/// - `person_properties`: Person properties available to release conditions.
+/// - `groups`: Group keys for group-targeted flags, keyed by group type.
+/// - `group_properties`: Group properties for group-targeted flags.
+/// - `group_type_mapping`: Mapping from PostHog group type index to group type
+///   name.
+///
+/// # Returns
+///
+/// The matched flag value: `Boolean(false)` for inactive or unmatched flags,
+/// `Boolean(true)` for matched boolean flags, or `String(variant)` for matched
+/// multivariate flags.
+///
+/// # Errors
+///
+/// Returns [`InconclusiveMatchError`] when required properties are missing or an
+/// operator cannot be evaluated locally.
 #[must_use = "feature flag evaluation result should be used"]
 #[allow(clippy::too_many_arguments)]
 pub fn match_feature_flag(
@@ -590,12 +637,17 @@ fn is_condition_match(
     Ok(true)
 }
 
-/// Match a feature flag with full context (cohorts, other flags)
-/// This version supports cohort membership checks and flag dependency checks.
+/// Match a feature flag with full context (cohorts, other flags).
 ///
+/// This version supports cohort membership checks and flag dependency checks.
 /// `person_properties` carries person-level property values; group-level
 /// properties are looked up from `ctx.group_properties` when a condition (or
 /// the flag itself) targets a group via `aggregation_group_type_index`.
+///
+/// # Errors
+///
+/// Returns [`InconclusiveMatchError`] when local evaluation cannot determine a
+/// result with the provided context.
 #[must_use = "feature flag evaluation result should be used"]
 pub fn match_feature_flag_with_context(
     flag: &FeatureFlag,
@@ -706,7 +758,16 @@ fn is_condition_match_with_context(
     Ok(true)
 }
 
-/// Match a property with additional context for cohorts and flag dependencies
+/// Match a property with additional context for cohorts and flag dependencies.
+///
+/// Use this when evaluating local feature flag conditions that can reference
+/// cohort membership (`type = "cohort"`) or another feature flag via
+/// `$feature/<flag-key>`.
+///
+/// # Errors
+///
+/// Returns [`InconclusiveMatchError`] when the property, cohort, or dependent
+/// flag cannot be evaluated from the supplied context.
 pub fn match_property_with_context(
     property: &Property,
     properties: &HashMap<String, serde_json::Value>,

--- a/src/global.rs
+++ b/src/global.rs
@@ -5,11 +5,19 @@ use crate::{client, Client, ClientOptions, Error, Event};
 static GLOBAL_CLIENT: OnceLock<Client> = OnceLock::new();
 static GLOBAL_DISABLE: OnceLock<bool> = OnceLock::new();
 
-/// [`init_global_client`] will initialize a globally available client singleton. This singleton
-/// can be used when you don't need more than one instance and have no need to regularly change
-/// the client options.
+/// Initialize the global client singleton.
+///
+/// Use the crate-level `init_global` re-export when you don't need more than
+/// one client instance and don't need to change client options at runtime.
+///
+/// # Parameters
+///
+/// - `options`: Project API key or [`ClientOptions`] used to construct the
+///   global client.
+///
 /// # Errors
-/// This function returns [`Error::AlreadyInitialized`] if called more than once.
+///
+/// Returns [`Error::AlreadyInitialized`] if called more than once.
 #[cfg(feature = "async-client")]
 pub async fn init_global_client<C: Into<ClientOptions>>(options: C) -> Result<(), Error> {
     if is_disabled() {
@@ -22,11 +30,19 @@ pub async fn init_global_client<C: Into<ClientOptions>>(options: C) -> Result<()
         .map_err(|_| Error::AlreadyInitialized)
 }
 
-/// [`init_global_client`] will initialize a globally available client singleton. This singleton
-/// can be used when you don't need more than one instance and have no need to regularly change
-/// the client options.
+/// Initialize the global client singleton.
+///
+/// Use the crate-level `init_global` re-export when you don't need more than
+/// one client instance and don't need to change client options at runtime.
+///
+/// # Parameters
+///
+/// - `options`: Project API key or [`ClientOptions`] used to construct the
+///   global client.
+///
 /// # Errors
-/// This function returns [`Error::AlreadyInitialized`] if called more than once.
+///
+/// Returns [`Error::AlreadyInitialized`] if called more than once.
 #[cfg(not(feature = "async-client"))]
 pub fn init_global_client<C: Into<ClientOptions>>(options: C) -> Result<(), Error> {
     if is_disabled() {
@@ -39,27 +55,43 @@ pub fn init_global_client<C: Into<ClientOptions>>(options: C) -> Result<(), Erro
         .map_err(|_| Error::AlreadyInitialized)
 }
 
-/// [`disable`] prevents the global client from being initialized.
-/// **NOTE:** It does *not* prevent use of the global client once initialized.
+/// Prevent the global client from being initialized.
+///
+/// # Remarks
+///
+/// This does *not* prevent use of a global client that was already initialized.
 pub fn disable() {
     let _ = GLOBAL_DISABLE.set(true);
 }
 
-/// [`is_disabled`] returns true if the global client has been disabled.
-/// **NOTE:** A disabled global client can still be used as long as it was
-/// initialized before it was disabled.
+/// Return `true` if global client initialization has been disabled.
+///
+/// # Remarks
+///
+/// A disabled global client can still be used if it was initialized before it
+/// was disabled.
 pub fn is_disabled() -> bool {
     *GLOBAL_DISABLE.get().unwrap_or(&false)
 }
 
-/// Capture the provided event, sending it to PostHog using the global client.
+/// Capture the provided event using the global client.
+///
+/// # Errors
+///
+/// Returns [`Error::NotInitialized`] if `init_global` has not successfully run,
+/// or any error returned by [`Client::capture`].
 #[cfg(feature = "async-client")]
 pub async fn capture(event: Event) -> Result<(), Error> {
     let client = GLOBAL_CLIENT.get().ok_or(Error::NotInitialized)?;
     client.capture(event).await
 }
 
-/// Capture the provided event, sending it to PostHog using the global client.
+/// Capture the provided event using the global client.
+///
+/// # Errors
+///
+/// Returns [`Error::NotInitialized`] if `init_global` has not successfully run,
+/// or any error returned by [`Client::capture`].
 #[cfg(not(feature = "async-client"))]
 pub fn capture(event: Event) -> Result<(), Error> {
     let client = GLOBAL_CLIENT.get().ok_or(Error::NotInitialized)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! Official Rust SDK for PostHog.
+//!
+//! Use [`client`] to construct a [`Client`], [`Event`] to capture analytics
+//! events, and [`Client::evaluate_flags`] with [`EvaluateFlagsOptions`] for
+//! feature flag evaluation.
+
 mod client;
 mod endpoints;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,45 @@
 //! Use [`client`] to construct a [`Client`], [`Event`] to capture analytics
 //! events, and [`Client::evaluate_flags`] with [`EvaluateFlagsOptions`] for
 //! feature flag evaluation.
-
+//!
+//! See the [PostHog Rust SDK documentation](https://posthog.com/docs/libraries/rust)
+//! for installation, configuration, and more examples.
+//!
+//! # Getting started
+//!
+//! Add `posthog-rs` to your `Cargo.toml`, then initialize a client with your
+//! project API key.
+//!
+//! ```no_run
+//! use posthog_rs::{client, EvaluateFlagsOptions, Event};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), posthog_rs::Error> {
+//!     let api_key = std::env::var("POSTHOG_API_KEY")
+//!         .expect("set POSTHOG_API_KEY to your PostHog project API key");
+//!
+//!     let posthog = client(api_key.as_str()).await;
+//!     let distinct_id = "user-123";
+//!
+//!     // Capture an analytics event.
+//!     let mut event = Event::new("signed_up", distinct_id);
+//!     event.insert_prop("plan", "pro")?;
+//!     posthog.capture(event).await?;
+//!
+//!     // Evaluate feature flags once, then read from the snapshot.
+//!     let flags = posthog
+//!         .evaluate_flags(distinct_id, EvaluateFlagsOptions::default())
+//!         .await?;
+//!
+//!     if flags.is_enabled("new-onboarding") {
+//!         let mut event = Event::new("onboarding_step_completed", distinct_id);
+//!         event.with_flags(&flags.only_accessed());
+//!         posthog.capture(event).await?;
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
 mod client;
 mod endpoints;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //! ```no_run
 //! use posthog_rs::{client, EvaluateFlagsOptions, Event};
 //!
+//! #[cfg(feature = "async-client")]
 //! #[tokio::main]
 //! async fn main() -> Result<(), posthog_rs::Error> {
 //!     let api_key = std::env::var("POSTHOG_API_KEY")
@@ -37,6 +38,31 @@
 //!         let mut event = Event::new("onboarding_step_completed", distinct_id);
 //!         event.with_flags(&flags.only_accessed());
 //!         posthog.capture(event).await?;
+//!     }
+//!
+//!     Ok(())
+//! }
+//!
+//! #[cfg(not(feature = "async-client"))]
+//! fn main() -> Result<(), posthog_rs::Error> {
+//!     let api_key = std::env::var("POSTHOG_API_KEY")
+//!         .expect("set POSTHOG_API_KEY to your PostHog project API key");
+//!
+//!     let posthog = client(api_key.as_str());
+//!     let distinct_id = "user-123";
+//!
+//!     // Capture an analytics event.
+//!     let mut event = Event::new("signed_up", distinct_id);
+//!     event.insert_prop("plan", "pro")?;
+//!     posthog.capture(event)?;
+//!
+//!     // Evaluate feature flags once, then read from the snapshot.
+//!     let flags = posthog.evaluate_flags(distinct_id, EvaluateFlagsOptions::default())?;
+//!
+//!     if flags.is_enabled("new-onboarding") {
+//!         let mut event = Event::new("onboarding_step_completed", distinct_id);
+//!         event.with_flags(&flags.only_accessed());
+//!         posthog.capture(event)?;
 //!     }
 //!
 //!     Ok(())

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -71,6 +71,7 @@ impl Default for FlagCache {
 }
 
 impl FlagCache {
+    /// Create an empty shared flag cache.
     pub fn new() -> Self {
         Self {
             flags: Arc::new(RwLock::new(HashMap::new())),
@@ -79,6 +80,8 @@ impl FlagCache {
         }
     }
 
+    /// Replace cached flags, group type mappings, and cohorts from a local
+    /// evaluation API response.
     pub fn update(&self, response: LocalEvaluationResponse) {
         let flag_count = response.flags.len();
         let mut flags = self.flags.write().unwrap();
@@ -96,18 +99,22 @@ impl FlagCache {
         debug!(flag_count, "Updated flag cache");
     }
 
+    /// Return a cached feature flag by key.
     pub fn get_flag(&self, key: &str) -> Option<FeatureFlag> {
         self.flags.read().unwrap().get(key).cloned()
     }
 
+    /// Return all cached feature flag definitions.
     pub fn get_all_flags(&self) -> Vec<FeatureFlag> {
         self.flags.read().unwrap().values().cloned().collect()
     }
 
+    /// Return a cached cohort by ID.
     pub fn get_cohort(&self, id: &str) -> Option<Cohort> {
         self.cohorts.read().unwrap().get(id).cloned()
     }
 
+    /// Return all cached cohorts, keyed by cohort ID.
     pub fn get_all_cohorts(&self) -> HashMap<String, Cohort> {
         self.cohorts.read().unwrap().clone()
     }
@@ -140,6 +147,7 @@ impl FlagCache {
         self.group_type_mapping.read().unwrap().clone()
     }
 
+    /// Remove all cached flags, group type mappings, and cohorts.
     pub fn clear(&self) {
         self.flags.write().unwrap().clear();
         self.group_type_mapping.write().unwrap().clear();
@@ -157,7 +165,8 @@ pub struct LocalEvaluationConfig {
     pub personal_api_key: String,
     /// Project API key to identify which project's flags to fetch
     pub project_api_key: String,
-    /// PostHog API host URL (e.g., "https://us.posthog.com")
+    /// PostHog API or ingestion host URL (for example,
+    /// `https://us.i.posthog.com`).
     pub api_host: String,
     /// How often to poll for updated flag definitions
     pub poll_interval: Duration,
@@ -169,7 +178,8 @@ pub struct LocalEvaluationConfig {
 ///
 /// Runs a background thread that periodically fetches flag definitions from
 /// the PostHog API and updates the shared cache. Use this for blocking/sync
-/// applications. For async applications, use [`AsyncFlagPoller`] instead.
+/// applications. With the `async-client` feature enabled, use
+/// `AsyncFlagPoller` for async applications instead.
 pub struct FlagPoller {
     config: LocalEvaluationConfig,
     cache: FlagCache,
@@ -179,6 +189,12 @@ pub struct FlagPoller {
 }
 
 impl FlagPoller {
+    /// Create a synchronous flag definition poller.
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: Credentials, host, polling interval, and request timeout.
+    /// - `cache`: Shared cache updated by the poller.
     pub fn new(config: LocalEvaluationConfig, cache: FlagCache) -> Self {
         let client = reqwest::blocking::Client::builder()
             .timeout(config.request_timeout)
@@ -194,7 +210,10 @@ impl FlagPoller {
         }
     }
 
-    /// Start the polling thread
+    /// Start the polling thread.
+    ///
+    /// Performs an initial synchronous load, then refreshes definitions in the
+    /// background until [`FlagPoller::stop`] is called or the poller is dropped.
     pub fn start(&mut self) {
         info!(
             poll_interval_secs = self.config.poll_interval.as_secs(),
@@ -276,7 +295,13 @@ impl FlagPoller {
         self.thread_handle = Some(handle);
     }
 
-    /// Load flags synchronously
+    /// Load flags synchronously and update the cache once.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Connection`] for request failures or non-success HTTP
+    /// statuses, and [`Error::Serialization`] when the response cannot be
+    /// parsed.
     #[instrument(skip(self), level = "debug")]
     pub fn load_flags(&self) -> Result<(), Error> {
         let url = format!(
@@ -313,7 +338,7 @@ impl FlagPoller {
         Ok(())
     }
 
-    /// Stop the polling thread
+    /// Stop the polling thread and wait for it to exit.
     pub fn stop(&mut self) {
         debug!("Stopping flag poller");
         self.stop_signal.store(true, Ordering::Relaxed);
@@ -346,6 +371,12 @@ pub struct AsyncFlagPoller {
 
 #[cfg(feature = "async-client")]
 impl AsyncFlagPoller {
+    /// Create an asynchronous flag definition poller.
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: Credentials, host, polling interval, and request timeout.
+    /// - `cache`: Shared cache updated by the poller.
     pub fn new(config: LocalEvaluationConfig, cache: FlagCache) -> Self {
         let client = reqwest::Client::builder()
             .timeout(config.request_timeout)
@@ -362,7 +393,11 @@ impl AsyncFlagPoller {
         }
     }
 
-    /// Start the polling task
+    /// Start the polling task.
+    ///
+    /// Performs an initial async load, then refreshes definitions in the
+    /// background until [`AsyncFlagPoller::stop`] is called or the poller is
+    /// dropped.
     pub async fn start(&mut self) {
         // Check if already running
         {
@@ -456,7 +491,13 @@ impl AsyncFlagPoller {
         self.task_handle = Some(task);
     }
 
-    /// Load flags asynchronously
+    /// Load flags asynchronously and update the cache once.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Connection`] for request failures or non-success HTTP
+    /// statuses, and [`Error::Serialization`] when the response cannot be
+    /// parsed.
     #[instrument(skip(self), level = "debug")]
     pub async fn load_flags(&self) -> Result<(), Error> {
         let url = format!(
@@ -497,7 +538,7 @@ impl AsyncFlagPoller {
         Ok(())
     }
 
-    /// Stop the polling task
+    /// Stop the polling task.
     pub async fn stop(&mut self) {
         debug!("Stopping async flag poller");
         self.stop_signal.store(true, Ordering::Relaxed);
@@ -507,7 +548,7 @@ impl AsyncFlagPoller {
         *self.is_running.write().await = false;
     }
 
-    /// Check if the poller is running
+    /// Check if the poller currently has a running background task.
     pub async fn is_running(&self) -> bool {
         *self.is_running.read().await
     }
@@ -534,6 +575,7 @@ pub struct LocalEvaluator {
 }
 
 impl LocalEvaluator {
+    /// Create an evaluator backed by a shared [`FlagCache`].
     pub fn new(cache: FlagCache) -> Self {
         Self { cache }
     }
@@ -550,6 +592,16 @@ impl LocalEvaluator {
     /// only consulted when the flag (or one of its conditions) targets a
     /// group via `aggregation_group_type_index`; pass empty maps for
     /// person-targeted flags.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(value))` when the flag is present and evaluated,
+    /// `Ok(None)` when the flag is absent from the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InconclusiveMatchError`] when required properties, cohorts, or
+    /// dependent flags are unavailable locally.
     #[instrument(
         skip(self, person_properties, groups, group_properties),
         level = "trace"
@@ -589,8 +641,21 @@ impl LocalEvaluator {
         }
     }
 
-    /// Evaluate a feature flag locally (simple version without cohort/flag dependency support).
-    /// Use this when you know the flag doesn't have cohort or flag dependency conditions.
+    /// Evaluate a feature flag locally without cohort or flag dependency
+    /// support.
+    ///
+    /// Use this when you know the flag doesn't have cohort or flag dependency
+    /// conditions.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(value))` when the flag is present and evaluated,
+    /// `Ok(None)` when the flag is absent from the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InconclusiveMatchError`] when required properties are
+    /// unavailable locally.
     #[instrument(
         skip(self, person_properties, groups, group_properties),
         level = "trace"
@@ -625,6 +690,10 @@ impl LocalEvaluator {
     }
 
     /// Get all flags and evaluate them with full context support.
+    ///
+    /// The returned map is keyed by feature flag key. Each value can be an
+    /// inconclusive error if that particular flag could not be evaluated from
+    /// the supplied context.
     #[instrument(
         skip(self, person_properties, groups, group_properties),
         level = "debug"

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -165,8 +165,8 @@ pub struct LocalEvaluationConfig {
     pub personal_api_key: String,
     /// Project API key to identify which project's flags to fetch
     pub project_api_key: String,
-    /// PostHog app host URL (for example, `https://us.posthog.com`).
-    /// Use `https://eu.posthog.com` for EU-hosted projects.
+    /// PostHog API host URL (for example, `https://us.i.posthog.com`).
+    /// Use `https://eu.i.posthog.com` for EU-hosted projects.
     pub api_host: String,
     /// How often to poll for updated flag definitions
     pub poll_interval: Duration,

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -165,8 +165,8 @@ pub struct LocalEvaluationConfig {
     pub personal_api_key: String,
     /// Project API key to identify which project's flags to fetch
     pub project_api_key: String,
-    /// PostHog API or ingestion host URL (for example,
-    /// `https://us.i.posthog.com`).
+    /// PostHog app host URL (for example, `https://us.posthog.com`).
+    /// Use `https://eu.posthog.com` for EU-hosted projects.
     pub api_host: String,
     /// How often to poll for updated flag definitions
     pub poll_interval: Duration,
@@ -179,7 +179,7 @@ pub struct LocalEvaluationConfig {
 /// Runs a background thread that periodically fetches flag definitions from
 /// the PostHog API and updates the shared cache. Use this for blocking/sync
 /// applications. With the `async-client` feature enabled, use
-/// `AsyncFlagPoller` for async applications instead.
+/// [`AsyncFlagPoller`] for async applications instead.
 pub struct FlagPoller {
     config: LocalEvaluationConfig,
     cache: FlagCache,


### PR DESCRIPTION
## :bulb: Motivation and Context
Improve the Rust SDK's generated API documentation for users integrating capture, feature flags, local evaluation, endpoint configuration, and global client APIs.

Changes:
- Expanded public rustdoc across client, blocking client, event, feature flag evaluation, local evaluation, endpoints, error, and global APIs.
- Clarified parameters, return values, errors, and usage notes for capture and feature flag flows.
- Clarified local evaluation API host examples to use PostHog ingestion API hosts.
- Added crate-level documentation for the main SDK entry points.

## :green_heart: How did you test it?
- `cargo test`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
