### PR TITLE
Add custom user agent support

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -25,6 +25,7 @@ use crate::feature_flag_evaluations::{
     FlagCalledEventParams,
 };
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
+use crate::get_default_user_agent;
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
@@ -691,7 +692,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
-            .header(USER_AGENT, &self.options.user_agent)
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -895,7 +896,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
-            .header(USER_AGENT, &self.options.user_agent)
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -1121,7 +1122,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
-            .header(USER_AGENT, &self.options.user_agent)
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 #[cfg(feature = "capture-v1")]
 use chrono::Utc;
+use reqwest::header::USER_AGENT;
 use reqwest::{header::CONTENT_TYPE, Client as HttpClient};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
@@ -691,6 +692,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, &self.options.user_agent)
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -894,6 +896,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, &self.options.user_agent)
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -1119,6 +1122,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, &self.options.user_agent)
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -248,6 +248,7 @@ pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
                 api_host: options.endpoints().api_host(),
                 poll_interval: Duration::from_secs(options.poll_interval_seconds),
                 request_timeout: Duration::from_secs(options.request_timeout_seconds),
+                user_agent: options.user_agent.clone(),
             };
 
             let mut poller = AsyncFlagPoller::new(config, cache.clone());

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -249,7 +249,6 @@ pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
                 api_host: options.endpoints().api_host(),
                 poll_interval: Duration::from_secs(options.poll_interval_seconds),
                 request_timeout: Duration::from_secs(options.request_timeout_seconds),
-                user_agent: options.user_agent.clone(),
             };
 
             let mut poller = AsyncFlagPoller::new(config, cache.clone());

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -654,6 +654,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, &self.options.user_agent)
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -852,6 +853,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, &self.options.user_agent)
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -1075,6 +1077,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, &self.options.user_agent)
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -227,7 +227,6 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
                 api_host: options.endpoints().api_host(),
                 poll_interval: Duration::from_secs(options.poll_interval_seconds),
                 request_timeout: Duration::from_secs(options.request_timeout_seconds),
-                user_agent: options.user_agent.clone(),
             };
 
             let mut poller = FlagPoller::new(config, cache.clone());

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -6,7 +6,10 @@ use std::time::Duration;
 
 #[cfg(feature = "capture-v1")]
 use chrono::Utc;
-use reqwest::{blocking::Client as HttpClient, header::CONTENT_TYPE};
+use reqwest::{
+    blocking::Client as HttpClient,
+    header::{CONTENT_TYPE, USER_AGENT},
+};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
 #[cfg(feature = "capture-v1")]
@@ -224,6 +227,7 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
                 api_host: options.endpoints().api_host(),
                 poll_interval: Duration::from_secs(options.poll_interval_seconds),
                 request_timeout: Duration::from_secs(options.request_timeout_seconds),
+                user_agent: options.user_agent.clone(),
             };
 
             let mut poller = FlagPoller::new(config, cache.clone());

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -27,6 +27,7 @@ use crate::feature_flag_evaluations::{
     FlagCalledEventParams,
 };
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
+use crate::get_default_user_agent;
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
@@ -657,7 +658,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
-            .header(USER_AGENT, &self.options.user_agent)
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -856,7 +857,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
-            .header(USER_AGENT, &self.options.user_agent)
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -1080,7 +1081,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
-            .header(USER_AGENT, &self.options.user_agent)
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -85,6 +85,7 @@ impl BeforeSendHook {
         (hook)(event)
     }
 }
+const POSTHOG_RUST_USERAGENT: &str = "posthog-node/rust";
 
 /// Configuration options for the PostHog client.
 ///
@@ -204,6 +205,9 @@ pub struct ClientOptions {
     #[builder(setter(skip))]
     #[builder(default = "EndpointManager::new(DEFAULT_HOST.to_string())")]
     endpoint_manager: EndpointManager,
+
+    #[builder(default = "POSTHOG_RUST_USERAGENT.to_string()")]
+    user_agent: String,
 }
 
 /// Resolved client-level default properties for capture requests.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -86,6 +86,11 @@ impl BeforeSendHook {
     }
 }
 pub const POSTHOG_RUST_USERAGENT: &str = "posthog-node/rust";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub fn get_default_user_agent() -> String {
+    format!("{}/{}", POSTHOG_RUST_USERAGENT, VERSION)
+}
 
 /// Configuration options for the PostHog client.
 ///
@@ -206,7 +211,7 @@ pub struct ClientOptions {
     #[builder(default = "EndpointManager::new(DEFAULT_HOST.to_string())")]
     endpoint_manager: EndpointManager,
 
-    #[builder(default = "POSTHOG_RUST_USERAGENT.to_string()")]
+    #[builder(default = "get_default_user_agent()")]
     user_agent: String,
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -85,11 +85,11 @@ impl BeforeSendHook {
         (hook)(event)
     }
 }
-pub const POSTHOG_RUST_USERAGENT: &str = "posthog-node/rust";
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
+const SDK_USERAGENT_NAME: &str = "posthog-rust";
 
 pub fn get_default_user_agent() -> String {
-    format!("{}/{}", POSTHOG_RUST_USERAGENT, VERSION)
+    format!("{}/{}", SDK_USERAGENT_NAME, CRATE_VERSION)
 }
 
 /// Configuration options for the PostHog client.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -86,7 +86,7 @@ impl BeforeSendHook {
     }
 }
 pub const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
-const SDK_USERAGENT_NAME: &str = "posthog-rust";
+const SDK_USERAGENT_NAME: &str = "posthog-rs";
 
 pub fn get_default_user_agent() -> String {
     format!("{}/{}", SDK_USERAGENT_NAME, CRATE_VERSION)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -210,9 +210,6 @@ pub struct ClientOptions {
     #[builder(setter(skip))]
     #[builder(default = "EndpointManager::new(DEFAULT_HOST.to_string())")]
     endpoint_manager: EndpointManager,
-
-    #[builder(default = "get_default_user_agent()")]
-    user_agent: String,
 }
 
 /// Resolved client-level default properties for capture requests.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -85,7 +85,7 @@ impl BeforeSendHook {
         (hook)(event)
     }
 }
-const POSTHOG_RUST_USERAGENT: &str = "posthog-node/rust";
+pub const POSTHOG_RUST_USERAGENT: &str = "posthog-node/rust";
 
 /// Configuration options for the PostHog client.
 ///

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -15,6 +15,8 @@ use super::retry::{backoff_duration, is_retryable_status};
 // `v1_capture::parse_retry_after` / `v1_capture::Step`.
 pub(crate) use super::retry::{parse_retry_after, Step};
 use super::{common::apply_runtime_context, CaptureCompression, CaptureDefaults, ClientOptions};
+use super::{CaptureCompression, CaptureDefaults, ClientOptions};
+use crate::client::get_default_user_agent;
 use crate::error::Error;
 use crate::event::Event;
 use crate::event_v1::{CaptureResponse, EventResult, EventStatus, V1ErrorResponse, V1Event};
@@ -46,10 +48,7 @@ pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<
 }
 
 pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u32) -> HeaderMap {
-    let version = env!("CARGO_PKG_VERSION");
-    // SDK identity: `<canonical-$lib-name>/<semver>`. The name must match v0's
-    // `$lib` ("posthog-rs"); capture materializes it into `$lib`/`$lib_version`.
-    let sdk_info = format!("posthog-rs/{version}");
+    let sdk_info = get_default_user_agent();
 
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::feature_flag_evaluations::FeatureFlagEvaluations;
-use crate::Error;
+use crate::{Error, CRATE_VERSION};
 
 /// Per-event V1 capture options. Known fields are typed; unknown keys go into
 /// `extra` via `#[serde(flatten)]` for forward compatibility with new backend
@@ -265,7 +265,7 @@ impl Event {
             );
         }
 
-        let version_str = env!("CARGO_PKG_VERSION");
+        let version_str = CRATE_VERSION;
         if !self.properties.contains_key("$lib_version") {
             self.properties.insert(
                 "$lib_version".into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub use client::Client;
 pub use client::ClientOptions;
 pub use client::ClientOptionsBuilder;
 pub use client::ClientOptionsBuilderError;
+pub use client::POSTHOG_RUST_USERAGENT;
 
 // Endpoints
 pub use endpoints::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,13 +85,13 @@ mod local_evaluation;
 // Public interface - any change to this is breaking!
 // Client
 pub use client::client;
+pub use client::get_default_user_agent;
 pub use client::BeforeSendHook;
 pub use client::CaptureCompression;
 pub use client::Client;
 pub use client::ClientOptions;
 pub use client::ClientOptionsBuilder;
 pub use client::ClientOptionsBuilderError;
-pub use client::POSTHOG_RUST_USERAGENT;
 
 // Endpoints
 pub use endpoints::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ pub use client::Client;
 pub use client::ClientOptions;
 pub use client::ClientOptionsBuilder;
 pub use client::ClientOptionsBuilderError;
+pub use client::CRATE_VERSION;
 
 // Endpoints
 pub use endpoints::{

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -172,6 +172,8 @@ pub struct LocalEvaluationConfig {
     pub poll_interval: Duration,
     /// Timeout for API requests
     pub request_timeout: Duration,
+    /// User agent for API Requests
+    pub user_agent: String,
 }
 
 /// Synchronous poller for feature flag definitions.

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -3,7 +3,7 @@ use crate::feature_flags::{
     FeatureFlag, FlagValue, InconclusiveMatchError,
 };
 use crate::Error;
-use reqwest::header::{HeaderMap, ETAG, IF_NONE_MATCH};
+use reqwest::header::{HeaderMap, ETAG, IF_NONE_MATCH, USER_AGENT};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -259,7 +259,8 @@ impl FlagPoller {
                         "Authorization",
                         format!("Bearer {}", config.personal_api_key),
                     )
-                    .header("X-PostHog-Project-Api-Key", &config.project_api_key);
+                    .header("X-PostHog-Project-Api-Key", &config.project_api_key)
+                    .header(USER_AGENT, &config.user_agent);
 
                 if let Some(ref etag) = last_etag {
                     request = request.header(IF_NONE_MATCH, etag.as_str());
@@ -319,6 +320,7 @@ impl FlagPoller {
                 format!("Bearer {}", self.config.personal_api_key),
             )
             .header("X-PostHog-Project-Api-Key", &self.config.project_api_key)
+            .header(USER_AGENT, &self.config.user_agent)
             .send()
             .map_err(|e| {
                 error!(error = %e, "Connection error loading flags");
@@ -450,7 +452,8 @@ impl AsyncFlagPoller {
                         let mut request = client
                             .get(&url)
                             .header("Authorization", format!("Bearer {}", config.personal_api_key))
-                            .header("X-PostHog-Project-Api-Key", &config.project_api_key);
+                            .header("X-PostHog-Project-Api-Key", &config.project_api_key)
+                            .header(USER_AGENT, &config.user_agent);
 
                         if let Some(ref etag) = last_etag {
                             request = request.header(IF_NONE_MATCH, etag.as_str());
@@ -502,6 +505,8 @@ impl AsyncFlagPoller {
     /// parsed.
     #[instrument(skip(self), level = "debug")]
     pub async fn load_flags(&self) -> Result<(), Error> {
+        use reqwest::header::USER_AGENT;
+
         let url = format!(
             "{}/flags/definitions/?send_cohorts",
             self.config.api_host.trim_end_matches('/')
@@ -515,6 +520,7 @@ impl AsyncFlagPoller {
                 format!("Bearer {}", self.config.personal_api_key),
             )
             .header("X-PostHog-Project-Api-Key", &self.config.project_api_key)
+            .header(USER_AGENT, &self.config.user_agent)
             .send()
             .await
             .map_err(|e| {

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -2,7 +2,7 @@ use crate::feature_flags::{
     match_feature_flag, match_feature_flag_with_context, CohortDefinition, EvaluationContext,
     FeatureFlag, FlagValue, InconclusiveMatchError,
 };
-use crate::Error;
+use crate::{get_default_user_agent, Error};
 use reqwest::header::{HeaderMap, ETAG, IF_NONE_MATCH, USER_AGENT};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -258,7 +258,7 @@ impl FlagPoller {
                         format!("Bearer {}", config.personal_api_key),
                     )
                     .header("X-PostHog-Project-Api-Key", &config.project_api_key)
-                    .header(USER_AGENT, &config.user_agent);
+                    .header(USER_AGENT, get_default_user_agent());
 
                 if let Some(ref etag) = last_etag {
                     request = request.header(IF_NONE_MATCH, etag.as_str());
@@ -318,7 +318,7 @@ impl FlagPoller {
                 format!("Bearer {}", self.config.personal_api_key),
             )
             .header("X-PostHog-Project-Api-Key", &self.config.project_api_key)
-            .header(USER_AGENT, &self.config.user_agent)
+            .header(USER_AGENT, get_default_user_agent())
             .send()
             .map_err(|e| {
                 error!(error = %e, "Connection error loading flags");
@@ -451,7 +451,7 @@ impl AsyncFlagPoller {
                             .get(&url)
                             .header("Authorization", format!("Bearer {}", config.personal_api_key))
                             .header("X-PostHog-Project-Api-Key", &config.project_api_key)
-                            .header(USER_AGENT, &config.user_agent);
+                            .header(USER_AGENT, get_default_user_agent());
 
                         if let Some(ref etag) = last_etag {
                             request = request.header(IF_NONE_MATCH, etag.as_str());
@@ -518,7 +518,7 @@ impl AsyncFlagPoller {
                 format!("Bearer {}", self.config.personal_api_key),
             )
             .header("X-PostHog-Project-Api-Key", &self.config.project_api_key)
-            .header(USER_AGENT, &self.config.user_agent)
+            .header(USER_AGENT, get_default_user_agent())
             .send()
             .await
             .map_err(|e| {

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -172,8 +172,6 @@ pub struct LocalEvaluationConfig {
     pub poll_interval: Duration,
     /// Timeout for API requests
     pub request_timeout: Duration,
-    /// User agent for API Requests
-    pub user_agent: String,
 }
 
 /// Synchronous poller for feature flag definitions.

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -503,8 +503,6 @@ impl AsyncFlagPoller {
     /// parsed.
     #[instrument(skip(self), level = "debug")]
     pub async fn load_flags(&self) -> Result<(), Error> {
-        use reqwest::header::USER_AGENT;
-
         let url = format!(
             "{}/flags/definitions/?send_cohorts",
             self.config.api_host.trim_end_matches('/')

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -106,38 +106,6 @@ async fn test_sends_default_useragent() {
 }
 
 #[tokio::test]
-async fn test_sends_custom_useragent() {
-    let server = MockServer::start();
-
-    let mock_response = json!({});
-    let custom_user_agent = "custom-user-agent";
-
-    let flags_mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/flags/")
-            .header(USER_AGENT.to_string(), custom_user_agent)
-            .query_param("v", "2");
-
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(mock_response);
-    });
-
-    let options = posthog_rs::ClientOptionsBuilder::default()
-        .api_key("test_api_key".into())
-        .host(server.base_url().as_str())
-        .user_agent("custom-user-agent".to_string())
-        .build()
-        .expect("should build client options");
-    let client = posthog_rs::client(options).await;
-
-    let _ = client
-        .get_feature_flags("test-user".to_string(), None, None, None)
-        .await;
-    flags_mock.assert();
-}
-
-#[tokio::test]
 async fn test_is_feature_enabled() {
     let server = MockServer::start();
 

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -7,7 +7,7 @@
 #![allow(deprecated)]
 
 use httpmock::prelude::*;
-use posthog_rs::{FlagValue, POSTHOG_RUST_USERAGENT};
+use posthog_rs::{get_default_user_agent, FlagValue};
 use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
@@ -89,7 +89,7 @@ async fn test_sends_default_useragent() {
     let flags_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/flags/")
-            .header(USER_AGENT.to_string(), POSTHOG_RUST_USERAGENT)
+            .header(USER_AGENT.to_string(), get_default_user_agent())
             .query_param("v", "2");
 
         then.status(200)

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -7,7 +7,8 @@
 #![allow(deprecated)]
 
 use httpmock::prelude::*;
-use posthog_rs::FlagValue;
+use posthog_rs::{FlagValue, POSTHOG_RUST_USERAGENT};
+use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -76,6 +77,63 @@ async fn test_get_all_feature_flags() {
 
     assert!(payloads.contains_key("variant-flag"));
 
+    flags_mock.assert();
+}
+
+#[tokio::test]
+async fn test_sends_default_useragent() {
+    let server = MockServer::start();
+
+    let mock_response = json!({});
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/flags/")
+            .header(USER_AGENT.to_string(), POSTHOG_RUST_USERAGENT)
+            .query_param("v", "2");
+
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(mock_response);
+    });
+
+    let client = create_test_client(server.base_url()).await;
+
+    let _ = client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .await;
+    flags_mock.assert();
+}
+
+#[tokio::test]
+async fn test_sends_custom_useragent() {
+    let server = MockServer::start();
+
+    let mock_response = json!({});
+    let custom_user_agent = "custom-user-agent";
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/flags/")
+            .header(USER_AGENT.to_string(), custom_user_agent)
+            .query_param("v", "2");
+
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(mock_response);
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .api_key("test_api_key".into())
+        .host(server.base_url().as_str())
+        .user_agent("custom-user-agent".to_string())
+        .build()
+        .expect("should build client options");
+    let client = posthog_rs::client(options).await;
+
+    let _ = client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .await;
     flags_mock.assert();
 }
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -98,36 +98,6 @@ fn test_sends_default_useragent() {
 }
 
 #[test]
-fn test_sends_custom_useragent() {
-    let server = MockServer::start();
-
-    let mock_response = json!({});
-    let custom_user_agent = "custom-user-agent";
-
-    let flags_mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/flags/")
-            .header(USER_AGENT.to_string(), custom_user_agent)
-            .query_param("v", "2");
-
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(mock_response);
-    });
-
-    let options = posthog_rs::ClientOptionsBuilder::default()
-        .api_key("test_api_key".into())
-        .host(server.base_url().as_str())
-        .user_agent("custom-user-agent".to_string())
-        .build()
-        .expect("should build client options");
-    let client = posthog_rs::client(options);
-
-    let _ = client.get_feature_flags("test-user".to_string(), None, None, None);
-    flags_mock.assert();
-}
-
-#[test]
 fn test_is_feature_enabled() {
     let server = MockServer::start();
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -7,7 +7,8 @@
 #![allow(deprecated)]
 
 use httpmock::prelude::*;
-use posthog_rs::FlagValue;
+use posthog_rs::{get_default_user_agent, FlagValue};
+use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -70,6 +71,59 @@ fn test_get_all_feature_flags() {
 
     assert!(payloads.contains_key("variant-flag"));
 
+    flags_mock.assert();
+}
+
+#[test]
+fn test_sends_default_useragent() {
+    let server = MockServer::start();
+
+    let mock_response = json!({});
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/flags/")
+            .header(USER_AGENT.to_string(), get_default_user_agent())
+            .query_param("v", "2");
+
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(mock_response);
+    });
+
+    let client = create_test_client(server.base_url());
+
+    let _ = client.get_feature_flags("test-user".to_string(), None, None, None);
+    flags_mock.assert();
+}
+
+#[test]
+fn test_sends_custom_useragent() {
+    let server = MockServer::start();
+
+    let mock_response = json!({});
+    let custom_user_agent = "custom-user-agent";
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/flags/")
+            .header(USER_AGENT.to_string(), custom_user_agent)
+            .query_param("v", "2");
+
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(mock_response);
+    });
+
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .api_key("test_api_key".into())
+        .host(server.base_url().as_str())
+        .user_agent("custom-user-agent".to_string())
+        .build()
+        .expect("should build client options");
+    let client = posthog_rs::client(options);
+
+    let _ = client.get_feature_flags("test-user".to_string(), None, None, None);
     flags_mock.assert();
 }
 

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -128,31 +128,6 @@ mod blocking {
     }
 
     #[test]
-    fn evaluate_flags_uses_custom_useragent() {
-        let server = MockServer::start();
-        let custom_user_agent = "my-custom-user-agent";
-        let flags_mock = server.mock(|when, then| {
-            when.method(POST)
-                .path("/flags/")
-                .header(USER_AGENT.to_string(), custom_user_agent);
-            then.status(200).json_body(flags_response_fixture());
-        });
-
-        let options = posthog_rs::ClientOptionsBuilder::default()
-            .api_key("test_api_key".into())
-            .host(server.base_url().as_str())
-            .user_agent(custom_user_agent.to_string())
-            .build()
-            .expect("should build client options");
-        let client = posthog_rs::client(options);
-
-        let _ = client
-            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
-            .unwrap();
-        flags_mock.assert();
-    }
-
-    #[test]
     fn unaccessed_flags_do_not_fire_events() {
         let server = MockServer::start();
         let flags_mock = server.mock(|when, then| {
@@ -623,32 +598,6 @@ mod async_tests {
             then.status(200).json_body(flags_response_fixture());
         });
         let client = create_test_client(server.base_url()).await;
-        let _ = client
-            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
-            .await
-            .unwrap();
-        flags_mock.assert();
-    }
-
-    #[tokio::test]
-    async fn evaluate_flags_uses_custom_useragent() {
-        let server = MockServer::start();
-        let custom_user_agent = "my-custom-user-agent";
-        let flags_mock = server.mock(|when, then| {
-            when.method(POST)
-                .path("/flags/")
-                .header(USER_AGENT.to_string(), custom_user_agent);
-            then.status(200).json_body(flags_response_fixture());
-        });
-
-        let options = posthog_rs::ClientOptionsBuilder::default()
-            .api_key("test_api_key".into())
-            .host(server.base_url().as_str())
-            .user_agent(custom_user_agent.to_string())
-            .build()
-            .expect("should build client options");
-        let client = posthog_rs::client(options).await;
-
         let _ = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
             .await

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -82,7 +82,8 @@ fn flags_response_fixture() -> Value {
 #[cfg(not(feature = "async-client"))]
 mod blocking {
     use super::*;
-    use posthog_rs::{EvaluateFlagsOptions, Event, FlagValue};
+    use posthog_rs::{get_default_user_agent, EvaluateFlagsOptions, Event, FlagValue};
+    use reqwest::header::USER_AGENT;
 
     fn create_test_client(base_url: String) -> posthog_rs::Client {
         let options: posthog_rs::ClientOptions = ("test_api_key", base_url.as_str()).into();
@@ -108,6 +109,47 @@ mod blocking {
         assert_eq!(keys, vec!["alpha", "beta", "variant-flag"]);
         flags_mock.assert_hits(1);
         capture_mock.assert_hits(0);
+    }
+
+    #[test]
+    fn evaluate_flags_uses_default_useragent() {
+        let server = MockServer::start();
+        let flags_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/flags/")
+                .header(USER_AGENT.to_string(), get_default_user_agent());
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let client = create_test_client(server.base_url());
+        let _ = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .unwrap();
+        flags_mock.assert();
+    }
+
+    #[test]
+    fn evaluate_flags_uses_custom_useragent() {
+        let server = MockServer::start();
+        let custom_user_agent = "my-custom-user-agent";
+        let flags_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/flags/")
+                .header(USER_AGENT.to_string(), custom_user_agent);
+            then.status(200).json_body(flags_response_fixture());
+        });
+
+        let options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key("test_api_key".into())
+            .host(server.base_url().as_str())
+            .user_agent(custom_user_agent.to_string())
+            .build()
+            .expect("should build client options");
+        let client = posthog_rs::client(options);
+
+        let _ = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .unwrap();
+        flags_mock.assert();
     }
 
     #[test]
@@ -539,7 +581,8 @@ mod async_tests {
     use super::*;
     #[cfg(not(feature = "capture-v1"))]
     use posthog_rs::Event;
-    use posthog_rs::{EvaluateFlagsOptions, FlagValue};
+    use posthog_rs::{get_default_user_agent, EvaluateFlagsOptions, FlagValue};
+    use reqwest::header::USER_AGENT;
 
     async fn create_test_client(base_url: String) -> posthog_rs::Client {
         let options: posthog_rs::ClientOptions = ("test_api_key", base_url.as_str()).into();
@@ -568,6 +611,49 @@ mod async_tests {
         keys.sort();
         assert_eq!(keys, vec!["alpha", "beta", "variant-flag"]);
         flags_mock.assert_hits(1);
+    }
+
+    #[tokio::test]
+    async fn evaluate_flags_uses_default_useragent() {
+        let server = MockServer::start();
+        let flags_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/flags/")
+                .header(USER_AGENT.to_string(), get_default_user_agent());
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let client = create_test_client(server.base_url()).await;
+        let _ = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .await
+            .unwrap();
+        flags_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn evaluate_flags_uses_custom_useragent() {
+        let server = MockServer::start();
+        let custom_user_agent = "my-custom-user-agent";
+        let flags_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/flags/")
+                .header(USER_AGENT.to_string(), custom_user_agent);
+            then.status(200).json_body(flags_response_fixture());
+        });
+
+        let options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key("test_api_key".into())
+            .host(server.base_url().as_str())
+            .user_agent(custom_user_agent.to_string())
+            .build()
+            .expect("should build client options");
+        let client = posthog_rs::client(options).await;
+
+        let _ = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .await
+            .unwrap();
+        flags_mock.assert();
     }
 
     #[tokio::test]

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -7,9 +7,9 @@ use httpmock::prelude::*;
 #[cfg(feature = "async-client")]
 use posthog_rs::AsyncFlagPoller;
 use posthog_rs::{
-    ClientOptionsBuilder, FeatureFlag, FeatureFlagCondition, FeatureFlagFilters, FlagCache,
-    FlagPoller, FlagValue, LocalEvaluationConfig, LocalEvaluationResponse, LocalEvaluator,
-    Property, POSTHOG_RUST_USERAGENT,
+    get_default_user_agent, ClientOptionsBuilder, FeatureFlag, FeatureFlagCondition,
+    FeatureFlagFilters, FlagCache, FlagPoller, FlagValue, LocalEvaluationConfig,
+    LocalEvaluationResponse, LocalEvaluator, Property,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -337,7 +337,7 @@ async fn test_etag_sent_on_second_poll() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
-        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
+        user_agent: get_default_user_agent(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -426,7 +426,7 @@ async fn test_304_preserves_cache() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
-        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
+        user_agent: get_default_user_agent(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -492,7 +492,7 @@ async fn test_no_etag_from_server() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(50),
         request_timeout: Duration::from_secs(5),
-        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
+        user_agent: get_default_user_agent(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -569,7 +569,7 @@ fn test_sync_etag_sent_on_second_poll() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
-        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
+        user_agent: get_default_user_agent(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());
@@ -655,7 +655,7 @@ fn test_sync_304_preserves_cache() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
-        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
+        user_agent: get_default_user_agent(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());
@@ -720,7 +720,7 @@ fn test_sync_no_etag_from_server() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(50),
         request_timeout: Duration::from_secs(5),
-        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
+        user_agent: get_default_user_agent(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -9,7 +9,7 @@ use posthog_rs::AsyncFlagPoller;
 use posthog_rs::{
     ClientOptionsBuilder, FeatureFlag, FeatureFlagCondition, FeatureFlagFilters, FlagCache,
     FlagPoller, FlagValue, LocalEvaluationConfig, LocalEvaluationResponse, LocalEvaluator,
-    Property,
+    Property, POSTHOG_RUST_USERAGENT,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -337,6 +337,7 @@ async fn test_etag_sent_on_second_poll() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
+        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -425,6 +426,7 @@ async fn test_304_preserves_cache() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
+        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -490,6 +492,7 @@ async fn test_no_etag_from_server() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(50),
         request_timeout: Duration::from_secs(5),
+        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -566,6 +569,7 @@ fn test_sync_etag_sent_on_second_poll() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
+        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());
@@ -651,6 +655,7 @@ fn test_sync_304_preserves_cache() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
+        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());
@@ -715,6 +720,7 @@ fn test_sync_no_etag_from_server() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(50),
         request_timeout: Duration::from_secs(5),
+        user_agent: POSTHOG_RUST_USERAGENT.to_string(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -276,53 +276,6 @@ async fn test_local_evaluation_with_mock_server_sends_default_user_agent() {
     eval_mock.assert();
 }
 
-#[cfg(feature = "async-client")]
-#[tokio::test]
-async fn test_local_evaluation_with_mock_server_sends_custom_user_agent() {
-    let server = MockServer::start();
-
-    // Mock the local evaluation endpoint
-    let mock_flags = json!({
-        "flags": [],
-        "group_type_mapping": {},
-        "cohorts": {}
-    });
-
-    let customer_useragent = "my-custom-user-agent";
-
-    let eval_mock = server.mock(|when, then| {
-        when.method(GET)
-            .path("/flags/definitions/")
-            .header("Authorization", "Bearer test_personal_key")
-            .header("X-PostHog-Project-Api-Key", "test_project_key")
-            .header(USER_AGENT.to_string(), customer_useragent)
-            .query_param("send_cohorts", "");
-        then.status(200).json_body(mock_flags);
-    });
-
-    // Create client with local evaluation enabled
-    let options = ClientOptionsBuilder::default()
-        .host(server.base_url())
-        .api_key("test_project_key".to_string())
-        .personal_api_key("test_personal_key".to_string())
-        .enable_local_evaluation(true)
-        .poll_interval_seconds(60)
-        .user_agent(customer_useragent.to_string())
-        .build()
-        .unwrap();
-
-    let client = posthog_rs::client(options).await;
-
-    // Give it a moment to load initial flags
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let _ = client
-        .get_feature_flag("feature-b", "", None, None, None)
-        .await;
-
-    eval_mock.assert();
-}
-
 #[test]
 fn test_cache_operations() {
     let cache = FlagCache::new();
@@ -430,7 +383,6 @@ async fn test_etag_sent_on_second_poll() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
-        user_agent: get_default_user_agent(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -519,7 +471,6 @@ async fn test_304_preserves_cache() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
-        user_agent: get_default_user_agent(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -585,7 +536,6 @@ async fn test_no_etag_from_server() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(50),
         request_timeout: Duration::from_secs(5),
-        user_agent: get_default_user_agent(),
     };
 
     let mut poller = AsyncFlagPoller::new(config, cache.clone());
@@ -662,7 +612,6 @@ fn test_sync_etag_sent_on_second_poll() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
-        user_agent: get_default_user_agent(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());
@@ -748,7 +697,6 @@ fn test_sync_304_preserves_cache() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(100),
         request_timeout: Duration::from_secs(5),
-        user_agent: get_default_user_agent(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());
@@ -813,7 +761,6 @@ fn test_sync_no_etag_from_server() {
         api_host: server.base_url(),
         poll_interval: Duration::from_millis(50),
         request_timeout: Duration::from_secs(5),
-        user_agent: get_default_user_agent(),
     };
 
     let mut poller = FlagPoller::new(config, cache.clone());

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -11,6 +11,8 @@ use posthog_rs::{
     FeatureFlagFilters, FlagCache, FlagPoller, FlagValue, LocalEvaluationConfig,
     LocalEvaluationResponse, LocalEvaluator, Property,
 };
+#[cfg(feature = "async-client")]
+use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -226,6 +228,97 @@ async fn test_local_evaluation_with_mock_server() {
         .await;
 
     assert!(result.unwrap() == Some(FlagValue::Boolean(true)));
+
+    eval_mock.assert();
+}
+
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn test_local_evaluation_with_mock_server_sends_default_user_agent() {
+    let server = MockServer::start();
+
+    // Mock the local evaluation endpoint
+    let mock_flags = json!({
+        "flags": [],
+        "group_type_mapping": {},
+        "cohorts": {}
+    });
+
+    let eval_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/flags/definitions/")
+            .header("Authorization", "Bearer test_personal_key")
+            .header("X-PostHog-Project-Api-Key", "test_project_key")
+            .header(USER_AGENT.to_string(), get_default_user_agent())
+            .query_param("send_cohorts", "");
+        then.status(200).json_body(mock_flags);
+    });
+
+    // Create client with local evaluation enabled
+    let options = ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .api_key("test_project_key".to_string())
+        .personal_api_key("test_personal_key".to_string())
+        .enable_local_evaluation(true)
+        .poll_interval_seconds(60)
+        .build()
+        .unwrap();
+
+    let client = posthog_rs::client(options).await;
+
+    // Give it a moment to load initial flags
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let _ = client
+        .get_feature_flag("feature-b", "", None, None, None)
+        .await;
+
+    eval_mock.assert();
+}
+
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn test_local_evaluation_with_mock_server_sends_custom_user_agent() {
+    let server = MockServer::start();
+
+    // Mock the local evaluation endpoint
+    let mock_flags = json!({
+        "flags": [],
+        "group_type_mapping": {},
+        "cohorts": {}
+    });
+
+    let customer_useragent = "my-custom-user-agent";
+
+    let eval_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/flags/definitions/")
+            .header("Authorization", "Bearer test_personal_key")
+            .header("X-PostHog-Project-Api-Key", "test_project_key")
+            .header(USER_AGENT.to_string(), customer_useragent)
+            .query_param("send_cohorts", "");
+        then.status(200).json_body(mock_flags);
+    });
+
+    // Create client with local evaluation enabled
+    let options = ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .api_key("test_project_key".to_string())
+        .personal_api_key("test_personal_key".to_string())
+        .enable_local_evaluation(true)
+        .poll_interval_seconds(60)
+        .user_agent(customer_useragent.to_string())
+        .build()
+        .unwrap();
+
+    let client = posthog_rs::client(options).await;
+
+    // Give it a moment to load initial flags
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let _ = client
+        .get_feature_flag("feature-b", "", None, None, None)
+        .await;
 
     eval_mock.assert();
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
When using the rust client the Posthog api does not return server flags. This is because of 2 reasons:
- The rust client does not send up a user agent which causes the Posthog server treat requests as a user(public) request even if you include a personal api key(secure flag token)
- Even if sending up a user agent in the same style of other libraries because the Posthog server still does not recognize the rust client so it assumes the request is coming from a user(public) and not a server.

While this PR wont change behavior, at least until the posthog server adds rust client support, it allows end users to input a custom user agent to lie to the posthog server so they can retrieve server flags.

## :green_heart: How did you test it?
Manually and with automated testing. I added tests that explicitly check for user agent using the HTTP Mock library.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
