### PR TITLE
fix: bring v0 capture into SDK compliance

### DIFF
--- a/.sampo/changesets/dashing-warden-kalma.md
+++ b/.sampo/changesets/dashing-warden-kalma.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Serialize the v0 capture `distinct_id` at the event root (canonical field) instead of the legacy `$distinct_id` alias, matching v1 and the v0 ingestion contract. Add retries to the v0 capture paths: transport errors and 408/500/502/503/504 are retried with exponential backoff honoring `Retry-After`, and a 429 is retried only when it carries a `Retry-After` (a bare 429 stays a terminal rate-limit). Retried requests resend the same bytes, preserving the event UUID and timestamp that dedup relies on. Add opt-in gzip compression for v0 capture via `capture_compression`: the body is gzipped with a `Content-Encoding: gzip` header and a `compression=gzip` query param (capture reads the query param on v0).

--- a/.sampo/changesets/dashing-warden-kalma.md
+++ b/.sampo/changesets/dashing-warden-kalma.md
@@ -3,3 +3,5 @@ cargo/posthog-rs: patch
 ---
 
 Serialize the v0 capture `distinct_id` at the event root (canonical field) instead of the legacy `$distinct_id` alias, matching v1 and the v0 ingestion contract. Add retries to the v0 capture paths: transport errors and 408/500/502/503/504 are retried with exponential backoff honoring `Retry-After`, and a 429 is retried only when it carries a `Retry-After` (a bare 429 stays a terminal rate-limit). Retried requests resend the same bytes, preserving the event UUID and timestamp that dedup relies on. Add opt-in gzip compression for v0 capture via `capture_compression`: the body is gzipped with a `Content-Encoding: gzip` header and a `compression=gzip` query param (capture reads the query param on v0).
+
+Fix the retry backoff timing on both v0 and v1: the first retry now waits exactly `retry_initial_backoff_ms` instead of double it (the call sites previously passed `attempt + 1` into the backoff calculation, skipping the configured initial delay).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1", features = [
     "time",
     "macros",
 ], optional = true }
-flate2 = { version = "1.0", optional = true }
+flate2 = "1.0"
 brotli = { version = "7.0", optional = true }
 zstd = { version = "0.13", optional = true }
 
@@ -38,6 +38,7 @@ zstd = { version = "0.13", optional = true }
 dotenv = "0.15.0"
 ctor = "0.1.26"
 tokio = { version = "1", features = ["full"] }
+flate2 = "1.0"
 httpmock = "0.7"
 serde_json = "1.0"
 futures = "0.3"
@@ -47,7 +48,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 default = ["async-client"]
 e2e-test = []
 async-client = ["tokio"]
-capture-v1 = ["flate2", "brotli", "zstd"]
+capture-v1 = ["brotli", "zstd"]
 test-harness = []
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ zstd = { version = "0.13", optional = true }
 dotenv = "0.15.0"
 ctor = "0.1.26"
 tokio = { version = "1", features = ["full"] }
-flate2 = "1.0"
 httpmock = "0.7"
 serde_json = "1.0"
 futures = "0.3"

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -121,11 +121,11 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     let mut capabilities: Vec<String> = Vec::new();
     if cfg!(feature = "capture-v1") {
         capabilities.push("capture_v1".to_string());
-        if let Some(algo) = state.compression {
-            capabilities.push(compression_capability(algo).to_string());
-        }
     } else {
         capabilities.push("capture_v0".to_string());
+    }
+    if let Some(algo) = state.compression {
+        capabilities.push(compression_capability(algo).to_string());
     }
     Json(HealthResponse {
         sdk_name: "posthog-rs",

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -128,7 +128,13 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         capabilities.push(compression_capability(algo).to_string());
     }
     Json(HealthResponse {
-        sdk_name: "posthog-rs",
+        // Per-build name so the v0 and v1 compliance jobs post distinct PR
+        // comments instead of overwriting one shared report.
+        sdk_name: if cfg!(feature = "capture-v1") {
+            "posthog-rs-v1"
+        } else {
+            "posthog-rs-v0"
+        },
         sdk_version: env!("CARGO_PKG_VERSION"),
         adapter_version: env!("CARGO_PKG_VERSION"),
         capabilities,

--- a/compliance/v0/Dockerfile
+++ b/compliance/v0/Dockerfile
@@ -6,5 +6,6 @@ RUN cargo build --release -p sdk-adapter
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/sdk-adapter /usr/local/bin/
+ENV COMPRESSION=gzip
 EXPOSE 8080
 CMD ["sdk-adapter"]

--- a/compliance/v0/docker-compose.yml
+++ b/compliance/v0/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ../..
       dockerfile: compliance/v0/Dockerfile
+    environment:
+      - COMPRESSION=gzip
     ports:
       - "8080:8080"
     networks:

--- a/compliance/v1/Dockerfile
+++ b/compliance/v1/Dockerfile
@@ -6,5 +6,6 @@ RUN cargo build --release -p sdk-adapter --features sdk-adapter/capture-v1
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/sdk-adapter /usr/local/bin/
+ENV COMPRESSION=gzip
 EXPOSE 8080
 CMD ["sdk-adapter"]

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -343,21 +343,9 @@ impl Client {
         super::v0_capture::prepare_event(&mut event, &defaults);
         let payload =
             super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
-
         let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let request = self
-            .client
-            .post(&url)
-            .header(CONTENT_TYPE, "application/json")
-            .body(payload);
-        let request = super::v0_capture::apply_extra_headers(&self.options, request);
-
-        let response = request
-            .send()
-            .await
-            .map_err(|e| Error::Connection(e.to_string()))?;
-
-        check_response(response).await
+        let (body, gzip) = self.encode_v0_body(payload);
+        self.send_v0_with_retry(&url, body, gzip).await
     }
 
     #[cfg(not(feature = "capture-v1"))]
@@ -374,19 +362,86 @@ impl Client {
             &defaults,
         )?;
         let url = self.options.endpoints().build_url(Endpoint::Batch);
-        let request = self
-            .client
-            .post(&url)
-            .header(CONTENT_TYPE, "application/json")
-            .body(payload);
-        let request = super::v0_capture::apply_extra_headers(&self.options, request);
+        let (body, gzip) = self.encode_v0_body(payload);
+        self.send_v0_with_retry(&url, body, gzip).await
+    }
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| Error::Connection(e.to_string()))?;
+    /// Encode the v0 JSON body, gzip-compressing when gzip is configured.
+    /// Returns the bytes and whether they are gzipped. v0 supports gzip only;
+    /// other algorithms (or a gzip failure) fall back to uncompressed.
+    #[cfg(not(feature = "capture-v1"))]
+    fn encode_v0_body(&self, json: String) -> (Vec<u8>, bool) {
+        match self.options.capture_compression {
+            Some(super::CaptureCompression::Gzip) => {
+                match crate::compression::gzip(json.as_bytes()) {
+                    Some(bytes) => (bytes, true),
+                    None => (json.into_bytes(), false),
+                }
+            }
+            Some(other) => {
+                tracing::warn!(
+                    ?other,
+                    "v0 capture supports gzip only; sending uncompressed"
+                );
+                (json.into_bytes(), false)
+            }
+            None => (json.into_bytes(), false),
+        }
+    }
 
-        check_response(response).await
+    /// POST `body` to `url`, retrying transient failures (transport errors and
+    /// 408/429/500/502/503/504) up to `max_capture_attempts`. The body is built
+    /// once by the caller and resent byte-for-byte, so a retried event keeps
+    /// its UUID and timestamp — which dedup relies on. When `gzip`, the request
+    /// advertises `Content-Encoding: gzip` and the `compression=gzip` query
+    /// param (capture reads the query param on v0, not the header).
+    #[cfg(not(feature = "capture-v1"))]
+    async fn send_v0_with_retry(&self, url: &str, body: Vec<u8>, gzip: bool) -> Result<(), Error> {
+        // v0 capture/batch URLs carry no query string, so capture reads the
+        // compression hint from this param (it does not consult Content-Encoding).
+        let url = if gzip {
+            format!("{url}?compression=gzip")
+        } else {
+            url.to_string()
+        };
+        let mut attempt: u32 = 1;
+        loop {
+            let mut request = self
+                .client
+                .post(&url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(body.clone());
+            if gzip {
+                request = request.header(reqwest::header::CONTENT_ENCODING, "gzip");
+            }
+            let request = super::v0_capture::apply_extra_headers(&self.options, request);
+
+            match request.send().await {
+                Err(e) => {
+                    if attempt >= self.options.max_capture_attempts {
+                        return Err(Error::Connection(e.to_string()));
+                    }
+                }
+                Ok(response) => {
+                    let status = response.status().as_u16();
+                    let retry_after = super::retry::parse_retry_after(response.headers());
+                    if !(super::retry::should_retry_v0(status, retry_after.is_some())
+                        && attempt < self.options.max_capture_attempts)
+                    {
+                        return check_response(response).await;
+                    }
+                    let delay =
+                        super::retry::backoff_duration(&self.options, attempt + 1, retry_after);
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                    continue;
+                }
+            }
+
+            let delay = super::retry::backoff_duration(&self.options, attempt + 1, None);
+            tokio::time::sleep(delay).await;
+            attempt += 1;
+        }
     }
 
     #[cfg(feature = "capture-v1")]

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -344,8 +344,8 @@ impl Client {
         let payload =
             super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
         let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let (body, gzip) = super::v0_capture::encode_body(&self.options, payload);
-        self.send_v0_with_retry(&url, body, gzip).await
+        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
+        self.send_v0_with_retry(&url, body, encoding).await
     }
 
     #[cfg(not(feature = "capture-v1"))]
@@ -362,24 +362,32 @@ impl Client {
             &defaults,
         )?;
         let url = self.options.endpoints().build_url(Endpoint::Batch);
-        let (body, gzip) = super::v0_capture::encode_body(&self.options, payload);
-        self.send_v0_with_retry(&url, body, gzip).await
+        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
+        self.send_v0_with_retry(&url, body, encoding).await
     }
 
     /// POST `body` to `url`, retrying transient failures (transport errors and
     /// 408/429/500/502/503/504) up to `max_capture_attempts`. The body is built
     /// once by the caller and resent byte-for-byte, so a retried event keeps
-    /// its UUID and timestamp — which dedup relies on. When `gzip`, the request
-    /// advertises `Content-Encoding: gzip` and the `compression=gzip` query
-    /// param (capture reads the query param on v0, not the header).
+    /// its UUID and timestamp — which dedup relies on. The retry decision is the
+    /// shared sans-IO logic in [`super::retry`]; this loop is just the transport.
+    /// When `encoding` is `Some`, the request advertises that `Content-Encoding`
+    /// and a matching `compression=<token>` query param (capture reads the query
+    /// param on v0, not the header).
     #[cfg(not(feature = "capture-v1"))]
-    async fn send_v0_with_retry(&self, url: &str, body: Vec<u8>, gzip: bool) -> Result<(), Error> {
+    async fn send_v0_with_retry(
+        &self,
+        url: &str,
+        body: Vec<u8>,
+        encoding: Option<&'static str>,
+    ) -> Result<(), Error> {
+        use super::retry::{v0_after_response, v0_after_transport_error, Step};
+
         // v0 capture/batch URLs carry no query string, so capture reads the
         // compression hint from this param (it does not consult Content-Encoding).
-        let url = if gzip {
-            format!("{url}?compression=gzip")
-        } else {
-            url.to_string()
+        let url = match encoding {
+            Some(token) => format!("{url}?compression={token}"),
+            None => url.to_string(),
         };
         let mut attempt: u32 = 1;
         loop {
@@ -388,36 +396,32 @@ impl Client {
                 .post(&url)
                 .header(CONTENT_TYPE, "application/json")
                 .body(body.clone());
-            if gzip {
-                request = request.header(reqwest::header::CONTENT_ENCODING, "gzip");
+            if let Some(token) = encoding {
+                request = request.header(reqwest::header::CONTENT_ENCODING, token);
             }
             let request = super::v0_capture::apply_extra_headers(&self.options, request);
 
-            match request.send().await {
-                Err(e) => {
-                    if attempt >= self.options.max_capture_attempts {
-                        return Err(Error::Connection(e.to_string()));
-                    }
-                }
+            let step = match request.send().await {
+                Err(e) => v0_after_transport_error(&self.options, attempt, e.to_string()),
                 Ok(response) => {
                     let status = response.status().as_u16();
                     let retry_after = super::retry::parse_retry_after(response.headers());
-                    if !(super::retry::should_retry_v0(status, retry_after.is_some())
-                        && attempt < self.options.max_capture_attempts)
-                    {
-                        return check_response(response).await;
-                    }
-                    let delay =
-                        super::retry::backoff_duration(&self.options, attempt + 1, retry_after);
+                    let body = response
+                        .text()
+                        .await
+                        .unwrap_or_else(|_| "Unknown error".to_string());
+                    v0_after_response(&self.options, attempt, status, retry_after, &body)
+                }
+            };
+
+            match step {
+                Step::Done => return Ok(()),
+                Step::Fail(e) => return Err(e),
+                Step::Backoff(delay) => {
                     tokio::time::sleep(delay).await;
                     attempt += 1;
-                    continue;
                 }
             }
-
-            let delay = super::retry::backoff_duration(&self.options, attempt + 1, None);
-            tokio::time::sleep(delay).await;
-            attempt += 1;
         }
     }
 

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -344,7 +344,7 @@ impl Client {
         let payload =
             super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
         let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let (body, gzip) = self.encode_v0_body(payload);
+        let (body, gzip) = super::v0_capture::encode_body(&self.options, payload);
         self.send_v0_with_retry(&url, body, gzip).await
     }
 
@@ -362,31 +362,8 @@ impl Client {
             &defaults,
         )?;
         let url = self.options.endpoints().build_url(Endpoint::Batch);
-        let (body, gzip) = self.encode_v0_body(payload);
+        let (body, gzip) = super::v0_capture::encode_body(&self.options, payload);
         self.send_v0_with_retry(&url, body, gzip).await
-    }
-
-    /// Encode the v0 JSON body, gzip-compressing when gzip is configured.
-    /// Returns the bytes and whether they are gzipped. v0 supports gzip only;
-    /// other algorithms (or a gzip failure) fall back to uncompressed.
-    #[cfg(not(feature = "capture-v1"))]
-    fn encode_v0_body(&self, json: String) -> (Vec<u8>, bool) {
-        match self.options.capture_compression {
-            Some(super::CaptureCompression::Gzip) => {
-                match crate::compression::gzip(json.as_bytes()) {
-                    Some(bytes) => (bytes, true),
-                    None => (json.into_bytes(), false),
-                }
-            }
-            Some(other) => {
-                tracing::warn!(
-                    ?other,
-                    "v0 capture supports gzip only; sending uncompressed"
-                );
-                (json.into_bytes(), false)
-            }
-            None => (json.into_bytes(), false),
-        }
     }
 
     /// POST `body` to `url`, retrying transient failures (transport errors and

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -326,20 +326,9 @@ impl Client {
         super::v0_capture::prepare_event(&mut event, &defaults);
         let payload =
             super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
-
         let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let request = self
-            .client
-            .post(&url)
-            .header(CONTENT_TYPE, "application/json")
-            .body(payload);
-        let request = super::v0_capture::apply_extra_headers(&self.options, request);
-
-        let response = request
-            .send()
-            .map_err(|e| Error::Connection(e.to_string()))?;
-
-        check_response(response)
+        let (body, gzip) = self.encode_v0_body(payload);
+        self.send_v0_with_retry(&url, body, gzip)
     }
 
     #[cfg(not(feature = "capture-v1"))]
@@ -356,18 +345,86 @@ impl Client {
             &defaults,
         )?;
         let url = self.options.endpoints().build_url(Endpoint::Batch);
-        let request = self
-            .client
-            .post(&url)
-            .header(CONTENT_TYPE, "application/json")
-            .body(payload);
-        let request = super::v0_capture::apply_extra_headers(&self.options, request);
+        let (body, gzip) = self.encode_v0_body(payload);
+        self.send_v0_with_retry(&url, body, gzip)
+    }
 
-        let response = request
-            .send()
-            .map_err(|e| Error::Connection(e.to_string()))?;
+    /// Encode the v0 JSON body, gzip-compressing when gzip is configured.
+    /// Returns the bytes and whether they are gzipped. v0 supports gzip only;
+    /// other algorithms (or a gzip failure) fall back to uncompressed.
+    #[cfg(not(feature = "capture-v1"))]
+    fn encode_v0_body(&self, json: String) -> (Vec<u8>, bool) {
+        match self.options.capture_compression {
+            Some(super::CaptureCompression::Gzip) => {
+                match crate::compression::gzip(json.as_bytes()) {
+                    Some(bytes) => (bytes, true),
+                    None => (json.into_bytes(), false),
+                }
+            }
+            Some(other) => {
+                tracing::warn!(
+                    ?other,
+                    "v0 capture supports gzip only; sending uncompressed"
+                );
+                (json.into_bytes(), false)
+            }
+            None => (json.into_bytes(), false),
+        }
+    }
 
-        check_response(response)
+    /// POST `body` to `url`, retrying transient failures (transport errors and
+    /// 408/429/500/502/503/504) up to `max_capture_attempts`. The body is built
+    /// once by the caller and resent byte-for-byte, so a retried event keeps
+    /// its UUID and timestamp — which dedup relies on. When `gzip`, the request
+    /// advertises `Content-Encoding: gzip` and the `compression=gzip` query
+    /// param (capture reads the query param on v0, not the header).
+    #[cfg(not(feature = "capture-v1"))]
+    fn send_v0_with_retry(&self, url: &str, body: Vec<u8>, gzip: bool) -> Result<(), Error> {
+        // v0 capture/batch URLs carry no query string, so capture reads the
+        // compression hint from this param (it does not consult Content-Encoding).
+        let url = if gzip {
+            format!("{url}?compression=gzip")
+        } else {
+            url.to_string()
+        };
+        let mut attempt: u32 = 1;
+        loop {
+            let mut request = self
+                .client
+                .post(&url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(body.clone());
+            if gzip {
+                request = request.header(reqwest::header::CONTENT_ENCODING, "gzip");
+            }
+            let request = super::v0_capture::apply_extra_headers(&self.options, request);
+
+            match request.send() {
+                Err(e) => {
+                    if attempt >= self.options.max_capture_attempts {
+                        return Err(Error::Connection(e.to_string()));
+                    }
+                }
+                Ok(response) => {
+                    let status = response.status().as_u16();
+                    let retry_after = super::retry::parse_retry_after(response.headers());
+                    if !(super::retry::should_retry_v0(status, retry_after.is_some())
+                        && attempt < self.options.max_capture_attempts)
+                    {
+                        return check_response(response);
+                    }
+                    let delay =
+                        super::retry::backoff_duration(&self.options, attempt + 1, retry_after);
+                    std::thread::sleep(delay);
+                    attempt += 1;
+                    continue;
+                }
+            }
+
+            let delay = super::retry::backoff_duration(&self.options, attempt + 1, None);
+            std::thread::sleep(delay);
+            attempt += 1;
+        }
     }
 
     #[cfg(feature = "capture-v1")]

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -327,8 +327,8 @@ impl Client {
         let payload =
             super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
         let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let (body, gzip) = super::v0_capture::encode_body(&self.options, payload);
-        self.send_v0_with_retry(&url, body, gzip)
+        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
+        self.send_v0_with_retry(&url, body, encoding)
     }
 
     #[cfg(not(feature = "capture-v1"))]
@@ -345,24 +345,32 @@ impl Client {
             &defaults,
         )?;
         let url = self.options.endpoints().build_url(Endpoint::Batch);
-        let (body, gzip) = super::v0_capture::encode_body(&self.options, payload);
-        self.send_v0_with_retry(&url, body, gzip)
+        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
+        self.send_v0_with_retry(&url, body, encoding)
     }
 
     /// POST `body` to `url`, retrying transient failures (transport errors and
     /// 408/429/500/502/503/504) up to `max_capture_attempts`. The body is built
     /// once by the caller and resent byte-for-byte, so a retried event keeps
-    /// its UUID and timestamp — which dedup relies on. When `gzip`, the request
-    /// advertises `Content-Encoding: gzip` and the `compression=gzip` query
-    /// param (capture reads the query param on v0, not the header).
+    /// its UUID and timestamp — which dedup relies on. The retry decision is the
+    /// shared sans-IO logic in [`super::retry`]; this loop is just the transport.
+    /// When `encoding` is `Some`, the request advertises that `Content-Encoding`
+    /// and a matching `compression=<token>` query param (capture reads the query
+    /// param on v0, not the header).
     #[cfg(not(feature = "capture-v1"))]
-    fn send_v0_with_retry(&self, url: &str, body: Vec<u8>, gzip: bool) -> Result<(), Error> {
+    fn send_v0_with_retry(
+        &self,
+        url: &str,
+        body: Vec<u8>,
+        encoding: Option<&'static str>,
+    ) -> Result<(), Error> {
+        use super::retry::{v0_after_response, v0_after_transport_error, Step};
+
         // v0 capture/batch URLs carry no query string, so capture reads the
         // compression hint from this param (it does not consult Content-Encoding).
-        let url = if gzip {
-            format!("{url}?compression=gzip")
-        } else {
-            url.to_string()
+        let url = match encoding {
+            Some(token) => format!("{url}?compression={token}"),
+            None => url.to_string(),
         };
         let mut attempt: u32 = 1;
         loop {
@@ -371,36 +379,31 @@ impl Client {
                 .post(&url)
                 .header(CONTENT_TYPE, "application/json")
                 .body(body.clone());
-            if gzip {
-                request = request.header(reqwest::header::CONTENT_ENCODING, "gzip");
+            if let Some(token) = encoding {
+                request = request.header(reqwest::header::CONTENT_ENCODING, token);
             }
             let request = super::v0_capture::apply_extra_headers(&self.options, request);
 
-            match request.send() {
-                Err(e) => {
-                    if attempt >= self.options.max_capture_attempts {
-                        return Err(Error::Connection(e.to_string()));
-                    }
-                }
+            let step = match request.send() {
+                Err(e) => v0_after_transport_error(&self.options, attempt, e.to_string()),
                 Ok(response) => {
                     let status = response.status().as_u16();
                     let retry_after = super::retry::parse_retry_after(response.headers());
-                    if !(super::retry::should_retry_v0(status, retry_after.is_some())
-                        && attempt < self.options.max_capture_attempts)
-                    {
-                        return check_response(response);
-                    }
-                    let delay =
-                        super::retry::backoff_duration(&self.options, attempt + 1, retry_after);
+                    let body = response
+                        .text()
+                        .unwrap_or_else(|_| "Unknown error".to_string());
+                    v0_after_response(&self.options, attempt, status, retry_after, &body)
+                }
+            };
+
+            match step {
+                Step::Done => return Ok(()),
+                Step::Fail(e) => return Err(e),
+                Step::Backoff(delay) => {
                     std::thread::sleep(delay);
                     attempt += 1;
-                    continue;
                 }
             }
-
-            let delay = super::retry::backoff_duration(&self.options, attempt + 1, None);
-            std::thread::sleep(delay);
-            attempt += 1;
         }
     }
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -327,7 +327,7 @@ impl Client {
         let payload =
             super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
         let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let (body, gzip) = self.encode_v0_body(payload);
+        let (body, gzip) = super::v0_capture::encode_body(&self.options, payload);
         self.send_v0_with_retry(&url, body, gzip)
     }
 
@@ -345,31 +345,8 @@ impl Client {
             &defaults,
         )?;
         let url = self.options.endpoints().build_url(Endpoint::Batch);
-        let (body, gzip) = self.encode_v0_body(payload);
+        let (body, gzip) = super::v0_capture::encode_body(&self.options, payload);
         self.send_v0_with_retry(&url, body, gzip)
-    }
-
-    /// Encode the v0 JSON body, gzip-compressing when gzip is configured.
-    /// Returns the bytes and whether they are gzipped. v0 supports gzip only;
-    /// other algorithms (or a gzip failure) fall back to uncompressed.
-    #[cfg(not(feature = "capture-v1"))]
-    fn encode_v0_body(&self, json: String) -> (Vec<u8>, bool) {
-        match self.options.capture_compression {
-            Some(super::CaptureCompression::Gzip) => {
-                match crate::compression::gzip(json.as_bytes()) {
-                    Some(bytes) => (bytes, true),
-                    None => (json.into_bytes(), false),
-                }
-            }
-            Some(other) => {
-                tracing::warn!(
-                    ?other,
-                    "v0 capture supports gzip only; sending uncompressed"
-                );
-                (json.into_bytes(), false)
-            }
-            None => (json.into_bytes(), false),
-        }
     }
 
     /// POST `body` to `url`, retrying transient failures (transport errors and

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,11 +2,12 @@ use crate::endpoints::{EndpointManager, DEFAULT_HOST};
 use derive_builder::Builder;
 use tracing::warn;
 
-/// Request-body compression algorithm for the V1 capture pipeline.
+/// Request-body compression algorithm for the capture pipelines.
 ///
-/// When set on [`ClientOptions`], V1 capture requests are compressed and the
+/// When set on [`ClientOptions`], capture requests are compressed and the
 /// matching `Content-Encoding` header is sent. The variant string matches the
-/// HTTP `Content-Encoding` token the server expects.
+/// HTTP `Content-Encoding` token the server expects. The V0 pipeline supports
+/// `Gzip` only; V1 supports all variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CaptureCompression {
     Gzip,
@@ -30,6 +31,7 @@ impl CaptureCompression {
 
 #[cfg(not(feature = "async-client"))]
 mod blocking;
+mod retry;
 #[cfg(not(feature = "capture-v1"))]
 mod v0_capture;
 #[cfg(feature = "capture-v1")]
@@ -138,11 +140,10 @@ pub struct ClientOptions {
     #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
     pub(crate) retry_max_backoff_ms: u64,
 
-    /// Optional request-body compression for the V1 capture pipeline. When
-    /// `None` (default), bodies are sent uncompressed. Requires the
-    /// `capture-v1` crate feature to take effect.
+    /// Optional request-body compression. When `None` (default), bodies are
+    /// sent uncompressed. The V0 pipeline supports `Gzip` only; V1 supports all
+    /// variants.
     #[builder(default, setter(strip_option))]
-    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
     pub(crate) capture_compression: Option<CaptureCompression>,
 
     /// Extra HTTP headers injected into every outbound capture request.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,7 +18,6 @@ pub enum CaptureCompression {
 
 impl CaptureCompression {
     /// The HTTP `Content-Encoding` token for this algorithm.
-    #[cfg(feature = "capture-v1")]
     pub(crate) fn content_encoding(self) -> &'static str {
         match self {
             CaptureCompression::Gzip => "gzip",

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -1,0 +1,155 @@
+//! Runtime-agnostic retry primitives shared by the V0 and V1 capture paths.
+
+use std::time::Duration;
+
+use reqwest::header::HeaderMap;
+
+use super::ClientOptions;
+
+/// Statuses worth retrying. Everything else (including 429) is terminal so the
+/// caller surfaces it without burning the attempt budget.
+pub(crate) fn is_retryable_status(status: u16) -> bool {
+    matches!(status, 408 | 500 | 502 | 503 | 504)
+}
+
+/// V0 retry decision. Beyond the shared retryable set, V0 retries 429 — but
+/// only when the server sent a `Retry-After` (an explicit "try again in N"
+/// instruction). A bare 429 stays terminal (`Error::RateLimit`), preserving
+/// long-standing v0 behavior. The V1 endpoint never returns 429, so this is
+/// intentionally scoped to V0.
+#[cfg(not(feature = "capture-v1"))]
+pub(crate) fn should_retry_v0(status: u16, has_retry_after: bool) -> bool {
+    is_retryable_status(status) || (status == 429 && has_retry_after)
+}
+
+/// Parse a numeric `Retry-After` (seconds). Ignores HTTP-date form, which the
+/// capture endpoints don't use.
+pub(crate) fn parse_retry_after(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+}
+
+/// Backoff before `attempt`: honor `Retry-After` when present, otherwise
+/// exponential growth from `retry_initial_backoff_ms`, clamped to
+/// `retry_max_backoff_ms`.
+pub(crate) fn backoff_duration(
+    opts: &ClientOptions,
+    attempt: u32,
+    retry_after_secs: Option<u64>,
+) -> Duration {
+    if let Some(secs) = retry_after_secs {
+        Duration::from_secs(secs)
+    } else {
+        let base_ms = opts.retry_initial_backoff_ms;
+        let max_ms = opts.retry_max_backoff_ms;
+        let backoff_ms = base_ms.saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)));
+        Duration::from_millis(backoff_ms.min(max_ms))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::{HeaderMap, HeaderValue};
+
+    use super::*;
+    use crate::client::ClientOptionsBuilder;
+
+    fn test_opts() -> ClientOptions {
+        ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .max_capture_attempts(3u32)
+            .retry_initial_backoff_ms(100u64)
+            .retry_max_backoff_ms(5000u64)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn retryable_statuses() {
+        for code in [408, 500, 502, 503, 504] {
+            assert!(
+                is_retryable_status(code),
+                "expected {} to be retryable",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn non_retryable_statuses() {
+        for code in [200, 201, 400, 401, 402, 403, 413, 415, 418, 429, 404] {
+            assert!(
+                !is_retryable_status(code),
+                "expected {} to NOT be retryable",
+                code
+            );
+        }
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    #[test]
+    fn v0_retries_429_only_with_retry_after() {
+        assert!(should_retry_v0(429, true));
+        assert!(!should_retry_v0(429, false));
+        // The shared retryable set applies regardless of Retry-After.
+        for code in [408, 500, 502, 503, 504] {
+            assert!(should_retry_v0(code, false));
+            assert!(should_retry_v0(code, true));
+        }
+        // Genuinely terminal statuses stay terminal either way.
+        for code in [400, 401, 402, 403, 413, 415] {
+            assert!(!should_retry_v0(code, false));
+            assert!(!should_retry_v0(code, true));
+        }
+    }
+
+    #[test]
+    fn parse_retry_after_valid() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("5"));
+        assert_eq!(parse_retry_after(&headers), Some(5));
+    }
+
+    #[test]
+    fn parse_retry_after_missing() {
+        let headers = HeaderMap::new();
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn parse_retry_after_non_numeric() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("not-a-number"));
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn backoff_explicit_retry_after_wins() {
+        let opts = test_opts();
+        assert_eq!(
+            backoff_duration(&opts, 1, Some(42)),
+            Duration::from_secs(42)
+        );
+    }
+
+    #[test]
+    fn backoff_exponential_growth() {
+        let opts = test_opts();
+        assert_eq!(backoff_duration(&opts, 1, None), Duration::from_millis(100));
+        assert_eq!(backoff_duration(&opts, 2, None), Duration::from_millis(200));
+        assert_eq!(backoff_duration(&opts, 3, None), Duration::from_millis(400));
+    }
+
+    #[test]
+    fn backoff_clamped_to_max() {
+        let opts = ClientOptionsBuilder::default()
+            .api_key("k".to_string())
+            .retry_initial_backoff_ms(100u64)
+            .retry_max_backoff_ms(150u64)
+            .build()
+            .unwrap();
+        assert_eq!(backoff_duration(&opts, 3, None), Duration::from_millis(150));
+    }
+}

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -5,6 +5,16 @@ use std::time::Duration;
 use reqwest::header::HeaderMap;
 
 use super::ClientOptions;
+use crate::error::Error;
+
+/// Outcome of one capture attempt, computed without any I/O so both the async
+/// and blocking clients (and both V0 and V1) can share the decision logic and
+/// keep only the transport-specific loop.
+pub(crate) enum Step {
+    Done,
+    Backoff(Duration),
+    Fail(Error),
+}
 
 /// Statuses worth retrying. Everything else (including 429) is terminal so the
 /// caller surfaces it without burning the attempt budget.
@@ -47,6 +57,41 @@ pub(crate) fn backoff_duration(
         let backoff_ms = base_ms.saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)));
         Duration::from_millis(backoff_ms.min(max_ms))
     }
+}
+
+/// Sans-IO decision for a completed V0 capture response. `attempt` is the
+/// just-finished attempt number (1-based); the backoff for the next attempt
+/// uses `attempt` directly so the first retry waits exactly
+/// `retry_initial_backoff_ms`.
+#[cfg(not(feature = "capture-v1"))]
+pub(crate) fn v0_after_response(
+    opts: &ClientOptions,
+    attempt: u32,
+    status: u16,
+    retry_after: Option<u64>,
+    body: &str,
+) -> Step {
+    if should_retry_v0(status, retry_after.is_some()) && attempt < opts.max_capture_attempts {
+        return Step::Backoff(backoff_duration(opts, attempt, retry_after));
+    }
+    match Error::from_http_response(status, body.to_string()) {
+        Some(err) => Step::Fail(err),
+        None => Step::Done,
+    }
+}
+
+/// Sans-IO decision for a V0 transport error (no HTTP response). Retries
+/// transport failures until the attempt budget is exhausted.
+#[cfg(not(feature = "capture-v1"))]
+pub(crate) fn v0_after_transport_error(
+    opts: &ClientOptions,
+    attempt: u32,
+    err_msg: String,
+) -> Step {
+    if attempt >= opts.max_capture_attempts {
+        return Step::Fail(Error::Connection(err_msg));
+    }
+    Step::Backoff(backoff_duration(opts, attempt, None))
 }
 
 #[cfg(test)]
@@ -153,5 +198,99 @@ mod tests {
             .build()
             .unwrap();
         assert_eq!(backoff_duration(&opts, 3, None), Duration::from_millis(150));
+    }
+
+    // -- v0 sans-IO decisions ------------------------------------------------
+
+    #[cfg(not(feature = "capture-v1"))]
+    fn schedule_opts() -> ClientOptions {
+        ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .max_capture_attempts(10u32)
+            .retry_initial_backoff_ms(100u64)
+            .retry_max_backoff_ms(1_000_000u64)
+            .build()
+            .unwrap()
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    fn backoff_ms(step: Step) -> u64 {
+        match step {
+            Step::Backoff(d) => d.as_millis() as u64,
+            _ => panic!("expected Step::Backoff"),
+        }
+    }
+
+    /// The schedule the call sites actually produce. Guards the `attempt + 1`
+    /// off-by-one: the first retry must wait exactly `retry_initial_backoff_ms`
+    /// (100ms here), not double it.
+    #[cfg(not(feature = "capture-v1"))]
+    #[test]
+    fn v0_backoff_schedule_starts_at_initial() {
+        let opts = schedule_opts();
+        // attempt = the just-finished attempt; first retry follows attempt 1.
+        assert_eq!(
+            backoff_ms(v0_after_response(&opts, 1, 503, None, "")),
+            100,
+            "first retry must honor retry_initial_backoff_ms exactly"
+        );
+        assert_eq!(backoff_ms(v0_after_response(&opts, 2, 503, None, "")), 200);
+        assert_eq!(backoff_ms(v0_after_response(&opts, 3, 503, None, "")), 400);
+        // Same schedule for transport errors.
+        assert_eq!(
+            backoff_ms(v0_after_transport_error(&opts, 1, "timeout".into())),
+            100
+        );
+        assert_eq!(
+            backoff_ms(v0_after_transport_error(&opts, 2, "timeout".into())),
+            200
+        );
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    #[test]
+    fn v0_after_response_terminal_and_success() {
+        let opts = schedule_opts();
+        // 2xx -> Done.
+        assert!(matches!(
+            v0_after_response(&opts, 1, 200, None, ""),
+            Step::Done
+        ));
+        // Bare 429 (no Retry-After) -> terminal RateLimit, no retry.
+        assert!(matches!(
+            v0_after_response(&opts, 1, 429, None, ""),
+            Step::Fail(Error::RateLimit)
+        ));
+        // 429 + Retry-After -> retried.
+        assert!(matches!(
+            v0_after_response(&opts, 1, 429, Some(1), ""),
+            Step::Backoff(_)
+        ));
+        // Non-retryable 4xx -> terminal.
+        assert!(matches!(
+            v0_after_response(&opts, 1, 400, None, "bad"),
+            Step::Fail(Error::BadRequest(_))
+        ));
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    #[test]
+    fn v0_exhausts_attempt_budget() {
+        let opts = ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .max_capture_attempts(3u32)
+            .retry_initial_backoff_ms(1u64)
+            .retry_max_backoff_ms(5u64)
+            .build()
+            .unwrap();
+        // Retryable status on the final attempt surfaces the error instead of backing off.
+        assert!(matches!(
+            v0_after_response(&opts, 3, 503, None, "boom"),
+            Step::Fail(Error::ServerError { .. })
+        ));
+        assert!(matches!(
+            v0_after_transport_error(&opts, 3, "timeout".into()),
+            Step::Fail(Error::Connection(_))
+        ));
     }
 }

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -106,23 +106,25 @@ mod tests {
     }
 
     #[test]
-    fn parse_retry_after_valid() {
-        let mut headers = HeaderMap::new();
-        headers.insert("retry-after", HeaderValue::from_static("5"));
-        assert_eq!(parse_retry_after(&headers), Some(5));
-    }
-
-    #[test]
-    fn parse_retry_after_missing() {
-        let headers = HeaderMap::new();
-        assert_eq!(parse_retry_after(&headers), None);
-    }
-
-    #[test]
-    fn parse_retry_after_non_numeric() {
-        let mut headers = HeaderMap::new();
-        headers.insert("retry-after", HeaderValue::from_static("not-a-number"));
-        assert_eq!(parse_retry_after(&headers), None);
+    fn parse_retry_after_cases() {
+        // (header value, expected): numeric parses, missing/non-numeric are None.
+        let cases: [(Option<&str>, Option<u64>); 3] = [
+            (Some("5"), Some(5)),
+            (None, None),
+            (Some("not-a-number"), None),
+        ];
+        for (header_val, expected) in cases {
+            let mut headers = HeaderMap::new();
+            if let Some(v) = header_val {
+                headers.insert("retry-after", HeaderValue::from_str(v).unwrap());
+            }
+            assert_eq!(
+                parse_retry_after(&headers),
+                expected,
+                "header={:?}",
+                header_val
+            );
+        }
     }
 
     #[test]

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -7,7 +7,7 @@ use reqwest::blocking::RequestBuilder;
 #[cfg(feature = "async-client")]
 use reqwest::RequestBuilder;
 
-use super::{CaptureCompression, CaptureDefaults, ClientOptions};
+use super::{CaptureDefaults, ClientOptions};
 use crate::error::Error;
 use crate::event::{BatchRequest, Event, InnerEvent};
 
@@ -62,23 +62,21 @@ pub(crate) fn build_batch_payload(
     serde_json::to_string(&batch_request).map_err(|e| Error::Serialization(e.to_string()))
 }
 
-/// Encode the V0 JSON body, gzip-compressing when gzip is configured. Returns
-/// the bytes and whether they are gzipped. V0 supports gzip only; other
-/// algorithms (or a gzip failure) fall back to uncompressed.
-pub(crate) fn encode_body(options: &ClientOptions, json: String) -> (Vec<u8>, bool) {
+/// Encode the V0 JSON body, compressing when configured. Returns the bytes and
+/// the `Content-Encoding` token to advertise (`Some(token)` when compressed,
+/// `None` when sent uncompressed). Routes through the shared `compress()`, so a
+/// V0 build is gzip-only by construction; a non-gzip algorithm or a compression
+/// failure falls back to uncompressed.
+pub(crate) fn encode_body(
+    options: &ClientOptions,
+    json: String,
+) -> (Vec<u8>, Option<&'static str>) {
     match options.capture_compression {
-        Some(CaptureCompression::Gzip) => match crate::compression::gzip(json.as_bytes()) {
-            Some(bytes) => (bytes, true),
-            None => (json.into_bytes(), false),
+        Some(algo) => match crate::compression::compress(algo, json.as_bytes()) {
+            Some((bytes, encoding)) => (bytes, Some(encoding)),
+            None => (json.into_bytes(), None),
         },
-        Some(other) => {
-            tracing::warn!(
-                ?other,
-                "v0 capture supports gzip only; sending uncompressed"
-            );
-            (json.into_bytes(), false)
-        }
-        None => (json.into_bytes(), false),
+        None => (json.into_bytes(), None),
     }
 }
 

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -7,7 +7,7 @@ use reqwest::blocking::RequestBuilder;
 #[cfg(feature = "async-client")]
 use reqwest::RequestBuilder;
 
-use super::{CaptureDefaults, ClientOptions};
+use super::{CaptureCompression, CaptureDefaults, ClientOptions};
 use crate::error::Error;
 use crate::event::{BatchRequest, Event, InnerEvent};
 
@@ -60,6 +60,26 @@ pub(crate) fn build_batch_payload(
         batch: inner_events,
     };
     serde_json::to_string(&batch_request).map_err(|e| Error::Serialization(e.to_string()))
+}
+
+/// Encode the V0 JSON body, gzip-compressing when gzip is configured. Returns
+/// the bytes and whether they are gzipped. V0 supports gzip only; other
+/// algorithms (or a gzip failure) fall back to uncompressed.
+pub(crate) fn encode_body(options: &ClientOptions, json: String) -> (Vec<u8>, bool) {
+    match options.capture_compression {
+        Some(CaptureCompression::Gzip) => match crate::compression::gzip(json.as_bytes()) {
+            Some(bytes) => (bytes, true),
+            None => (json.into_bytes(), false),
+        },
+        Some(other) => {
+            tracing::warn!(
+                ?other,
+                "v0 capture supports gzip only; sending uncompressed"
+            );
+            (json.into_bytes(), false)
+        }
+        None => (json.into_bytes(), false),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -11,6 +11,10 @@ use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use tracing::debug;
 use uuid::Uuid;
 
+use super::retry::{backoff_duration, is_retryable_status};
+// Re-exported so the V1 capture loop in the client modules can reach it as
+// `v1_capture::parse_retry_after`.
+pub(crate) use super::retry::parse_retry_after;
 use super::{CaptureCompression, CaptureDefaults, ClientOptions};
 use crate::error::Error;
 use crate::event::Event;
@@ -102,36 +106,6 @@ pub(crate) fn maybe_compress(
         }
     }
     payload
-}
-
-// ---------------------------------------------------------------------------
-// Retry helpers
-// ---------------------------------------------------------------------------
-
-pub(crate) fn is_retryable_status(status: u16) -> bool {
-    matches!(status, 408 | 500 | 502 | 503 | 504)
-}
-
-pub(crate) fn parse_retry_after(headers: &HeaderMap) -> Option<u64> {
-    headers
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-}
-
-pub(crate) fn backoff_duration(
-    opts: &ClientOptions,
-    attempt: u32,
-    retry_after_secs: Option<u64>,
-) -> Duration {
-    if let Some(secs) = retry_after_secs {
-        Duration::from_secs(secs)
-    } else {
-        let base_ms = opts.retry_initial_backoff_ms;
-        let max_ms = opts.retry_max_backoff_ms;
-        let backoff_ms = base_ms.saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)));
-        Duration::from_millis(backoff_ms.min(max_ms))
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -279,9 +253,7 @@ pub(crate) fn after_response(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::time::Duration;
 
-    use reqwest::header::{HeaderMap, HeaderValue};
     use uuid::Uuid;
 
     use super::*;
@@ -316,84 +288,6 @@ mod tests {
             result: status,
             details: details.map(String::from),
         }
-    }
-
-    // -- is_retryable_status -------------------------------------------------
-
-    #[test]
-    fn retryable_statuses() {
-        for code in [408, 500, 502, 503, 504] {
-            assert!(
-                is_retryable_status(code),
-                "expected {} to be retryable",
-                code
-            );
-        }
-    }
-
-    #[test]
-    fn non_retryable_statuses() {
-        for code in [200, 201, 400, 401, 402, 403, 413, 415, 418, 404] {
-            assert!(
-                !is_retryable_status(code),
-                "expected {} to NOT be retryable",
-                code
-            );
-        }
-    }
-
-    // -- parse_retry_after ---------------------------------------------------
-
-    #[test]
-    fn parse_retry_after_valid() {
-        let mut headers = HeaderMap::new();
-        headers.insert("retry-after", HeaderValue::from_static("5"));
-        assert_eq!(parse_retry_after(&headers), Some(5));
-    }
-
-    #[test]
-    fn parse_retry_after_missing() {
-        let headers = HeaderMap::new();
-        assert_eq!(parse_retry_after(&headers), None);
-    }
-
-    #[test]
-    fn parse_retry_after_non_numeric() {
-        let mut headers = HeaderMap::new();
-        headers.insert("retry-after", HeaderValue::from_static("not-a-number"));
-        assert_eq!(parse_retry_after(&headers), None);
-    }
-
-    // -- backoff_duration ----------------------------------------------------
-
-    #[test]
-    fn backoff_explicit_retry_after_wins() {
-        let opts = test_opts();
-        let d = backoff_duration(&opts, 1, Some(42));
-        assert_eq!(d, Duration::from_secs(42));
-    }
-
-    #[test]
-    fn backoff_exponential_growth() {
-        let opts = test_opts();
-        let d1 = backoff_duration(&opts, 1, None);
-        let d2 = backoff_duration(&opts, 2, None);
-        let d3 = backoff_duration(&opts, 3, None);
-        assert_eq!(d1, Duration::from_millis(100));
-        assert_eq!(d2, Duration::from_millis(200));
-        assert_eq!(d3, Duration::from_millis(400));
-    }
-
-    #[test]
-    fn backoff_clamped_to_max() {
-        let opts = ClientOptionsBuilder::default()
-            .api_key("k".to_string())
-            .retry_initial_backoff_ms(100u64)
-            .retry_max_backoff_ms(150u64)
-            .build()
-            .unwrap();
-        let d = backoff_duration(&opts, 3, None);
-        assert_eq!(d, Duration::from_millis(150));
     }
 
     // -- count_results -------------------------------------------------------

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -2,7 +2,6 @@
 //! Each client keeps only the I/O; this module owns everything else.
 
 use std::collections::HashMap;
-use std::time::Duration;
 
 pub(crate) const V1_CAPTURE_PATH: &str = "/i/v1/analytics/events";
 
@@ -12,9 +11,9 @@ use tracing::debug;
 use uuid::Uuid;
 
 use super::retry::{backoff_duration, is_retryable_status};
-// Re-exported so the V1 capture loop in the client modules can reach it as
-// `v1_capture::parse_retry_after`.
-pub(crate) use super::retry::parse_retry_after;
+// Re-exported so the V1 capture loops in the client modules can reach them as
+// `v1_capture::parse_retry_after` / `v1_capture::Step`.
+pub(crate) use super::retry::{parse_retry_after, Step};
 use super::{CaptureCompression, CaptureDefaults, ClientOptions};
 use crate::error::Error;
 use crate::event::Event;
@@ -155,12 +154,6 @@ pub(crate) fn process_batch_response(
 // Sans-IO control flow
 // ---------------------------------------------------------------------------
 
-pub(crate) enum Step {
-    Done,
-    Backoff(Duration),
-    Fail(Error),
-}
-
 pub(crate) fn after_transport_error(
     opts: &ClientOptions,
     request_id: &Uuid,
@@ -176,7 +169,7 @@ pub(crate) fn after_transport_error(
         error = %err_msg,
         "V1 capture request failed, will retry"
     );
-    Step::Backoff(backoff_duration(opts, attempt + 1, None))
+    Step::Backoff(backoff_duration(opts, attempt, None))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -218,7 +211,7 @@ pub(crate) fn after_response(
         if pending.is_empty() || is_final {
             Step::Done
         } else {
-            Step::Backoff(backoff_duration(opts, attempt + 1, retry_after))
+            Step::Backoff(backoff_duration(opts, attempt, retry_after))
         }
     } else if is_retryable_status(status) {
         let error_desc = serde_json::from_str::<V1ErrorResponse>(body)
@@ -240,7 +233,7 @@ pub(crate) fn after_response(
                     .unwrap_or_else(|| Error::Connection(format!("HTTP {status}"))),
             )
         } else {
-            Step::Backoff(backoff_duration(opts, attempt + 1, retry_after))
+            Step::Backoff(backoff_duration(opts, attempt, retry_after))
         }
     } else {
         Step::Fail(
@@ -386,6 +379,55 @@ mod tests {
         let next = process_batch_response(vec![e.clone()], &results, &mut final_results, false);
         assert!(next.is_empty());
         assert!(final_results.is_empty());
+    }
+
+    // -- backoff schedule ----------------------------------------------------
+
+    /// Guards the `attempt + 1` off-by-one on the V1 call sites: the first
+    /// retry must wait exactly `retry_initial_backoff_ms`, not double it.
+    #[test]
+    fn v1_backoff_schedule_starts_at_initial() {
+        let opts = ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .max_capture_attempts(10u32)
+            .retry_initial_backoff_ms(100u64)
+            .retry_max_backoff_ms(1_000_000u64)
+            .build()
+            .unwrap();
+        let rid = Uuid::now_v7();
+        let ms = |step: Step| match step {
+            Step::Backoff(d) => d.as_millis() as u64,
+            _ => panic!("expected Step::Backoff"),
+        };
+        assert_eq!(
+            ms(after_transport_error(&opts, &rid, 1, "timeout".into())),
+            100,
+            "first retry must honor retry_initial_backoff_ms exactly"
+        );
+        assert_eq!(
+            ms(after_transport_error(&opts, &rid, 2, "timeout".into())),
+            200
+        );
+        assert_eq!(
+            ms(after_transport_error(&opts, &rid, 3, "timeout".into())),
+            400
+        );
+
+        // Same schedule via a retryable HTTP response.
+        let body = r#"{"error":"service_unavailable"}"#;
+        let mut pending = vec![dummy_v1_event()];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            1,
+            503,
+            None,
+            body,
+            &mut pending,
+            &mut final_results,
+        );
+        assert_eq!(ms(step), 100);
     }
 
     // -- after_transport_error -----------------------------------------------

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,10 +1,10 @@
 //! Request-body compression for the capture pipelines.
 //!
-//! `gzip` is always available (used by V0 and V1). The multi-algorithm
-//! `compress` entry point is V1-only, since deflate/br/zstd ship behind the
-//! `capture-v1` feature.
+//! `compress` is the single entry point shared by V0 and V1. `gzip` is always
+//! available (V0 supports gzip only); `deflate`/`br`/`zstd` ship behind the
+//! `capture-v1` feature, so in a V0 build those codecs aren't compiled in and
+//! the enum's non-gzip variants fall back to uncompressed.
 
-#[cfg(feature = "capture-v1")]
 use crate::client::CaptureCompression;
 
 /// Gzip-compress `data`. Returns `None` (with a warning) on failure so the
@@ -22,47 +22,74 @@ pub(crate) fn gzip(data: &[u8]) -> Option<Vec<u8>> {
     }
 }
 
-/// Compress `data` with `algo`, returning the compressed bytes alongside the
-/// HTTP `Content-Encoding` token to advertise. Returns `None` when compression
-/// fails, signalling the caller to send the payload uncompressed without a
-/// `Content-Encoding` header.
 #[cfg(feature = "capture-v1")]
-pub(crate) fn compress(algo: CaptureCompression, data: &[u8]) -> Option<(Vec<u8>, &'static str)> {
+fn deflate(data: &[u8]) -> Option<Vec<u8>> {
     use std::io::Write;
 
-    let encoding = algo.content_encoding();
-    if let CaptureCompression::Gzip = algo {
-        return gzip(data).map(|bytes| (bytes, encoding));
-    }
-    let result: std::io::Result<Vec<u8>> = match algo {
-        CaptureCompression::Gzip => unreachable!("handled above"),
-        CaptureCompression::Deflate => {
-            let mut encoder =
-                flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-            encoder.write_all(data).and_then(|_| encoder.finish())
-        }
-        CaptureCompression::Br => {
-            let mut out = Vec::new();
-            {
-                let mut encoder = brotli::CompressorWriter::new(&mut out, 4096, 5, 22);
-                if let Err(e) = encoder.write_all(data).and_then(|_| encoder.flush()) {
-                    Err(e)
-                } else {
-                    Ok(())
-                }
-            }
-            .map(|_| out)
-        }
-        CaptureCompression::Zstd => zstd::stream::encode_all(data, 0),
-    };
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    encode_or_warn(
+        "deflate",
+        encoder.write_all(data).and_then(|_| encoder.finish()),
+    )
+}
 
+#[cfg(feature = "capture-v1")]
+fn brotli(data: &[u8]) -> Option<Vec<u8>> {
+    use std::io::Write;
+
+    let mut out = Vec::new();
+    let result = {
+        let mut encoder = brotli::CompressorWriter::new(&mut out, 4096, 5, 22);
+        encoder.write_all(data).and_then(|_| encoder.flush())
+    };
+    encode_or_warn("br", result.map(|_| out))
+}
+
+#[cfg(feature = "capture-v1")]
+fn zstd(data: &[u8]) -> Option<Vec<u8>> {
+    encode_or_warn("zstd", zstd::stream::encode_all(data, 0))
+}
+
+#[cfg(feature = "capture-v1")]
+fn encode_or_warn(encoding: &'static str, result: std::io::Result<Vec<u8>>) -> Option<Vec<u8>> {
     match result {
-        Ok(bytes) => Some((bytes, encoding)),
+        Ok(bytes) => Some(bytes),
         Err(e) => {
-            tracing::warn!(error = %e, encoding, "failed to compress V1 capture body; sending uncompressed");
+            tracing::warn!(error = %e, encoding, "failed to compress capture body; sending uncompressed");
             None
         }
     }
+}
+
+/// Compress `data` with `algo`, returning the compressed bytes alongside the
+/// HTTP `Content-Encoding` token to advertise. Returns `None` when compression
+/// fails (or the algorithm isn't supported by this build), signalling the
+/// caller to send the payload uncompressed without a `Content-Encoding` header.
+///
+/// The `gzip` arm is always compiled; the deflate/br/zstd arms exist only with
+/// the `capture-v1` feature, so a V0 build is gzip-only by construction.
+pub(crate) fn compress(algo: CaptureCompression, data: &[u8]) -> Option<(Vec<u8>, &'static str)> {
+    let encoding = algo.content_encoding();
+    let bytes = match algo {
+        CaptureCompression::Gzip => gzip(data)?,
+        #[cfg(feature = "capture-v1")]
+        CaptureCompression::Deflate => deflate(data)?,
+        #[cfg(feature = "capture-v1")]
+        CaptureCompression::Br => brotli(data)?,
+        #[cfg(feature = "capture-v1")]
+        CaptureCompression::Zstd => zstd(data)?,
+        // V0 build: the enum still has these variants, but their codecs aren't
+        // compiled in, so we can't honor them — send uncompressed instead.
+        #[cfg(not(feature = "capture-v1"))]
+        other => {
+            tracing::warn!(
+                ?other,
+                "v0 capture supports gzip only; sending uncompressed"
+            );
+            return None;
+        }
+    };
+    Some((bytes, encoding))
 }
 
 #[cfg(test)]
@@ -82,9 +109,8 @@ mod tests {
         assert_eq!(out, data);
     }
 
-    #[cfg(feature = "capture-v1")]
     #[test]
-    fn gzip_roundtrips() {
+    fn compress_gzip_roundtrips() {
         let data = br#"{"hello":"world"}"#;
         let (compressed, encoding) = compress(CaptureCompression::Gzip, data).unwrap();
         assert_eq!(encoding, "gzip");
@@ -94,6 +120,17 @@ mod tests {
         let mut out = Vec::new();
         decoder.read_to_end(&mut out).unwrap();
         assert_eq!(out, data);
+    }
+
+    /// In a V0 build the non-gzip codecs aren't compiled in, so `compress`
+    /// falls back to uncompressed (`None`) — this is the gzip-only gate.
+    #[cfg(not(feature = "capture-v1"))]
+    #[test]
+    fn compress_non_gzip_falls_back_to_uncompressed_in_v0() {
+        let data = br#"{"hello":"world"}"#;
+        assert!(compress(CaptureCompression::Deflate, data).is_none());
+        assert!(compress(CaptureCompression::Br, data).is_none());
+        assert!(compress(CaptureCompression::Zstd, data).is_none());
     }
 
     #[cfg(feature = "capture-v1")]

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,23 +1,41 @@
-//! Request-body compression for the V1 capture pipeline.
+//! Request-body compression for the capture pipelines.
 //!
-//! This module is only compiled when the `capture-v1` crate feature is enabled.
+//! `gzip` is always available (used by V0 and V1). The multi-algorithm
+//! `compress` entry point is V1-only, since deflate/br/zstd ship behind the
+//! `capture-v1` feature.
 
+#[cfg(feature = "capture-v1")]
 use crate::client::CaptureCompression;
+
+/// Gzip-compress `data`. Returns `None` (with a warning) on failure so the
+/// caller can fall back to sending the payload uncompressed.
+pub(crate) fn gzip(data: &[u8]) -> Option<Vec<u8>> {
+    use std::io::Write;
+
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    match encoder.write_all(data).and_then(|_| encoder.finish()) {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to gzip capture body; sending uncompressed");
+            None
+        }
+    }
+}
 
 /// Compress `data` with `algo`, returning the compressed bytes alongside the
 /// HTTP `Content-Encoding` token to advertise. Returns `None` when compression
 /// fails, signalling the caller to send the payload uncompressed without a
 /// `Content-Encoding` header.
+#[cfg(feature = "capture-v1")]
 pub(crate) fn compress(algo: CaptureCompression, data: &[u8]) -> Option<(Vec<u8>, &'static str)> {
     use std::io::Write;
 
     let encoding = algo.content_encoding();
+    if let CaptureCompression::Gzip = algo {
+        return gzip(data).map(|bytes| (bytes, encoding));
+    }
     let result: std::io::Result<Vec<u8>> = match algo {
-        CaptureCompression::Gzip => {
-            let mut encoder =
-                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-            encoder.write_all(data).and_then(|_| encoder.finish())
-        }
+        CaptureCompression::Gzip => unreachable!("handled above"),
         CaptureCompression::Deflate => {
             let mut encoder =
                 flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
@@ -53,6 +71,19 @@ mod tests {
     use std::io::Read;
 
     #[test]
+    fn gzip_helper_roundtrips() {
+        let data = br#"{"hello":"world"}"#;
+        let compressed = gzip(data).unwrap();
+        assert_ne!(compressed, data);
+
+        let mut decoder = flate2::read::GzDecoder::new(&compressed[..]);
+        let mut out = Vec::new();
+        decoder.read_to_end(&mut out).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[cfg(feature = "capture-v1")]
+    #[test]
     fn gzip_roundtrips() {
         let data = br#"{"hello":"world"}"#;
         let (compressed, encoding) = compress(CaptureCompression::Gzip, data).unwrap();
@@ -65,6 +96,7 @@ mod tests {
         assert_eq!(out, data);
     }
 
+    #[cfg(feature = "capture-v1")]
     #[test]
     fn deflate_roundtrips() {
         let data = br#"{"hello":"world"}"#;
@@ -77,6 +109,7 @@ mod tests {
         assert_eq!(out, data);
     }
 
+    #[cfg(feature = "capture-v1")]
     #[test]
     fn zstd_roundtrips() {
         let data = br#"{"hello":"world"}"#;
@@ -86,6 +119,7 @@ mod tests {
         assert_eq!(out, data);
     }
 
+    #[cfg(feature = "capture-v1")]
     #[test]
     fn brotli_produces_output() {
         let data = br#"{"hello":"world"}"#;

--- a/src/event.rs
+++ b/src/event.rs
@@ -33,7 +33,6 @@ pub struct EventOptions {
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Event {
     event: String,
-    #[serde(rename = "$distinct_id")]
     distinct_id: String,
     properties: HashMap<String, serde_json::Value>,
     groups: HashMap<String, String>,
@@ -319,7 +318,6 @@ pub struct InnerEvent {
     api_key: String,
     uuid: Uuid,
     event: String,
-    #[serde(rename = "$distinct_id")]
     distinct_id: String,
     properties: HashMap<String, serde_json::Value>,
     timestamp: Option<NaiveDateTime>,
@@ -362,6 +360,39 @@ pub mod tests {
             inner.properties.get("$lib"),
             Some(&serde_json::Value::String("posthog-rs".to_string()))
         );
+    }
+
+    #[test]
+    fn v0_serializes_distinct_id_at_root() {
+        let inner = build_v0(Event::new("test", "user1"));
+        let json = serde_json::to_value(&inner).unwrap();
+
+        // Canonical field at the event root; the legacy `$distinct_id` spelling
+        // (only tolerated by capture via a serde alias) must not be emitted.
+        assert_eq!(json["distinct_id"], "user1");
+        assert!(json.get("$distinct_id").is_none());
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    #[test]
+    fn v0_batch_serializes_distinct_id_at_root() {
+        use crate::event::BatchRequest;
+
+        let batch = BatchRequest {
+            api_key: "test_api_key".to_string(),
+            historical_migration: false,
+            batch: vec![
+                build_v0(Event::new("e1", "user1")),
+                build_v0(Event::new("e2", "user2")),
+            ],
+        };
+        let json = serde_json::to_value(&batch).unwrap();
+
+        let events = json["batch"].as_array().expect("batch is an array");
+        for (event, expected_id) in events.iter().zip(["user1", "user2"]) {
+            assert_eq!(event["distinct_id"], expected_id);
+            assert!(event.get("$distinct_id").is_none());
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,6 @@
 //! }
 //! ```
 mod client;
-#[cfg(feature = "capture-v1")]
 mod compression;
 mod endpoints;
 mod error;

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -414,6 +414,7 @@ async fn test_client_with_empty_api_key_is_noop() {
     }
 }
 
+#[cfg(not(feature = "capture-v1"))]
 async fn assert_disabled_client_is_noop(api_key: Option<&str>) {
     let server = MockServer::start();
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -235,6 +235,7 @@ fn test_client_with_empty_api_key_is_noop() {
     }
 }
 
+#[cfg(not(feature = "capture-v1"))]
 fn assert_disabled_client_is_noop(api_key: Option<&str>) {
     let server = MockServer::start();
 

--- a/tests/test_v0_blocking_retry.rs
+++ b/tests/test_v0_blocking_retry.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "async-client", not(feature = "capture-v1")))]
+#![cfg(all(not(feature = "async-client"), not(feature = "capture-v1")))]
 
 use std::io::Read;
 use std::time::{Duration, Instant};
@@ -10,7 +10,7 @@ use posthog_rs::{CaptureCompression, Client, ClientOptionsBuilder, Event};
 // prove retried attempts resend the same bytes.
 const FIXED_UUID: &str = "01920000-0000-7000-8000-0000000000ff";
 
-async fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
+fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
     let options = ClientOptionsBuilder::default()
         .api_key("phc_test_token".to_string())
         .host(base_url)
@@ -21,23 +21,21 @@ async fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
         .retry_max_backoff_ms(5u64)
         .build()
         .unwrap();
-    posthog_rs::client(options).await
+    posthog_rs::client(options)
 }
 
 /// Drive whichever v0 path (single `/i/v0/e/` vs `/batch/`) the test wants,
 /// so coverage of both stays DRY.
-async fn capture(client: &Client, batch: bool) -> Result<(), posthog_rs::Error> {
+fn capture(client: &Client, batch: bool) -> Result<(), posthog_rs::Error> {
     if batch {
-        client
-            .capture_batch(vec![Event::new("e", "user-1")], false)
-            .await
+        client.capture_batch(vec![Event::new("e", "user-1")], false)
     } else {
-        client.capture(Event::new("e", "user-1")).await
+        client.capture(Event::new("e", "user-1"))
     }
 }
 
-#[tokio::test]
-async fn retryable_status_exhausts_attempts() {
+#[test]
+fn retryable_status_exhausts_attempts() {
     for status in [408u16, 500, 502, 503, 504] {
         for batch in [false, true] {
             let server = MockServer::start();
@@ -46,8 +44,8 @@ async fn retryable_status_exhausts_attempts() {
                 then.status(status);
             });
 
-            let client = create_v0_client(server.base_url(), 3).await;
-            let result = capture(&client, batch).await;
+            let client = create_v0_client(server.base_url(), 3);
+            let result = capture(&client, batch);
 
             assert!(
                 result.is_err(),
@@ -60,8 +58,8 @@ async fn retryable_status_exhausts_attempts() {
     }
 }
 
-#[tokio::test]
-async fn terminal_status_sends_once() {
+#[test]
+fn terminal_status_sends_once() {
     // 429 here carries no Retry-After, so it is terminal (RateLimit), not
     // retried — see `honors_retry_after_header` for the 429 + Retry-After case.
     for status in [400u16, 401, 402, 403, 413, 415, 429] {
@@ -72,11 +70,10 @@ async fn terminal_status_sends_once() {
                 then.status(status);
             });
 
-            let client = create_v0_client(server.base_url(), 3).await;
-            let result = capture(&client, batch).await;
+            let client = create_v0_client(server.base_url(), 3);
+            let result = capture(&client, batch);
 
             let err = result.expect_err(&format!("status {status} should be terminal"));
-            // A bare 429 (no Retry-After) is a terminal rate-limit, not a retry.
             if status == 429 {
                 assert!(
                     matches!(err, posthog_rs::Error::RateLimit),
@@ -89,8 +86,8 @@ async fn terminal_status_sends_once() {
     }
 }
 
-#[tokio::test]
-async fn success_sends_once() {
+#[test]
+fn success_sends_once() {
     for batch in [false, true] {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
@@ -98,14 +95,14 @@ async fn success_sends_once() {
             then.status(200);
         });
 
-        let client = create_v0_client(server.base_url(), 3).await;
-        capture(&client, batch).await.unwrap();
+        let client = create_v0_client(server.base_url(), 3);
+        capture(&client, batch).unwrap();
         mock.assert_hits(1);
     }
 }
 
-#[tokio::test]
-async fn retries_resend_identical_event() {
+#[test]
+fn retries_resend_identical_event() {
     let server = MockServer::start();
     // The mock only matches requests carrying the original UUID, so reaching
     // 3 hits proves every retry resent the same event identity.
@@ -114,10 +111,10 @@ async fn retries_resend_identical_event() {
         then.status(503);
     });
 
-    let client = create_v0_client(server.base_url(), 3).await;
+    let client = create_v0_client(server.base_url(), 3);
     let mut event = Event::new("e", "user-1");
     event.set_uuid(uuid::Uuid::parse_str(FIXED_UUID).unwrap());
-    let _ = client.capture(event).await;
+    let _ = client.capture(event);
 
     mock.assert_hits(3);
 }
@@ -135,8 +132,8 @@ fn body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
     }
 }
 
-#[tokio::test]
-async fn gzip_sets_header_query_param_and_compresses_body() {
+#[test]
+fn gzip_sets_header_query_param_and_compresses_body() {
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -152,17 +149,14 @@ async fn gzip_sets_header_query_param_and_compresses_body() {
         .capture_compression(CaptureCompression::Gzip)
         .build()
         .unwrap();
-    let client = posthog_rs::client(options).await;
-    client
-        .capture(Event::new("test_event", "user1"))
-        .await
-        .unwrap();
+    let client = posthog_rs::client(options);
+    client.capture(Event::new("test_event", "user1")).unwrap();
 
     mock.assert();
 }
 
-#[tokio::test]
-async fn honors_retry_after_header() {
+#[test]
+fn honors_retry_after_header() {
     let server = MockServer::start();
     // Mirrors the contract's `respects_retry_after_header`: a 429 carrying
     // Retry-After must delay the resend by the header value, not the (tiny)
@@ -172,9 +166,9 @@ async fn honors_retry_after_header() {
         then.status(429).header("retry-after", "1");
     });
 
-    let client = create_v0_client(server.base_url(), 2).await;
+    let client = create_v0_client(server.base_url(), 2);
     let start = Instant::now();
-    let _ = client.capture(Event::new("e", "user-1")).await;
+    let _ = client.capture(Event::new("e", "user-1"));
     let elapsed = start.elapsed();
 
     mock.assert_hits(2);

--- a/tests/test_v0_retry.rs
+++ b/tests/test_v0_retry.rs
@@ -1,0 +1,180 @@
+#![cfg(all(feature = "async-client", not(feature = "capture-v1")))]
+
+use std::io::Read;
+use std::time::{Duration, Instant};
+
+use httpmock::prelude::*;
+use posthog_rs::{CaptureCompression, Client, ClientOptionsBuilder, Event};
+
+// A real v7 UUID so the event passes through unchanged; matched on the wire to
+// prove retried attempts resend the same bytes.
+const FIXED_UUID: &str = "01920000-0000-7000-8000-0000000000ff";
+
+async fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(base_url)
+        .max_capture_attempts(max_attempts)
+        // Tiny backoffs keep the retry tests fast; the retry-after test below
+        // relies on these being far smaller than the header value it asserts.
+        .retry_initial_backoff_ms(1u64)
+        .retry_max_backoff_ms(5u64)
+        .build()
+        .unwrap();
+    posthog_rs::client(options).await
+}
+
+/// Drive whichever v0 path (single `/i/v0/e/` vs `/batch/`) the test wants,
+/// so coverage of both stays DRY.
+async fn capture(client: &Client, batch: bool) -> Result<(), posthog_rs::Error> {
+    if batch {
+        client
+            .capture_batch(vec![Event::new("e", "user-1")], false)
+            .await
+    } else {
+        client.capture(Event::new("e", "user-1")).await
+    }
+}
+
+#[tokio::test]
+async fn retryable_status_exhausts_attempts() {
+    for status in [408u16, 500, 502, 503, 504] {
+        for batch in [false, true] {
+            let server = MockServer::start();
+            let mock = server.mock(|when, then| {
+                when.method(POST);
+                then.status(status);
+            });
+
+            let client = create_v0_client(server.base_url(), 3).await;
+            let result = capture(&client, batch).await;
+
+            assert!(
+                result.is_err(),
+                "status {} (batch={}) should error after exhausting retries",
+                status,
+                batch
+            );
+            mock.assert_hits(3);
+        }
+    }
+}
+
+#[tokio::test]
+async fn terminal_status_sends_once() {
+    // 429 here carries no Retry-After, so it is terminal (RateLimit), not
+    // retried — see `honors_retry_after_header` for the 429 + Retry-After case.
+    for status in [400u16, 401, 402, 403, 413, 415, 429] {
+        for batch in [false, true] {
+            let server = MockServer::start();
+            let mock = server.mock(|when, then| {
+                when.method(POST);
+                then.status(status);
+            });
+
+            let client = create_v0_client(server.base_url(), 3).await;
+            let result = capture(&client, batch).await;
+
+            assert!(result.is_err(), "status {} should be terminal", status);
+            mock.assert_hits(1);
+        }
+    }
+}
+
+#[tokio::test]
+async fn success_sends_once() {
+    for batch in [false, true] {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST);
+            then.status(200);
+        });
+
+        let client = create_v0_client(server.base_url(), 3).await;
+        capture(&client, batch).await.unwrap();
+        mock.assert_hits(1);
+    }
+}
+
+#[tokio::test]
+async fn retries_resend_identical_event() {
+    let server = MockServer::start();
+    // The mock only matches requests carrying the original UUID, so reaching
+    // 3 hits proves every retry resent the same event identity.
+    let mock = server.mock(|when, then| {
+        when.method(POST).body_contains(FIXED_UUID);
+        then.status(503);
+    });
+
+    let client = create_v0_client(server.base_url(), 3).await;
+    let mut event = Event::new("e", "user-1");
+    event.set_uuid(uuid::Uuid::parse_str(FIXED_UUID).unwrap());
+    let _ = client.capture(event).await;
+
+    mock.assert_hits(3);
+}
+
+/// Matcher: the request body is valid gzip that decodes to the expected event.
+fn body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
+    let Some(body) = req.body.as_ref() else {
+        return false;
+    };
+    let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+    let mut decoded = String::new();
+    match decoder.read_to_string(&mut decoded) {
+        Ok(_) => decoded.contains(r#""distinct_id":"user1""#),
+        Err(_) => false,
+    }
+}
+
+#[tokio::test]
+async fn gzip_sets_header_query_param_and_compresses_body() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .header("content-encoding", "gzip")
+            .query_param("compression", "gzip")
+            .matches(body_gunzips_to_user1);
+        then.status(200);
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .capture_compression(CaptureCompression::Gzip)
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+    client
+        .capture(Event::new("test_event", "user1"))
+        .await
+        .unwrap();
+
+    mock.assert();
+}
+
+#[tokio::test]
+async fn honors_retry_after_header() {
+    let server = MockServer::start();
+    // Mirrors the contract's `respects_retry_after_header`: a 429 carrying
+    // Retry-After must delay the resend by the header value, not the (tiny)
+    // exponential backoff.
+    let mock = server.mock(|when, then| {
+        when.method(POST);
+        then.status(429).header("retry-after", "1");
+    });
+
+    let client = create_v0_client(server.base_url(), 2).await;
+    let start = Instant::now();
+    let _ = client.capture(Event::new("e", "user-1")).await;
+    let elapsed = start.elapsed();
+
+    mock.assert_hits(2);
+    // Exponential backoff here would be ~1ms; only an honored Retry-After: 1
+    // produces a gap this large.
+    assert!(
+        elapsed >= Duration::from_millis(900),
+        "Retry-After header not honored: waited only {:?}",
+        elapsed
+    );
+}

--- a/tests/test_v1_blocking.rs
+++ b/tests/test_v1_blocking.rs
@@ -557,6 +557,21 @@ fn v1_blocking_batch_sets_historical_migration() {
     mock.assert();
 }
 
+/// Matcher: the request body is valid gzip that decodes to the expected event.
+fn v1_body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
+    use std::io::Read;
+
+    let Some(body) = req.body.as_ref() else {
+        return false;
+    };
+    let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+    let mut decoded = String::new();
+    match decoder.read_to_string(&mut decoded) {
+        Ok(_) => decoded.contains(r#""distinct_id":"user-1""#),
+        Err(_) => false,
+    }
+}
+
 #[test]
 fn v1_blocking_sends_gzip_content_encoding() {
     use posthog_rs::CaptureCompression;
@@ -565,7 +580,8 @@ fn v1_blocking_sends_gzip_content_encoding() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .header("content-encoding", "gzip");
+            .header("content-encoding", "gzip")
+            .matches(v1_body_gunzips_to_user1);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -528,6 +528,23 @@ async fn v1_capture_preserves_uuid_and_timestamp_across_retries() {
     success_mock.assert();
 }
 
+/// Matcher: the request body is valid gzip that decodes to the expected event.
+/// Asserts the compressor actually produced the advertised encoding, not just
+/// that the header was set.
+fn v1_body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
+    use std::io::Read;
+
+    let Some(body) = req.body.as_ref() else {
+        return false;
+    };
+    let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+    let mut decoded = String::new();
+    match decoder.read_to_string(&mut decoded) {
+        Ok(_) => decoded.contains(r#""distinct_id":"user-1""#),
+        Err(_) => false,
+    }
+}
+
 #[tokio::test]
 async fn v1_capture_sends_gzip_content_encoding() {
     use posthog_rs::CaptureCompression;
@@ -536,7 +553,8 @@ async fn v1_capture_sends_gzip_content_encoding() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .header("content-encoding", "gzip");
+            .header("content-encoding", "gzip")
+            .matches(v1_body_gunzips_to_user1);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -552,6 +570,48 @@ async fn v1_capture_sends_gzip_content_encoding() {
 
     client.capture(Event::new("test", "user-1")).await.unwrap();
     mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_honors_retry_after_header() {
+    use std::time::{Duration, Instant};
+
+    // A retryable status carrying Retry-After must delay the resend by the
+    // header value, not the tiny exponential backoff — parity with the v0 test.
+    let server = MockServer::start();
+    let fail_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "1");
+        then.status(503)
+            .header("content-type", "application/json")
+            .header("retry-after", "1")
+            .json_body(json!({ "error": "service_unavailable" }));
+    });
+    let success_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-attempt", "2");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let start = Instant::now();
+    let result = client.capture(Event::new("test", "user-1")).await;
+    let elapsed = start.elapsed();
+
+    assert!(result.is_ok());
+    fail_mock.assert();
+    success_mock.assert();
+    // The client's exponential backoff here is ~10ms; only an honored
+    // Retry-After: 1 produces a gap this large.
+    assert!(
+        elapsed >= Duration::from_millis(900),
+        "Retry-After header not honored: waited only {:?}",
+        elapsed
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## :bulb: Motivation and Context

The v0 SDK-harness compliance suite had 14 failing tests in three buckets: the wire field was `$distinct_id` (harness wants `distinct_id`), the v0 capture paths had no retry loop, and gzip was gated behind `capture-v1`. This fixes all three — **v0 is now 29/29, v1 stays 94/94.**

_Note: the feature-flags scoped compliance tests are still failing. These can be handled in another follow-on PR_

**`distinct_id` at root (no `$`) is legal and supported by the backend in v0.** `rust/capture` accepts `distinct_id` as the canonical field and only tolerates `$distinct_id` via a legacy serde alias, then normalizes to `distinct_id` on the Kafka envelope:

- `RawEvent.distinct_id` is the canonical field; `$distinct_id` is just a serde `alias`: [rust/common/types/src/event.rs#L67-L68](https://github.com/PostHog/posthog/blob/6b5d8897db037b97856f522bf72e8083b553838a/rust/common/types/src/event.rs#L67-L68)
- v0 `extract_distinct_id` tests assert both spellings extract identically: [rust/capture/src/v0_request.rs#L512-L513](https://github.com/PostHog/posthog/blob/6b5d8897db037b97856f522bf72e8083b553838a/rust/capture/src/v0_request.rs#L512-L513)

So this is "stop depending on a legacy alias and emit the canonical field," not a payload that was losing data — zero risk to ingestion.

**gzip uses a v0-compatible query param.** Capture reads compression from the `compression` query param (`gzip`/`gzip-js`) or sniffs gzip magic bytes — it does **not** consult `Content-Encoding`. So the v0 path sends both `?compression=gzip` (for the backend) and `Content-Encoding: gzip` (for the harness assertion / HTTP correctness):

- accepted query values: [rust/capture/src/payload/types.rs#L28](https://github.com/PostHog/posthog/blob/6b5d8897db037b97856f522bf72e8083b553838a/rust/capture/src/payload/types.rs#L28)
- decode path (query hint OR magic bytes): [rust/capture/src/payload/decompression.rs#L116](https://github.com/PostHog/posthog/blob/6b5d8897db037b97856f522bf72e8083b553838a/rust/capture/src/payload/decompression.rs#L116)

429 is retried only when it carries `Retry-After` (a bare 429 stays a terminal rate-limit, preserving existing behavior); v1 never receives 429, so that widening is scoped to v0.

## :green_heart: How did you test it?

- New unit tests: wire-shape (`distinct_id` at root, single + batch), retry predicates, gzip roundtrip.
- New integration tests (`httpmock`): retryable vs terminal statuses, attempt counts, `Retry-After`, byte-identical resends, and gzip (header + query param + body decodes to the event).
- `cargo test` green on default, `capture-v1`, blocking, and blocking+`capture-v1`; `cargo clippy -- -D warnings` clean.
- Compliance suites: **v0 29/29**, **v1 94/94**.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file