### PR TITLE
refactor: reduce duplicated feature flag code

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use reqwest::{header::CONTENT_TYPE, Client as HttpClient};
@@ -12,17 +12,16 @@ use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
     FlagCalledEventParams,
 };
-use crate::feature_flags::{
-    match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagDetail, FlagValue,
-};
+use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{event::InnerEvent, Error, Event};
 
+use super::common::{
+    already_reported, build_dedup_key, extract_flag_details, flag_called_event,
+    flag_event_dedup_cache, local_record, remote_record_from_detail, DetailedFlagsResponse,
+    FlagEventDedupCache,
+};
 use super::ClientOptions;
-
-/// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
-/// dedup cache. On overflow the entire map is reset (matches the JS SDK).
-const MAX_FLAG_CALLED_CACHE_SIZE: usize = 50_000;
 
 async fn check_response(response: reqwest::Response) -> Result<(), Error> {
     let status = response.status().as_u16();
@@ -57,7 +56,7 @@ struct AsyncFlagEventHost {
     disabled: bool,
     disable_geoip: bool,
     is_server: bool,
-    dedup_cache: Mutex<HashMap<String, HashSet<String>>>,
+    dedup_cache: FlagEventDedupCache,
     /// Tokio runtime handle captured at host construction (which always runs
     /// inside the runtime that hosts `evaluate_flags`). This lets snapshot
     /// access methods spawn `$feature_flag_called` shipping from any thread —
@@ -76,28 +75,9 @@ impl AsyncFlagEventHost {
             disabled: options.is_disabled(),
             disable_geoip: options.disable_geoip,
             is_server: options.is_server,
-            dedup_cache: Mutex::new(HashMap::new()),
+            dedup_cache: flag_event_dedup_cache(),
             runtime: tokio::runtime::Handle::current(),
         }
-    }
-
-    /// Returns `true` when the helper has already shipped this
-    /// `(distinct_id, key, response)` combination and the caller should skip.
-    fn already_reported(&self, distinct_id: &str, dedup_key: &str) -> bool {
-        let mut cache = self.dedup_cache.lock().unwrap_or_else(|p| p.into_inner());
-        if let Some(seen) = cache.get(distinct_id) {
-            if seen.contains(dedup_key) {
-                return true;
-            }
-        }
-        if cache.len() >= MAX_FLAG_CALLED_CACHE_SIZE {
-            cache.clear();
-        }
-        cache
-            .entry(distinct_id.to_string())
-            .or_default()
-            .insert(dedup_key.to_string());
-        false
     }
 
     fn spawn_ship(&self, event: Event) {
@@ -140,29 +120,13 @@ impl AsyncFlagEventHost {
 impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
     fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
         let dedup_key = build_dedup_key(&params.key, params.response.as_ref(), &params.groups);
-        if self.already_reported(&params.distinct_id, &dedup_key) {
+        if already_reported(&self.dedup_cache, &params.distinct_id, &dedup_key) {
             return;
         }
 
-        let mut event = Event::new(
-            "$feature_flag_called".to_string(),
-            params.distinct_id.clone(),
-        );
-        for (k, v) in params.properties {
-            if event.insert_prop(k, v).is_err() {
-                return;
-            }
+        if let Some(event) = flag_called_event(params, self.disable_geoip, self.is_server) {
+            self.spawn_ship(event);
         }
-        for (group_name, group_id) in &params.groups {
-            event.add_group(group_name, group_id);
-        }
-        if params.disable_geoip.unwrap_or(self.disable_geoip) {
-            let _ = event.insert_prop("$geoip_disable", true);
-        }
-        if self.is_server {
-            let _ = event.insert_prop("$is_server", true);
-        }
-        self.spawn_ship(event);
     }
 
     fn log_warning(&self, message: &str) {
@@ -170,40 +134,6 @@ impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
         // with their tracing-subscriber level filter (e.g. `posthog_rs=error`).
         warn!("{message}");
     }
-}
-
-fn build_dedup_key(
-    flag_key: &str,
-    response: Option<&FlagValue>,
-    groups: &HashMap<String, String>,
-) -> String {
-    let response_repr = match response {
-        Some(FlagValue::Boolean(true)) => "true".to_string(),
-        Some(FlagValue::Boolean(false)) => "false".to_string(),
-        Some(FlagValue::String(s)) => s.clone(),
-        None => "::null::".to_string(),
-    };
-    if groups.is_empty() {
-        format!("{flag_key}_{response_repr}")
-    } else {
-        // Canonicalize so two equal group maps with different insertion orders
-        // produce the same dedup key — necessary for group-scoped flags to fire
-        // exactly once per distinct group context.
-        let mut sorted: Vec<(&String, &String)> = groups.iter().collect();
-        sorted.sort_by(|a, b| a.0.cmp(b.0));
-        let groups_repr: String = sorted
-            .iter()
-            .map(|(k, v)| format!("{}={}", pct(k), pct(v)))
-            .collect::<Vec<_>>()
-            .join(";");
-        format!("{flag_key}_{response_repr}_{groups_repr}")
-    }
-}
-
-fn pct(s: &str) -> String {
-    s.replace('%', "%25")
-        .replace('=', "%3D")
-        .replace(';', "%3B")
 }
 
 /// Construct an async PostHog client from an API key or [`ClientOptions`].
@@ -897,115 +827,5 @@ impl Client {
             Error::Serialization(format!("Failed to parse feature flags response: {e}"))
         })?;
         Ok(extract_flag_details(parsed))
-    }
-}
-
-/// Normalised view of a `/flags?v=2` response surfacing the per-flag detail
-/// shape needed by the snapshot path.
-struct DetailedFlagsResponse {
-    flags: HashMap<String, FlagDetail>,
-    request_id: Option<String>,
-    errors_while_computing_flags: bool,
-    quota_limited: bool,
-}
-
-fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFlagsResponse {
-    match response {
-        FeatureFlagsResponse::V2 {
-            flags,
-            request_id,
-            errors_while_computing_flags,
-            quota_limited,
-        } => DetailedFlagsResponse {
-            flags,
-            request_id,
-            errors_while_computing_flags,
-            quota_limited,
-        },
-        FeatureFlagsResponse::Legacy {
-            feature_flags,
-            feature_flag_payloads,
-            errors,
-        } => {
-            let mut flags = HashMap::new();
-            for (key, value) in feature_flags {
-                let (enabled, variant) = match value {
-                    FlagValue::Boolean(b) => (b, None),
-                    FlagValue::String(s) => (true, Some(s)),
-                };
-                let payload = feature_flag_payloads.get(&key).cloned();
-                flags.insert(
-                    key.clone(),
-                    FlagDetail {
-                        key,
-                        enabled,
-                        variant,
-                        reason: None,
-                        metadata: payload.map(|payload| crate::feature_flags::FlagMetadata {
-                            id: 0,
-                            version: 0,
-                            description: None,
-                            payload: Some(payload),
-                        }),
-                    },
-                );
-            }
-            DetailedFlagsResponse {
-                flags,
-                request_id: None,
-                errors_while_computing_flags: errors.is_some_and(|e| !e.is_empty()),
-                quota_limited: false,
-            }
-        }
-    }
-}
-
-fn local_record(value: FlagValue) -> EvaluatedFlagRecord {
-    let (enabled, variant) = match value {
-        FlagValue::Boolean(b) => (b, None),
-        FlagValue::String(s) => (true, Some(s)),
-    };
-    EvaluatedFlagRecord {
-        enabled,
-        variant,
-        // Local definitions do not surface a payload through the poller today.
-        payload: None,
-        id: None,
-        version: None,
-        reason: Some("Evaluated locally".to_string()),
-        locally_evaluated: true,
-    }
-}
-
-fn remote_record_from_detail(detail: FlagDetail) -> EvaluatedFlagRecord {
-    let metadata = detail.metadata;
-    let reason = detail
-        .reason
-        .and_then(|r| r.description.or(Some(r.code)))
-        .filter(|s| !s.is_empty());
-    let id = metadata.as_ref().map(|m| m.id);
-    let version = metadata.as_ref().map(|m| m.version);
-    let payload = metadata.and_then(|m| m.payload).map(normalize_payload);
-    EvaluatedFlagRecord {
-        enabled: detail.enabled,
-        variant: detail.variant,
-        payload,
-        id,
-        version,
-        reason,
-        locally_evaluated: false,
-    }
-}
-
-/// `metadata.payload` from `/flags?v=2` is sometimes a JSON-encoded string
-/// (e.g. `"{\"color\":\"blue\"}"`) rather than already-parsed JSON. Try to
-/// parse a `String` payload as JSON and fall back to the raw string on
-/// failure so users can branch on a uniform [`serde_json::Value`].
-fn normalize_payload(payload: serde_json::Value) -> serde_json::Value {
-    match payload {
-        serde_json::Value::String(raw) => {
-            serde_json::from_str(&raw).unwrap_or(serde_json::Value::String(raw))
-        }
-        other => other,
     }
 }

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use reqwest::{blocking::Client as HttpClient, header::CONTENT_TYPE};
@@ -12,17 +12,16 @@ use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
     FlagCalledEventParams,
 };
-use crate::feature_flags::{
-    match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagDetail, FlagValue,
-};
+use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{event::InnerEvent, Error, Event};
 
+use super::common::{
+    already_reported, build_dedup_key, extract_flag_details, flag_called_event,
+    flag_event_dedup_cache, local_record, remote_record_from_detail, DetailedFlagsResponse,
+    FlagEventDedupCache,
+};
 use super::ClientOptions;
-
-/// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
-/// dedup cache. On overflow the entire map is reset (matches the JS SDK).
-const MAX_FLAG_CALLED_CACHE_SIZE: usize = 50_000;
 
 fn check_response(response: reqwest::blocking::Response) -> Result<(), Error> {
     let status = response.status().as_u16();
@@ -56,7 +55,7 @@ struct BlockingFlagEventHost {
     disabled: bool,
     disable_geoip: bool,
     is_server: bool,
-    dedup_cache: Mutex<HashMap<String, HashSet<String>>>,
+    dedup_cache: FlagEventDedupCache,
 }
 
 impl BlockingFlagEventHost {
@@ -68,27 +67,8 @@ impl BlockingFlagEventHost {
             disabled: options.is_disabled(),
             disable_geoip: options.disable_geoip,
             is_server: options.is_server,
-            dedup_cache: Mutex::new(HashMap::new()),
+            dedup_cache: flag_event_dedup_cache(),
         }
-    }
-
-    /// Returns `true` when the helper has already shipped this
-    /// `(distinct_id, key, response)` combination and the caller should skip.
-    fn already_reported(&self, distinct_id: &str, dedup_key: &str) -> bool {
-        let mut cache = self.dedup_cache.lock().unwrap_or_else(|p| p.into_inner());
-        if let Some(seen) = cache.get(distinct_id) {
-            if seen.contains(dedup_key) {
-                return true;
-            }
-        }
-        if cache.len() >= MAX_FLAG_CALLED_CACHE_SIZE {
-            cache.clear();
-        }
-        cache
-            .entry(distinct_id.to_string())
-            .or_default()
-            .insert(dedup_key.to_string());
-        false
     }
 
     fn ship_event(&self, event: Event) {
@@ -124,29 +104,13 @@ impl BlockingFlagEventHost {
 impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
     fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
         let dedup_key = build_dedup_key(&params.key, params.response.as_ref(), &params.groups);
-        if self.already_reported(&params.distinct_id, &dedup_key) {
+        if already_reported(&self.dedup_cache, &params.distinct_id, &dedup_key) {
             return;
         }
 
-        let mut event = Event::new(
-            "$feature_flag_called".to_string(),
-            params.distinct_id.clone(),
-        );
-        for (k, v) in params.properties {
-            if event.insert_prop(k, v).is_err() {
-                return;
-            }
+        if let Some(event) = flag_called_event(params, self.disable_geoip, self.is_server) {
+            self.ship_event(event);
         }
-        for (group_name, group_id) in &params.groups {
-            event.add_group(group_name, group_id);
-        }
-        if params.disable_geoip.unwrap_or(self.disable_geoip) {
-            let _ = event.insert_prop("$geoip_disable", true);
-        }
-        if self.is_server {
-            let _ = event.insert_prop("$is_server", true);
-        }
-        self.ship_event(event);
     }
 
     fn log_warning(&self, message: &str) {
@@ -154,40 +118,6 @@ impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
         // with their tracing-subscriber level filter (e.g. `posthog_rs=error`).
         warn!("{message}");
     }
-}
-
-fn build_dedup_key(
-    flag_key: &str,
-    response: Option<&FlagValue>,
-    groups: &HashMap<String, String>,
-) -> String {
-    let response_repr = match response {
-        Some(FlagValue::Boolean(true)) => "true".to_string(),
-        Some(FlagValue::Boolean(false)) => "false".to_string(),
-        Some(FlagValue::String(s)) => s.clone(),
-        None => "::null::".to_string(),
-    };
-    if groups.is_empty() {
-        format!("{flag_key}_{response_repr}")
-    } else {
-        // Canonicalize so two equal group maps with different insertion orders
-        // produce the same dedup key — necessary for group-scoped flags to fire
-        // exactly once per distinct group context.
-        let mut sorted: Vec<(&String, &String)> = groups.iter().collect();
-        sorted.sort_by(|a, b| a.0.cmp(b.0));
-        let groups_repr: String = sorted
-            .iter()
-            .map(|(k, v)| format!("{}={}", pct(k), pct(v)))
-            .collect::<Vec<_>>()
-            .join(";");
-        format!("{flag_key}_{response_repr}_{groups_repr}")
-    }
-}
-
-fn pct(s: &str) -> String {
-    s.replace('%', "%25")
-        .replace('=', "%3D")
-        .replace(';', "%3B")
 }
 
 /// Construct a blocking PostHog client from an API key or [`ClientOptions`].
@@ -871,117 +801,5 @@ impl Client {
             Error::Serialization(format!("Failed to parse feature flags response: {e}"))
         })?;
         Ok(extract_flag_details(parsed))
-    }
-}
-
-/// Normalised view of a `/flags?v=2` response surfacing the per-flag detail
-/// shape needed by the snapshot path.
-struct DetailedFlagsResponse {
-    flags: HashMap<String, FlagDetail>,
-    request_id: Option<String>,
-    errors_while_computing_flags: bool,
-    quota_limited: bool,
-}
-
-fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFlagsResponse {
-    match response {
-        FeatureFlagsResponse::V2 {
-            flags,
-            request_id,
-            errors_while_computing_flags,
-            quota_limited,
-        } => DetailedFlagsResponse {
-            flags,
-            request_id,
-            errors_while_computing_flags,
-            quota_limited,
-        },
-        // The legacy decide format does not surface metadata; build a synthetic
-        // detail so the snapshot still carries enabled/variant for each flag.
-        FeatureFlagsResponse::Legacy {
-            feature_flags,
-            feature_flag_payloads,
-            errors,
-        } => {
-            let mut flags = HashMap::new();
-            for (key, value) in feature_flags {
-                let (enabled, variant) = match value {
-                    FlagValue::Boolean(b) => (b, None),
-                    FlagValue::String(s) => (true, Some(s)),
-                };
-                let payload = feature_flag_payloads.get(&key).cloned();
-                flags.insert(
-                    key.clone(),
-                    FlagDetail {
-                        key,
-                        enabled,
-                        variant,
-                        reason: None,
-                        metadata: payload.map(|payload| crate::feature_flags::FlagMetadata {
-                            id: 0,
-                            version: 0,
-                            description: None,
-                            payload: Some(payload),
-                        }),
-                    },
-                );
-            }
-            DetailedFlagsResponse {
-                flags,
-                request_id: None,
-                errors_while_computing_flags: errors.is_some_and(|e| !e.is_empty()),
-                quota_limited: false,
-            }
-        }
-    }
-}
-
-fn local_record(value: FlagValue) -> EvaluatedFlagRecord {
-    let (enabled, variant) = match value {
-        FlagValue::Boolean(b) => (b, None),
-        FlagValue::String(s) => (true, Some(s)),
-    };
-    EvaluatedFlagRecord {
-        enabled,
-        variant,
-        // Local definitions do not surface a payload through the poller today.
-        payload: None,
-        id: None,
-        version: None,
-        reason: Some("Evaluated locally".to_string()),
-        locally_evaluated: true,
-    }
-}
-
-fn remote_record_from_detail(detail: FlagDetail) -> EvaluatedFlagRecord {
-    let metadata = detail.metadata;
-    let reason = detail
-        .reason
-        .and_then(|r| r.description.or(Some(r.code)))
-        .filter(|s| !s.is_empty());
-    let id = metadata.as_ref().map(|m| m.id);
-    let version = metadata.as_ref().map(|m| m.version);
-    let payload = metadata.and_then(|m| m.payload).map(normalize_payload);
-    EvaluatedFlagRecord {
-        enabled: detail.enabled,
-        variant: detail.variant,
-        payload,
-        id,
-        version,
-        reason,
-        locally_evaluated: false,
-    }
-}
-
-/// `metadata.payload` from `/flags?v=2` is sometimes a JSON-encoded string
-/// (e.g. `"{\"color\":\"blue\"}"`) rather than already-parsed JSON. Try to
-/// parse a `String` payload as JSON and fall back to the raw string on
-/// failure so users can branch on a uniform [`serde_json::Value`].
-fn normalize_payload(payload: serde_json::Value) -> serde_json::Value {
-    match payload {
-        serde_json::Value::String(raw) => {
-            serde_json::from_str(&raw).unwrap_or(serde_json::Value::String(raw))
-        }
-        other => other,
     }
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,0 +1,206 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use crate::feature_flag_evaluations::{EvaluatedFlagRecord, FlagCalledEventParams};
+use crate::feature_flags::{FeatureFlagsResponse, FlagDetail, FlagMetadata, FlagValue};
+use crate::Event;
+
+/// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
+/// dedup cache. On overflow the entire map is reset (matches the JS SDK).
+pub(super) const MAX_FLAG_CALLED_CACHE_SIZE: usize = 50_000;
+
+pub(super) type FlagEventDedupCache = Mutex<HashMap<String, HashSet<String>>>;
+
+pub(super) fn flag_event_dedup_cache() -> FlagEventDedupCache {
+    Mutex::new(HashMap::new())
+}
+
+/// Returns `true` when the helper has already shipped this
+/// `(distinct_id, key, response)` combination and the caller should skip.
+pub(super) fn already_reported(
+    cache: &FlagEventDedupCache,
+    distinct_id: &str,
+    dedup_key: &str,
+) -> bool {
+    let mut cache = cache.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(seen) = cache.get(distinct_id) {
+        if seen.contains(dedup_key) {
+            return true;
+        }
+    }
+    if cache.len() >= MAX_FLAG_CALLED_CACHE_SIZE {
+        cache.clear();
+    }
+    cache
+        .entry(distinct_id.to_string())
+        .or_default()
+        .insert(dedup_key.to_string());
+    false
+}
+
+pub(super) fn build_dedup_key(
+    flag_key: &str,
+    response: Option<&FlagValue>,
+    groups: &HashMap<String, String>,
+) -> String {
+    let response_repr = match response {
+        Some(FlagValue::Boolean(true)) => "true".to_string(),
+        Some(FlagValue::Boolean(false)) => "false".to_string(),
+        Some(FlagValue::String(s)) => s.clone(),
+        None => "::null::".to_string(),
+    };
+    if groups.is_empty() {
+        format!("{flag_key}_{response_repr}")
+    } else {
+        // Canonicalize so two equal group maps with different insertion orders
+        // produce the same dedup key — necessary for group-scoped flags to fire
+        // exactly once per distinct group context.
+        let mut sorted: Vec<(&String, &String)> = groups.iter().collect();
+        sorted.sort_by(|a, b| a.0.cmp(b.0));
+        let groups_repr: String = sorted
+            .iter()
+            .map(|(k, v)| format!("{}={}", pct(k), pct(v)))
+            .collect::<Vec<_>>()
+            .join(";");
+        format!("{flag_key}_{response_repr}_{groups_repr}")
+    }
+}
+
+fn pct(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace('=', "%3D")
+        .replace(';', "%3B")
+}
+
+pub(super) fn flag_called_event(
+    params: FlagCalledEventParams,
+    client_disable_geoip: bool,
+    is_server: bool,
+) -> Option<Event> {
+    let mut event = Event::new("$feature_flag_called".to_string(), params.distinct_id);
+    for (k, v) in params.properties {
+        if event.insert_prop(k, v).is_err() {
+            return None;
+        }
+    }
+    for (group_name, group_id) in &params.groups {
+        event.add_group(group_name, group_id);
+    }
+    if params.disable_geoip.unwrap_or(client_disable_geoip) {
+        let _ = event.insert_prop("$geoip_disable", true);
+    }
+    if is_server {
+        let _ = event.insert_prop("$is_server", true);
+    }
+    Some(event)
+}
+
+/// Normalised view of a `/flags?v=2` response surfacing the per-flag detail
+/// shape needed by the snapshot path.
+pub(super) struct DetailedFlagsResponse {
+    pub(super) flags: HashMap<String, FlagDetail>,
+    pub(super) request_id: Option<String>,
+    pub(super) errors_while_computing_flags: bool,
+    pub(super) quota_limited: bool,
+}
+
+pub(super) fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFlagsResponse {
+    match response {
+        FeatureFlagsResponse::V2 {
+            flags,
+            request_id,
+            errors_while_computing_flags,
+            quota_limited,
+        } => DetailedFlagsResponse {
+            flags,
+            request_id,
+            errors_while_computing_flags,
+            quota_limited,
+        },
+        FeatureFlagsResponse::Legacy {
+            feature_flags,
+            feature_flag_payloads,
+            errors,
+        } => {
+            let mut flags = HashMap::new();
+            for (key, value) in feature_flags {
+                let (enabled, variant) = match value {
+                    FlagValue::Boolean(b) => (b, None),
+                    FlagValue::String(s) => (true, Some(s)),
+                };
+                let payload = feature_flag_payloads.get(&key).cloned();
+                flags.insert(
+                    key.clone(),
+                    FlagDetail {
+                        key,
+                        enabled,
+                        variant,
+                        reason: None,
+                        metadata: payload.map(|payload| FlagMetadata {
+                            id: 0,
+                            version: 0,
+                            description: None,
+                            payload: Some(payload),
+                        }),
+                    },
+                );
+            }
+            DetailedFlagsResponse {
+                flags,
+                request_id: None,
+                errors_while_computing_flags: errors.is_some_and(|e| !e.is_empty()),
+                quota_limited: false,
+            }
+        }
+    }
+}
+
+pub(super) fn local_record(value: FlagValue) -> EvaluatedFlagRecord {
+    let (enabled, variant) = match value {
+        FlagValue::Boolean(b) => (b, None),
+        FlagValue::String(s) => (true, Some(s)),
+    };
+    EvaluatedFlagRecord {
+        enabled,
+        variant,
+        // Local definitions do not surface a payload through the poller today.
+        payload: None,
+        id: None,
+        version: None,
+        reason: Some("Evaluated locally".to_string()),
+        locally_evaluated: true,
+    }
+}
+
+pub(super) fn remote_record_from_detail(detail: FlagDetail) -> EvaluatedFlagRecord {
+    let metadata = detail.metadata;
+    let reason = detail
+        .reason
+        .and_then(|r| r.description.or(Some(r.code)))
+        .filter(|s| !s.is_empty());
+    let id = metadata.as_ref().map(|m| m.id);
+    let version = metadata.as_ref().map(|m| m.version);
+    let payload = metadata.and_then(|m| m.payload).map(normalize_payload);
+    EvaluatedFlagRecord {
+        enabled: detail.enabled,
+        variant: detail.variant,
+        payload,
+        id,
+        version,
+        reason,
+        locally_evaluated: false,
+    }
+}
+
+/// `metadata.payload` from `/flags?v=2` is sometimes a JSON-encoded string
+/// (e.g. `"{\"color\":\"blue\"}"`) rather than already-parsed JSON. Try to
+/// parse a `String` payload as JSON and fall back to the raw string on
+/// failure so users can branch on a uniform [`serde_json::Value`].
+fn normalize_payload(payload: serde_json::Value) -> serde_json::Value {
+    match payload {
+        serde_json::Value::String(raw) => {
+            serde_json::from_str(&raw).unwrap_or(serde_json::Value::String(raw))
+        }
+        other => other,
+    }
+}

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -204,3 +204,95 @@ fn normalize_payload(payload: serde_json::Value) -> serde_json::Value {
         other => other,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn groups(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn flag_params(
+        properties: HashMap<String, serde_json::Value>,
+        groups: HashMap<String, String>,
+        disable_geoip: Option<bool>,
+    ) -> FlagCalledEventParams {
+        FlagCalledEventParams {
+            distinct_id: "user-1".to_string(),
+            key: "alpha".to_string(),
+            response: Some(FlagValue::Boolean(true)),
+            groups,
+            disable_geoip,
+            properties,
+        }
+    }
+
+    #[test]
+    fn dedup_key_canonicalizes_group_order_and_escapes_separators() {
+        let first = build_dedup_key(
+            "alpha",
+            Some(&FlagValue::Boolean(true)),
+            &groups(&[("organization", "org-a"), ("team", "red")]),
+        );
+        let second = build_dedup_key(
+            "alpha",
+            Some(&FlagValue::Boolean(true)),
+            &groups(&[("team", "red"), ("organization", "org-a")]),
+        );
+        assert_eq!(first, second);
+
+        let with_separator_in_key = build_dedup_key(
+            "alpha",
+            Some(&FlagValue::Boolean(true)),
+            &groups(&[("a=b", "c")]),
+        );
+        let with_separator_in_value = build_dedup_key(
+            "alpha",
+            Some(&FlagValue::Boolean(true)),
+            &groups(&[("a", "b=c")]),
+        );
+        assert_ne!(with_separator_in_key, with_separator_in_value);
+    }
+
+    #[test]
+    fn flag_called_event_applies_defaults_groups_and_preserves_caller_properties() {
+        let mut properties = HashMap::new();
+        properties.insert("$is_server".to_string(), json!(false));
+        properties.insert("$geoip_disable".to_string(), json!(false));
+
+        let event = flag_called_event(
+            flag_params(properties, groups(&[("organization", "org-a")]), Some(true)),
+            true,
+            true,
+        )
+        .expect("valid flag-called event");
+
+        assert_eq!(
+            event.groups().get("organization"),
+            Some(&"org-a".to_string())
+        );
+        assert_eq!(event.properties().get("$is_server"), Some(&json!(false)));
+        assert_eq!(
+            event.properties().get("$geoip_disable"),
+            Some(&json!(false))
+        );
+    }
+
+    #[test]
+    fn flag_called_event_adds_defaults_when_missing() {
+        let event = flag_called_event(
+            flag_params(HashMap::new(), HashMap::new(), None),
+            true,
+            true,
+        )
+        .expect("valid flag-called event");
+
+        assert_eq!(event.properties().get("$is_server"), Some(&json!(true)));
+        assert_eq!(event.properties().get("$geoip_disable"), Some(&json!(true)));
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,6 +2,8 @@ use crate::endpoints::{EndpointManager, DEFAULT_HOST};
 use derive_builder::Builder;
 use tracing::warn;
 
+mod common;
+
 #[cfg(not(feature = "async-client"))]
 mod blocking;
 #[cfg(not(feature = "async-client"))]

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1072,19 +1072,6 @@ fn compute_caret_bounds(version: SemverTuple) -> (SemverTuple, SemverTuple) {
     }
 }
 
-fn parse_property_semver(
-    property_key: &str,
-    value: &serde_json::Value,
-) -> Result<SemverTuple, InconclusiveMatchError> {
-    let prop_str = value_to_string(value);
-    parse_semver(&prop_str).ok_or_else(|| {
-        InconclusiveMatchError::new(&format!(
-            "Unable to parse property semver value for '{}': {:?}",
-            property_key, value
-        ))
-    })
-}
-
 fn parse_target_semver(
     target_value: &serde_json::Value,
 ) -> Result<SemverTuple, InconclusiveMatchError> {
@@ -1095,17 +1082,6 @@ fn parse_target_semver(
             target_value
         ))
     })
-}
-
-fn parse_semver_operands(
-    property_key: &str,
-    target_value: &serde_json::Value,
-    value: &serde_json::Value,
-) -> Result<(SemverTuple, SemverTuple), InconclusiveMatchError> {
-    Ok((
-        parse_property_semver(property_key, value)?,
-        parse_target_semver(target_value)?,
-    ))
 }
 
 fn match_property(
@@ -1129,6 +1105,22 @@ fn match_property(
                 property.key
             )));
         }
+    };
+
+    let parse_property_semver = || {
+        let prop_str = value_to_string(value);
+        parse_semver(&prop_str).ok_or_else(|| {
+            InconclusiveMatchError::new(&format!(
+                "Unable to parse property semver value for '{}': {:?}",
+                property.key, value
+            ))
+        })
+    };
+    let parse_semver_operands = || {
+        Ok((
+            parse_property_semver()?,
+            parse_target_semver(&property.value)?,
+        ))
     };
 
     Ok(match property.operator.as_str() {
@@ -1208,8 +1200,7 @@ fn match_property(
         }
         // Semver comparison operators
         "semver_eq" | "semver_neq" | "semver_gt" | "semver_gte" | "semver_lt" | "semver_lte" => {
-            let (prop_version, target_version) =
-                parse_semver_operands(&property.key, &property.value, value)?;
+            let (prop_version, target_version) = parse_semver_operands()?;
 
             match property.operator.as_str() {
                 "semver_eq" => prop_version == target_version,
@@ -1222,19 +1213,17 @@ fn match_property(
             }
         }
         "semver_tilde" => {
-            let (prop_version, target_version) =
-                parse_semver_operands(&property.key, &property.value, value)?;
+            let (prop_version, target_version) = parse_semver_operands()?;
             let (lower, upper) = compute_tilde_bounds(target_version);
             prop_version >= lower && prop_version < upper
         }
         "semver_caret" => {
-            let (prop_version, target_version) =
-                parse_semver_operands(&property.key, &property.value, value)?;
+            let (prop_version, target_version) = parse_semver_operands()?;
             let (lower, upper) = compute_caret_bounds(target_version);
             prop_version >= lower && prop_version < upper
         }
         "semver_wildcard" => {
-            let prop_version = parse_property_semver(&property.key, value)?;
+            let prop_version = parse_property_semver()?;
             let target_str = value_to_string(&property.value);
 
             let (lower, upper) = parse_semver_wildcard(&target_str).ok_or_else(|| {

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1072,6 +1072,39 @@ fn compute_caret_bounds(version: SemverTuple) -> (SemverTuple, SemverTuple) {
     }
 }
 
+fn parse_property_semver(
+    property: &Property,
+    value: &serde_json::Value,
+) -> Result<SemverTuple, InconclusiveMatchError> {
+    let prop_str = value_to_string(value);
+    parse_semver(&prop_str).ok_or_else(|| {
+        InconclusiveMatchError::new(&format!(
+            "Unable to parse property semver value for '{}': {:?}",
+            property.key, value
+        ))
+    })
+}
+
+fn parse_target_semver(property: &Property) -> Result<SemverTuple, InconclusiveMatchError> {
+    let target_str = value_to_string(&property.value);
+    parse_semver(&target_str).ok_or_else(|| {
+        InconclusiveMatchError::new(&format!(
+            "Unable to parse target semver value: {:?}",
+            property.value
+        ))
+    })
+}
+
+fn parse_semver_operands(
+    property: &Property,
+    value: &serde_json::Value,
+) -> Result<(SemverTuple, SemverTuple), InconclusiveMatchError> {
+    Ok((
+        parse_property_semver(property, value)?,
+        parse_target_semver(property)?,
+    ))
+}
+
 fn match_property(
     property: &Property,
     properties: &HashMap<String, serde_json::Value>,
@@ -1172,22 +1205,7 @@ fn match_property(
         }
         // Semver comparison operators
         "semver_eq" | "semver_neq" | "semver_gt" | "semver_gte" | "semver_lt" | "semver_lte" => {
-            let prop_str = value_to_string(value);
-            let target_str = value_to_string(&property.value);
-
-            let prop_version = parse_semver(&prop_str).ok_or_else(|| {
-                InconclusiveMatchError::new(&format!(
-                    "Unable to parse property semver value for '{}': {:?}",
-                    property.key, value
-                ))
-            })?;
-
-            let target_version = parse_semver(&target_str).ok_or_else(|| {
-                InconclusiveMatchError::new(&format!(
-                    "Unable to parse target semver value: {:?}",
-                    property.value
-                ))
-            })?;
+            let (prop_version, target_version) = parse_semver_operands(property, value)?;
 
             match property.operator.as_str() {
                 "semver_eq" => prop_version == target_version,
@@ -1200,57 +1218,18 @@ fn match_property(
             }
         }
         "semver_tilde" => {
-            let prop_str = value_to_string(value);
-            let target_str = value_to_string(&property.value);
-
-            let prop_version = parse_semver(&prop_str).ok_or_else(|| {
-                InconclusiveMatchError::new(&format!(
-                    "Unable to parse property semver value for '{}': {:?}",
-                    property.key, value
-                ))
-            })?;
-
-            let target_version = parse_semver(&target_str).ok_or_else(|| {
-                InconclusiveMatchError::new(&format!(
-                    "Unable to parse target semver value: {:?}",
-                    property.value
-                ))
-            })?;
-
+            let (prop_version, target_version) = parse_semver_operands(property, value)?;
             let (lower, upper) = compute_tilde_bounds(target_version);
             prop_version >= lower && prop_version < upper
         }
         "semver_caret" => {
-            let prop_str = value_to_string(value);
-            let target_str = value_to_string(&property.value);
-
-            let prop_version = parse_semver(&prop_str).ok_or_else(|| {
-                InconclusiveMatchError::new(&format!(
-                    "Unable to parse property semver value for '{}': {:?}",
-                    property.key, value
-                ))
-            })?;
-
-            let target_version = parse_semver(&target_str).ok_or_else(|| {
-                InconclusiveMatchError::new(&format!(
-                    "Unable to parse target semver value: {:?}",
-                    property.value
-                ))
-            })?;
-
+            let (prop_version, target_version) = parse_semver_operands(property, value)?;
             let (lower, upper) = compute_caret_bounds(target_version);
             prop_version >= lower && prop_version < upper
         }
         "semver_wildcard" => {
-            let prop_str = value_to_string(value);
+            let prop_version = parse_property_semver(property, value)?;
             let target_str = value_to_string(&property.value);
-
-            let prop_version = parse_semver(&prop_str).ok_or_else(|| {
-                InconclusiveMatchError::new(&format!(
-                    "Unable to parse property semver value for '{}': {:?}",
-                    property.key, value
-                ))
-            })?;
 
             let (lower, upper) = parse_semver_wildcard(&target_str).ok_or_else(|| {
                 InconclusiveMatchError::new(&format!(

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1073,35 +1073,38 @@ fn compute_caret_bounds(version: SemverTuple) -> (SemverTuple, SemverTuple) {
 }
 
 fn parse_property_semver(
-    property: &Property,
+    property_key: &str,
     value: &serde_json::Value,
 ) -> Result<SemverTuple, InconclusiveMatchError> {
     let prop_str = value_to_string(value);
     parse_semver(&prop_str).ok_or_else(|| {
         InconclusiveMatchError::new(&format!(
             "Unable to parse property semver value for '{}': {:?}",
-            property.key, value
+            property_key, value
         ))
     })
 }
 
-fn parse_target_semver(property: &Property) -> Result<SemverTuple, InconclusiveMatchError> {
-    let target_str = value_to_string(&property.value);
+fn parse_target_semver(
+    target_value: &serde_json::Value,
+) -> Result<SemverTuple, InconclusiveMatchError> {
+    let target_str = value_to_string(target_value);
     parse_semver(&target_str).ok_or_else(|| {
         InconclusiveMatchError::new(&format!(
             "Unable to parse target semver value: {:?}",
-            property.value
+            target_value
         ))
     })
 }
 
 fn parse_semver_operands(
-    property: &Property,
+    property_key: &str,
+    target_value: &serde_json::Value,
     value: &serde_json::Value,
 ) -> Result<(SemverTuple, SemverTuple), InconclusiveMatchError> {
     Ok((
-        parse_property_semver(property, value)?,
-        parse_target_semver(property)?,
+        parse_property_semver(property_key, value)?,
+        parse_target_semver(target_value)?,
     ))
 }
 
@@ -1205,7 +1208,8 @@ fn match_property(
         }
         // Semver comparison operators
         "semver_eq" | "semver_neq" | "semver_gt" | "semver_gte" | "semver_lt" | "semver_lte" => {
-            let (prop_version, target_version) = parse_semver_operands(property, value)?;
+            let (prop_version, target_version) =
+                parse_semver_operands(&property.key, &property.value, value)?;
 
             match property.operator.as_str() {
                 "semver_eq" => prop_version == target_version,
@@ -1218,17 +1222,19 @@ fn match_property(
             }
         }
         "semver_tilde" => {
-            let (prop_version, target_version) = parse_semver_operands(property, value)?;
+            let (prop_version, target_version) =
+                parse_semver_operands(&property.key, &property.value, value)?;
             let (lower, upper) = compute_tilde_bounds(target_version);
             prop_version >= lower && prop_version < upper
         }
         "semver_caret" => {
-            let (prop_version, target_version) = parse_semver_operands(property, value)?;
+            let (prop_version, target_version) =
+                parse_semver_operands(&property.key, &property.value, value)?;
             let (lower, upper) = compute_caret_bounds(target_version);
             prop_version >= lower && prop_version < upper
         }
         "semver_wildcard" => {
-            let prop_version = parse_property_semver(property, value)?;
+            let prop_version = parse_property_semver(&property.key, value)?;
             let target_str = value_to_string(&property.value);
 
             let (lower, upper) = parse_semver_wildcard(&target_str).ok_or_else(|| {


### PR DESCRIPTION
## :bulb: Motivation and Context

This is a POC for http://github.com/marandaneto/dry4rust, based on duplicate candidates reported by dry4rust in this repository.

The goal is to demonstrate a small, low-risk duplicate-removal pass in production code without changing SDK behavior.

Changes:
- Extracted shared async/blocking client feature-flag helpers into `src/client/common.rs`.
- Reused common `$feature_flag_called` dedup/event-building logic across async and blocking clients.
- Reused common `/flags` detail extraction and evaluated-record normalization logic.
- Reduced repeated semver operand parsing in feature flag property matching.
- Adjusted semver parsing helpers to avoid CodeQL unused-variable false positives.

## :green_heart: How did you test it?

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --no-default-features`
- `cargo test --all-features`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
