### PR TITLE
feat: emit $is_server property on captured events

### DIFF
--- a/.sampo/changesets/is-server-property.md
+++ b/.sampo/changesets/is-server-property.md
@@ -1,5 +1,5 @@
 ---
-cargo/posthog-rs: patch
+cargo/posthog-rs: minor
 ---
 
 Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `is_server` to `false` when using posthog-rs as a client/CLI so the device OS is attributed normally.

--- a/.sampo/changesets/is-server-property.md
+++ b/.sampo/changesets/is-server-property.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Emit `$is_server` property on captured events so PostHog can identify server-side events.

--- a/.sampo/changesets/is-server-property.md
+++ b/.sampo/changesets/is-server-property.md
@@ -2,4 +2,4 @@
 cargo/posthog-rs: patch
 ---
 
-Emit `$is_server` property on captured events so PostHog can identify server-side events.
+Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `is_server` to `false` when using posthog-rs as a client/CLI so the device OS is attributed normally.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -104,7 +104,7 @@ impl AsyncFlagEventHost {
         if self.disabled {
             return;
         }
-        let inner_event = InnerEvent::new(event, self.api_key.clone(), self.is_server);
+        let inner_event = InnerEvent::new(event, self.api_key.clone());
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
             Err(e) => {
@@ -158,6 +158,9 @@ impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
         }
         if params.disable_geoip.unwrap_or(self.disable_geoip) {
             let _ = event.insert_prop("$geoip_disable", true);
+        }
+        if self.is_server {
+            let _ = event.insert_prop("$is_server", true);
         }
         self.spawn_ship(event);
     }
@@ -259,9 +262,12 @@ impl Client {
         if self.options.disable_geoip {
             event.insert_prop("$geoip_disable", true).ok();
         }
+        // Mark server-side events so ingestion doesn't attribute the host OS to the person.
+        if self.options.is_server {
+            event.insert_prop("$is_server", true).ok();
+        }
 
-        let inner_event =
-            InnerEvent::new(event, self.options.api_key.clone(), self.options.is_server);
+        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
 
         let payload =
             serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))?;
@@ -300,7 +306,10 @@ impl Client {
                 if disable_geoip {
                     event.insert_prop("$geoip_disable", true).ok();
                 }
-                InnerEvent::new(event, self.options.api_key.clone(), is_server)
+                if is_server {
+                    event.insert_prop("$is_server", true).ok();
+                }
+                InnerEvent::new(event, self.options.api_key.clone())
             })
             .collect();
 

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -56,6 +56,7 @@ struct AsyncFlagEventHost {
     capture_url: String,
     disabled: bool,
     disable_geoip: bool,
+    is_server: bool,
     dedup_cache: Mutex<HashMap<String, HashSet<String>>>,
     /// Tokio runtime handle captured at host construction (which always runs
     /// inside the runtime that hosts `evaluate_flags`). This lets snapshot
@@ -74,6 +75,7 @@ impl AsyncFlagEventHost {
             capture_url,
             disabled: options.is_disabled(),
             disable_geoip: options.disable_geoip,
+            is_server: options.is_server,
             dedup_cache: Mutex::new(HashMap::new()),
             runtime: tokio::runtime::Handle::current(),
         }
@@ -102,7 +104,7 @@ impl AsyncFlagEventHost {
         if self.disabled {
             return;
         }
-        let inner_event = InnerEvent::new(event, self.api_key.clone());
+        let inner_event = InnerEvent::new(event, self.api_key.clone(), self.is_server);
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
             Err(e) => {
@@ -258,7 +260,8 @@ impl Client {
             event.insert_prop("$geoip_disable", true).ok();
         }
 
-        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
+        let inner_event =
+            InnerEvent::new(event, self.options.api_key.clone(), self.options.is_server);
 
         let payload =
             serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))?;
@@ -290,13 +293,14 @@ impl Client {
         }
 
         let disable_geoip = self.options.disable_geoip;
+        let is_server = self.options.is_server;
         let inner_events: Vec<InnerEvent> = events
             .into_iter()
             .map(|mut event| {
                 if disable_geoip {
                     event.insert_prop("$geoip_disable", true).ok();
                 }
-                InnerEvent::new(event, self.options.api_key.clone())
+                InnerEvent::new(event, self.options.api_key.clone(), is_server)
             })
             .collect();
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -95,7 +95,7 @@ impl BlockingFlagEventHost {
         if self.disabled {
             return;
         }
-        let inner_event = InnerEvent::new(event, self.api_key.clone(), self.is_server);
+        let inner_event = InnerEvent::new(event, self.api_key.clone());
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
             Err(e) => {
@@ -142,6 +142,9 @@ impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
         }
         if params.disable_geoip.unwrap_or(self.disable_geoip) {
             let _ = event.insert_prop("$geoip_disable", true);
+        }
+        if self.is_server {
+            let _ = event.insert_prop("$is_server", true);
         }
         self.ship_event(event);
     }
@@ -243,9 +246,12 @@ impl Client {
         if self.options.disable_geoip {
             event.insert_prop("$geoip_disable", true).ok();
         }
+        // Mark server-side events so ingestion doesn't attribute the host OS to the person.
+        if self.options.is_server {
+            event.insert_prop("$is_server", true).ok();
+        }
 
-        let inner_event =
-            InnerEvent::new(event, self.options.api_key.clone(), self.options.is_server);
+        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
 
         let payload =
             serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))?;
@@ -284,7 +290,10 @@ impl Client {
                 if disable_geoip {
                     event.insert_prop("$geoip_disable", true).ok();
                 }
-                InnerEvent::new(event, self.options.api_key.clone(), is_server)
+                if is_server {
+                    event.insert_prop("$is_server", true).ok();
+                }
+                InnerEvent::new(event, self.options.api_key.clone())
             })
             .collect();
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -55,6 +55,7 @@ struct BlockingFlagEventHost {
     endpoints: EndpointManager,
     disabled: bool,
     disable_geoip: bool,
+    is_server: bool,
     dedup_cache: Mutex<HashMap<String, HashSet<String>>>,
 }
 
@@ -66,6 +67,7 @@ impl BlockingFlagEventHost {
             endpoints: options.endpoints().clone(),
             disabled: options.is_disabled(),
             disable_geoip: options.disable_geoip,
+            is_server: options.is_server,
             dedup_cache: Mutex::new(HashMap::new()),
         }
     }
@@ -93,7 +95,7 @@ impl BlockingFlagEventHost {
         if self.disabled {
             return;
         }
-        let inner_event = InnerEvent::new(event, self.api_key.clone());
+        let inner_event = InnerEvent::new(event, self.api_key.clone(), self.is_server);
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
             Err(e) => {
@@ -242,7 +244,8 @@ impl Client {
             event.insert_prop("$geoip_disable", true).ok();
         }
 
-        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
+        let inner_event =
+            InnerEvent::new(event, self.options.api_key.clone(), self.options.is_server);
 
         let payload =
             serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))?;
@@ -274,13 +277,14 @@ impl Client {
         }
 
         let disable_geoip = self.options.disable_geoip;
+        let is_server = self.options.is_server;
         let inner_events: Vec<InnerEvent> = events
             .into_iter()
             .map(|mut event| {
                 if disable_geoip {
                     event.insert_prop("$geoip_disable", true).ok();
                 }
-                InnerEvent::new(event, self.options.api_key.clone())
+                InnerEvent::new(event, self.options.api_key.clone(), is_server)
             })
             .collect();
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -67,26 +67,9 @@ pub struct ClientOptions {
     #[builder(default = "false")]
     disable_geoip: bool,
 
-    /// Whether events originate from a server-side environment.
-    ///
-    /// Defaults to `true`. When `true`, the SDK adds `$is_server: true` to every
-    /// captured event so PostHog can identify server-side events. Set this to
-    /// `false` when running posthog-rs as a client/CLI (for example a desktop or
-    /// command-line tool) so the event's device OS is attributed normally and
-    /// `$is_server` is omitted. A caller-set `$is_server` property on an
-    /// individual event always takes precedence over this option.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// use posthog_rs::ClientOptionsBuilder;
-    ///
-    /// let options = ClientOptionsBuilder::default()
-    ///     .api_key("your-api-key".to_string())
-    ///     .is_server(false) // running as a CLI/client
-    ///     .build()
-    ///     .unwrap();
-    /// ```
+    /// Whether events originate from a server-side runtime. Defaults to `true`,
+    /// which stamps `$is_server: true` so PostHog won't attribute the host OS to
+    /// the user. Set `false` for client/CLI use (the property is then omitted).
     #[builder(default = "true")]
     is_server: bool,
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -67,6 +67,29 @@ pub struct ClientOptions {
     #[builder(default = "false")]
     disable_geoip: bool,
 
+    /// Whether events originate from a server-side environment.
+    ///
+    /// Defaults to `true`. When `true`, the SDK adds `$is_server: true` to every
+    /// captured event so PostHog can identify server-side events. Set this to
+    /// `false` when running posthog-rs as a client/CLI (for example a desktop or
+    /// command-line tool) so the event's device OS is attributed normally and
+    /// `$is_server` is omitted. A caller-set `$is_server` property on an
+    /// individual event always takes precedence over this option.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use posthog_rs::ClientOptionsBuilder;
+    ///
+    /// let options = ClientOptionsBuilder::default()
+    ///     .api_key("your-api-key".to_string())
+    ///     .is_server(false) // running as a CLI/client
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    #[builder(default = "true")]
+    is_server: bool,
+
     /// Feature flags request timeout in seconds
     #[builder(default = "3")]
     feature_flags_request_timeout_seconds: u64,

--- a/src/event.rs
+++ b/src/event.rs
@@ -297,6 +297,9 @@ pub mod tests {
         event.insert_prop("$lib", "posthog-js").unwrap();
         event.insert_prop("$lib_version", "1.42.0").unwrap();
         event.insert_prop("$lib_version__major", 1u64).unwrap();
+        // A forwarded browser event sets $is_server explicitly; the caller's
+        // value must survive even when the client is configured as a server.
+        event.insert_prop("$is_server", false).unwrap();
 
         let inner = InnerEvent::new(event, "key".to_string(), true);
         let props = &inner.properties;
@@ -304,6 +307,10 @@ pub mod tests {
         assert_eq!(
             props.get("$lib"),
             Some(&serde_json::Value::String("posthog-js".to_string()))
+        );
+        assert_eq!(
+            props.get("$is_server"),
+            Some(&serde_json::Value::Bool(false))
         );
         assert_eq!(
             props.get("$lib_version"),

--- a/src/event.rs
+++ b/src/event.rs
@@ -147,6 +147,11 @@ impl InnerEvent {
             );
         }
 
+        // Mark every event as originating from a server-side SDK.
+        if !properties.contains_key("$is_server") {
+            properties.insert("$is_server".into(), serde_json::Value::Bool(true));
+        }
+
         let version_str = env!("CARGO_PKG_VERSION");
         if !properties.contains_key("$lib_version") {
             properties.insert(
@@ -218,6 +223,7 @@ pub mod tests {
             props.get("$lib"),
             Some(&serde_json::Value::String("posthog-rs".to_string()))
         );
+        assert_eq!(props.get("$is_server"), Some(&serde_json::Value::Bool(true)));
     }
 
     #[test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -231,7 +231,10 @@ pub mod tests {
             props.get("$lib"),
             Some(&serde_json::Value::String("posthog-rs".to_string()))
         );
-        assert_eq!(props.get("$is_server"), Some(&serde_json::Value::Bool(true)));
+        assert_eq!(
+            props.get("$is_server"),
+            Some(&serde_json::Value::Bool(true))
+        );
     }
 
     #[test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -134,7 +134,13 @@ pub struct InnerEvent {
 }
 
 impl InnerEvent {
-    pub fn new(event: Event, api_key: String) -> Self {
+    /// Build an [`InnerEvent`] from an [`Event`], stamping the SDK metadata
+    /// (`$lib`, `$lib_version`, and so on) and, when `is_server` is `true`,
+    /// marking the event as originating from a server-side SDK via
+    /// `$is_server: true`. A caller-set `$is_server` property is always
+    /// preserved. The `is_server` flag is sourced from the client's
+    /// [`ClientOptions::is_server`](crate::ClientOptions) configuration.
+    pub fn new(event: Event, api_key: String, is_server: bool) -> Self {
         let uuid = event.uuid;
         let mut properties = event.properties;
 
@@ -147,8 +153,10 @@ impl InnerEvent {
             );
         }
 
-        // Mark every event as originating from a server-side SDK.
-        if !properties.contains_key("$is_server") {
+        // Mark every event as originating from a server-side SDK, unless the
+        // client is configured as a client/CLI (`is_server == false`). A
+        // caller-set value always wins.
+        if is_server && !properties.contains_key("$is_server") {
             properties.insert("$is_server".into(), serde_json::Value::Bool(true));
         }
 
@@ -215,7 +223,7 @@ pub mod tests {
         let api_key = "test_api_key".to_string();
 
         // Act
-        let inner_event = InnerEvent::new(event, api_key);
+        let inner_event = InnerEvent::new(event, api_key, true);
 
         // Assert
         let props = &inner_event.properties;
@@ -227,10 +235,44 @@ pub mod tests {
     }
 
     #[test]
+    fn inner_event_omits_is_server_when_disabled() {
+        // Arrange
+        let mut event = Event::new("unit test event", "1234");
+        event.insert_prop("key1", "value1").unwrap();
+        let api_key = "test_api_key".to_string();
+
+        // Act: client configured as a client/CLI (is_server = false)
+        let inner_event = InnerEvent::new(event, api_key, false);
+
+        // Assert: $is_server must not be added
+        let props = &inner_event.properties;
+        assert_eq!(props.get("$is_server"), None);
+        // Other lib metadata is still stamped
+        assert_eq!(
+            props.get("$lib"),
+            Some(&serde_json::Value::String("posthog-rs".to_string()))
+        );
+    }
+
+    #[test]
+    fn inner_event_preserves_caller_set_is_server_when_disabled() {
+        // A caller-set $is_server always wins, even when is_server == false.
+        let mut event = Event::new("unit test event", "1234");
+        event.insert_prop("$is_server", true).unwrap();
+
+        let inner_event = InnerEvent::new(event, "key".to_string(), false);
+
+        assert_eq!(
+            inner_event.properties.get("$is_server"),
+            Some(&serde_json::Value::Bool(true))
+        );
+    }
+
+    #[test]
     fn inner_event_includes_auto_generated_uuid() {
         let event = Event::new("test", "user1");
 
-        let inner = InnerEvent::new(event, "key".to_string());
+        let inner = InnerEvent::new(event, "key".to_string(), true);
         let json = serde_json::to_value(&inner).unwrap();
 
         let uuid_str = json["uuid"].as_str().expect("uuid should be present");
@@ -243,7 +285,7 @@ pub mod tests {
         let mut event = Event::new("test", "user1");
         event.set_uuid(uuid);
 
-        let inner = InnerEvent::new(event, "key".to_string());
+        let inner = InnerEvent::new(event, "key".to_string(), true);
         let json = serde_json::to_value(&inner).unwrap();
 
         assert_eq!(json["uuid"], uuid.to_string());
@@ -256,7 +298,7 @@ pub mod tests {
         event.insert_prop("$lib_version", "1.42.0").unwrap();
         event.insert_prop("$lib_version__major", 1u64).unwrap();
 
-        let inner = InnerEvent::new(event, "key".to_string());
+        let inner = InnerEvent::new(event, "key".to_string(), true);
         let props = &inner.properties;
 
         assert_eq!(

--- a/src/event.rs
+++ b/src/event.rs
@@ -135,12 +135,8 @@ pub struct InnerEvent {
 
 impl InnerEvent {
     /// Build an [`InnerEvent`] from an [`Event`], stamping the SDK metadata
-    /// (`$lib`, `$lib_version`, and so on) and, when `is_server` is `true`,
-    /// marking the event as originating from a server-side SDK via
-    /// `$is_server: true`. A caller-set `$is_server` property is always
-    /// preserved. The `is_server` flag is sourced from the client's
-    /// [`ClientOptions::is_server`](crate::ClientOptions) configuration.
-    pub fn new(event: Event, api_key: String, is_server: bool) -> Self {
+    /// (`$lib`, `$lib_version`).
+    pub fn new(event: Event, api_key: String) -> Self {
         let uuid = event.uuid;
         let mut properties = event.properties;
 
@@ -151,13 +147,6 @@ impl InnerEvent {
                 "$lib".into(),
                 serde_json::Value::String("posthog-rs".into()),
             );
-        }
-
-        // Mark every event as originating from a server-side SDK, unless the
-        // client is configured as a client/CLI (`is_server == false`). A
-        // caller-set value always wins.
-        if is_server && !properties.contains_key("$is_server") {
-            properties.insert("$is_server".into(), serde_json::Value::Bool(true));
         }
 
         let version_str = env!("CARGO_PKG_VERSION");
@@ -223,7 +212,7 @@ pub mod tests {
         let api_key = "test_api_key".to_string();
 
         // Act
-        let inner_event = InnerEvent::new(event, api_key, true);
+        let inner_event = InnerEvent::new(event, api_key);
 
         // Assert
         let props = &inner_event.properties;
@@ -231,51 +220,13 @@ pub mod tests {
             props.get("$lib"),
             Some(&serde_json::Value::String("posthog-rs".to_string()))
         );
-        assert_eq!(
-            props.get("$is_server"),
-            Some(&serde_json::Value::Bool(true))
-        );
-    }
-
-    #[test]
-    fn inner_event_omits_is_server_when_disabled() {
-        // Arrange
-        let mut event = Event::new("unit test event", "1234");
-        event.insert_prop("key1", "value1").unwrap();
-        let api_key = "test_api_key".to_string();
-
-        // Act: client configured as a client/CLI (is_server = false)
-        let inner_event = InnerEvent::new(event, api_key, false);
-
-        // Assert: $is_server must not be added
-        let props = &inner_event.properties;
-        assert_eq!(props.get("$is_server"), None);
-        // Other lib metadata is still stamped
-        assert_eq!(
-            props.get("$lib"),
-            Some(&serde_json::Value::String("posthog-rs".to_string()))
-        );
-    }
-
-    #[test]
-    fn inner_event_preserves_caller_set_is_server_when_disabled() {
-        // A caller-set $is_server always wins, even when is_server == false.
-        let mut event = Event::new("unit test event", "1234");
-        event.insert_prop("$is_server", true).unwrap();
-
-        let inner_event = InnerEvent::new(event, "key".to_string(), false);
-
-        assert_eq!(
-            inner_event.properties.get("$is_server"),
-            Some(&serde_json::Value::Bool(true))
-        );
     }
 
     #[test]
     fn inner_event_includes_auto_generated_uuid() {
         let event = Event::new("test", "user1");
 
-        let inner = InnerEvent::new(event, "key".to_string(), true);
+        let inner = InnerEvent::new(event, "key".to_string());
         let json = serde_json::to_value(&inner).unwrap();
 
         let uuid_str = json["uuid"].as_str().expect("uuid should be present");
@@ -288,7 +239,7 @@ pub mod tests {
         let mut event = Event::new("test", "user1");
         event.set_uuid(uuid);
 
-        let inner = InnerEvent::new(event, "key".to_string(), true);
+        let inner = InnerEvent::new(event, "key".to_string());
         let json = serde_json::to_value(&inner).unwrap();
 
         assert_eq!(json["uuid"], uuid.to_string());
@@ -300,20 +251,13 @@ pub mod tests {
         event.insert_prop("$lib", "posthog-js").unwrap();
         event.insert_prop("$lib_version", "1.42.0").unwrap();
         event.insert_prop("$lib_version__major", 1u64).unwrap();
-        // A forwarded browser event sets $is_server explicitly; the caller's
-        // value must survive even when the client is configured as a server.
-        event.insert_prop("$is_server", false).unwrap();
 
-        let inner = InnerEvent::new(event, "key".to_string(), true);
+        let inner = InnerEvent::new(event, "key".to_string());
         let props = &inner.properties;
 
         assert_eq!(
             props.get("$lib"),
             Some(&serde_json::Value::String("posthog-js".to_string()))
-        );
-        assert_eq!(
-            props.get("$is_server"),
-            Some(&serde_json::Value::Bool(false))
         );
         assert_eq!(
             props.get("$lib_version"),


### PR DESCRIPTION
Adds `$is_server: true` to every event captured by this SDK so PostHog ingestion can identify server-side events.