### PR TITLE
fix: keep root package as workspace member for sampo release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,7 @@ capture-v1 = ["flate2", "brotli", "zstd"]
 test-harness = []
 
 [workspace]
-members = ["compliance/adapter"]
+# Explicitly list "." so the root posthog-rs package stays a discoverable
+# workspace member. Without it, sampo only sees `members` and fails to find
+# `cargo/posthog-rs` when applying changesets during release.
+members = [".", "compliance/adapter"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,4 @@ capture-v1 = ["flate2", "brotli", "zstd"]
 test-harness = []
 
 [workspace]
-# Explicitly list "." so the root posthog-rs package stays a discoverable
-# workspace member. Without it, sampo only sees `members` and fails to find
-# `cargo/posthog-rs` when applying changesets during release.
 members = [".", "compliance/adapter"]


### PR DESCRIPTION
## :bulb: Motivation and Context

The [Release and publish workflow failed](https://github.com/PostHog/posthog-rs/actions/runs/26974127913/job/79596716355) on the `main` push for #116 with:

```
Failed to release packages: Changeset error: Changeset references 'cargo/posthog-rs', but it was not found in the workspace.
```

#116 added a `[workspace]` table to the root `Cargo.toml` listing only `compliance/adapter` in `members`. Sampo discovers packages by enumerating `workspace.members`, so once the workspace table existed it stopped seeing the root `posthog-rs` package. The pending `add-v1-capture-pipeline.md` changeset references `cargo/posthog-rs`, which was then "not found", and the release aborted.

Listing `"."` explicitly keeps the root crate a discoverable workspace member while still including `compliance/adapter`.

## :green_heart: How did you test it?

Reproduced the failure locally against the failing commit (`79673c3`) with `sampo 0.17.4`:

- Before: `sampo release` → `Changeset references 'cargo/posthog-rs', but it was not found in the workspace.`
- After adding `"."` to `members`: `sampo release` plans `posthog-rs: 0.8.0 -> 0.9.0`, consumes the changeset, regenerates `Cargo.lock`, and exits 0.
- `cargo metadata` discovers both `posthog-rs` and `sdk-adapter` with no warnings about the redundant `"."` member.

Once merged, the release workflow re-runs on `main` and should publish `0.9.0` from the existing changeset.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file (n/a — this fixes the release pipeline itself; the existing changeset is consumed on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
