### PR TITLE
fix(capture): route flag events through capture + papercuts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,16 @@ jobs:
     - name: Unit test (default features)
       run: cargo test --verbose
 
-    - name: Unit test (workspace, includes capture-v1)
+    # The adapter only enables async-client + test-harness, so the workspace
+    # build does NOT unify capture-v1 in; it gets its own explicit steps below.
+    - name: Unit test (workspace)
       run: cargo test --workspace --verbose
+
+    - name: Unit test (capture-v1, async client)
+      run: cargo test --verbose --features capture-v1
+
+    - name: Unit test (capture-v1, blocking client)
+      run: cargo test --verbose --no-default-features --features capture-v1
 
     # TODO: when v1 endpoint ships, remove the capture-v1 feature gate;
     # v1 e2e test (get_client_v1_async) will then run here automatically.

--- a/.sampo/changesets/capture-v1-2xx-sdk-info-flag-events.md
+++ b/.sampo/changesets/capture-v1-2xx-sdk-info-flag-events.md
@@ -1,0 +1,9 @@
+---
+cargo/posthog-rs: patch
+---
+
+Three fixes to the unstable `capture-v1` pipeline (off by default):
+
+- Accept any 2xx HTTP status as success on V1 capture responses instead of exactly 200, so a future 201/202/207 from capture is not misclassified as a connection error. Malformed bodies on 2xx still surface as `Error::Serialization`.
+- Send the canonical SDK identity `posthog-rs/<version>` (previously `posthog-rust/<version>`) in the `posthog-sdk-info` and `user-agent` headers. The name segment now matches the `$lib` value the v0 path sends, so capture-side `$lib`/`$lib_version` materialization attributes V1 traffic correctly in SDK Health, usage reports, and Library columns.
+- Route `$feature_flag_called` events through the V1 analytics endpoint when `capture-v1` is enabled (previously they always took the legacy v0 path, splitting the pipeline). Shipping stays fire-and-forget with a single attempt and no retry loop, matching the v0 flag-event semantics on both the async and blocking clients.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -11,6 +11,8 @@ use tracing::{debug, instrument, trace, warn};
 use uuid::Uuid;
 
 use crate::endpoints::Endpoint;
+#[cfg(not(feature = "capture-v1"))]
+use crate::event::InnerEvent;
 #[cfg(feature = "capture-v1")]
 use crate::event_v1::CaptureResponse;
 use crate::feature_flag_evaluations::{
@@ -19,7 +21,7 @@ use crate::feature_flag_evaluations::{
 };
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
-use crate::{event::InnerEvent, Error, Event};
+use crate::{Error, Event};
 
 use super::common::{
     already_reported, build_dedup_key, extract_flag_details, flag_called_event,
@@ -28,6 +30,7 @@ use super::common::{
 };
 use super::ClientOptions;
 
+#[cfg(not(feature = "capture-v1"))]
 async fn check_response(response: reqwest::Response) -> Result<(), Error> {
     let status = response.status().as_u16();
     let body = response
@@ -54,13 +57,14 @@ pub struct Client {
 /// `$feature_flag_called` events through a clone of the async [`Client`]'s
 /// HTTP transport. The event ship is fire-and-forget: errors are logged at
 /// `debug` level but do not surface to the caller, matching the JS SDK.
+///
+/// With the `capture-v1` feature the events go to the same V1 endpoint as
+/// regular capture (single attempt, no retry loop); otherwise they take the
+/// legacy v0 `/i/v0/e/` path.
 struct AsyncFlagEventHost {
     http_client: HttpClient,
-    api_key: String,
+    options: ClientOptions,
     capture_url: String,
-    disabled: bool,
-    disable_geoip: bool,
-    is_server: bool,
     dedup_cache: FlagEventDedupCache,
     /// Tokio runtime handle captured at host construction (which always runs
     /// inside the runtime that hosts `evaluate_flags`). This lets snapshot
@@ -72,25 +76,80 @@ struct AsyncFlagEventHost {
 
 impl AsyncFlagEventHost {
     fn from_options(options: &ClientOptions, http_client: HttpClient) -> Self {
+        #[cfg(feature = "capture-v1")]
+        let capture_url = options
+            .endpoints()
+            .build_custom_url(super::v1_capture::V1_CAPTURE_PATH);
+        #[cfg(not(feature = "capture-v1"))]
         let capture_url = options.endpoints().build_url(Endpoint::Capture);
         Self {
             http_client,
-            api_key: options.api_key.clone(),
+            options: options.clone(),
             capture_url,
-            disabled: options.is_disabled(),
-            disable_geoip: options.disable_geoip,
-            is_server: options.is_server,
             dedup_cache: flag_event_dedup_cache(),
             runtime: tokio::runtime::Handle::current(),
         }
     }
 
-    fn spawn_ship(&self, mut event: Event) {
-        if self.disabled {
+    fn spawn_ship(&self, event: Event) {
+        if self.options.is_disabled() {
             return;
         }
+        #[cfg(feature = "capture-v1")]
+        self.spawn_ship_v1(event);
+        #[cfg(not(feature = "capture-v1"))]
+        self.spawn_ship_v0(event);
+    }
+
+    /// Ship over the V1 capture endpoint. Deliberately a single attempt with
+    /// no retry loop, matching v0 flag-event semantics: a lost
+    /// `$feature_flag_called` event is not worth retry traffic, and shipping
+    /// must never block or slow flag reads.
+    #[cfg(feature = "capture-v1")]
+    fn spawn_ship_v1(&self, event: Event) {
+        let (headers, body) =
+            match super::v1_capture::build_flag_event_request(&self.options, &event) {
+                Ok(parts) => parts,
+                Err(e) => {
+                    debug!(error = %e, "failed to serialize $feature_flag_called event");
+                    return;
+                }
+            };
+        let http_client = self.http_client.clone();
+        let url = self.capture_url.clone();
+        self.runtime.spawn(async move {
+            match http_client
+                .post(&url)
+                .headers(headers)
+                .body(body)
+                .send()
+                .await
+            {
+                Ok(resp) => {
+                    let status = resp.status().as_u16();
+                    if !(200..=299).contains(&status) {
+                        let message = resp
+                            .text()
+                            .await
+                            .unwrap_or_else(|_| "Unknown error".to_string());
+                        debug!(
+                            status,
+                            "$feature_flag_called event rejected by server: {message}"
+                        );
+                    }
+                }
+                Err(send_err) => {
+                    let message = send_err.to_string();
+                    debug!("failed to send $feature_flag_called event: {message}");
+                }
+            }
+        });
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    fn spawn_ship_v0(&self, mut event: Event) {
         event.prepare_for_v0();
-        let inner_event = InnerEvent::new(event, self.api_key.clone());
+        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
             Err(e) => {
@@ -130,7 +189,9 @@ impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
             return;
         }
 
-        if let Some(event) = flag_called_event(params, self.disable_geoip, self.is_server) {
+        if let Some(event) =
+            flag_called_event(params, self.options.disable_geoip, self.options.is_server)
+        {
             self.spawn_ship(event);
         }
     }

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -58,9 +58,8 @@ pub struct Client {
 /// HTTP transport. The event ship is fire-and-forget: errors are logged at
 /// `debug` level but do not surface to the caller, matching the JS SDK.
 ///
-/// With the `capture-v1` feature the events go to the same V1 endpoint as
-/// regular capture (single attempt, no retry loop); otherwise they take the
-/// legacy v0 `/i/v0/e/` path.
+/// With `capture-v1`, events ship to the V1 endpoint (single attempt);
+/// otherwise the legacy v0 `/i/v0/e/` path.
 struct AsyncFlagEventHost {
     http_client: HttpClient,
     options: ClientOptions,
@@ -101,10 +100,8 @@ impl AsyncFlagEventHost {
         self.spawn_ship_v0(event);
     }
 
-    /// Ship over the V1 capture endpoint. Deliberately a single attempt with
-    /// no retry loop, matching v0 flag-event semantics: a lost
-    /// `$feature_flag_called` event is not worth retry traffic, and shipping
-    /// must never block or slow flag reads.
+    /// Single attempt, no retries — matches v0 flag-event semantics: losses
+    /// aren't worth retry traffic and shipping must never slow flag reads.
     #[cfg(feature = "capture-v1")]
     fn spawn_ship_v1(&self, event: Event) {
         let (headers, body) =

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -57,9 +57,8 @@ pub struct Client {
 /// HTTP transport. Constructed lazily and cached on the [`Client`] so all
 /// snapshots share a single dedup cache.
 ///
-/// With the `capture-v1` feature the events go to the same V1 endpoint as
-/// regular capture (single synchronous attempt, no retry loop); otherwise
-/// they take the legacy v0 `/i/v0/e/` path.
+/// With `capture-v1`, events ship to the V1 endpoint (single synchronous
+/// attempt); otherwise the legacy v0 `/i/v0/e/` path.
 struct BlockingFlagEventHost {
     http_client: HttpClient,
     options: ClientOptions,
@@ -93,10 +92,8 @@ impl BlockingFlagEventHost {
         self.ship_event_v0(event);
     }
 
-    /// Ship over the V1 capture endpoint. Deliberately a single attempt with
-    /// no retry loop, matching v0 flag-event semantics: a lost
-    /// `$feature_flag_called` event is not worth retry traffic or extra
-    /// blocking time on the caller's thread.
+    /// Single attempt, no retries — matches v0 flag-event semantics: losses
+    /// aren't worth retry traffic or extra blocking time on the caller.
     #[cfg(feature = "capture-v1")]
     fn ship_event_v1(&self, event: Event) {
         let (headers, body) =

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -10,7 +10,9 @@ use tracing::{debug, instrument, trace, warn};
 #[cfg(feature = "capture-v1")]
 use uuid::Uuid;
 
-use crate::endpoints::{Endpoint, EndpointManager};
+use crate::endpoints::Endpoint;
+#[cfg(not(feature = "capture-v1"))]
+use crate::event::InnerEvent;
 #[cfg(feature = "capture-v1")]
 use crate::event_v1::CaptureResponse;
 use crate::feature_flag_evaluations::{
@@ -19,7 +21,7 @@ use crate::feature_flag_evaluations::{
 };
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
-use crate::{event::InnerEvent, Error, Event};
+use crate::{Error, Event};
 
 use super::common::{
     already_reported, build_dedup_key, extract_flag_details, flag_called_event,
@@ -28,6 +30,7 @@ use super::common::{
 };
 use super::ClientOptions;
 
+#[cfg(not(feature = "capture-v1"))]
 fn check_response(response: reqwest::blocking::Response) -> Result<(), Error> {
     let status = response.status().as_u16();
     let body = response
@@ -53,35 +56,84 @@ pub struct Client {
 /// `$feature_flag_called` events through a clone of the blocking [`Client`]'s
 /// HTTP transport. Constructed lazily and cached on the [`Client`] so all
 /// snapshots share a single dedup cache.
+///
+/// With the `capture-v1` feature the events go to the same V1 endpoint as
+/// regular capture (single synchronous attempt, no retry loop); otherwise
+/// they take the legacy v0 `/i/v0/e/` path.
 struct BlockingFlagEventHost {
     http_client: HttpClient,
-    api_key: String,
-    endpoints: EndpointManager,
-    disabled: bool,
-    disable_geoip: bool,
-    is_server: bool,
+    options: ClientOptions,
+    capture_url: String,
     dedup_cache: FlagEventDedupCache,
 }
 
 impl BlockingFlagEventHost {
     fn from_options(options: &ClientOptions, http_client: HttpClient) -> Self {
+        #[cfg(feature = "capture-v1")]
+        let capture_url = options
+            .endpoints()
+            .build_custom_url(super::v1_capture::V1_CAPTURE_PATH);
+        #[cfg(not(feature = "capture-v1"))]
+        let capture_url = options.endpoints().build_url(Endpoint::Capture);
         Self {
             http_client,
-            api_key: options.api_key.clone(),
-            endpoints: options.endpoints().clone(),
-            disabled: options.is_disabled(),
-            disable_geoip: options.disable_geoip,
-            is_server: options.is_server,
+            options: options.clone(),
+            capture_url,
             dedup_cache: flag_event_dedup_cache(),
         }
     }
 
-    fn ship_event(&self, mut event: Event) {
-        if self.disabled {
+    fn ship_event(&self, event: Event) {
+        if self.options.is_disabled() {
             return;
         }
+        #[cfg(feature = "capture-v1")]
+        self.ship_event_v1(event);
+        #[cfg(not(feature = "capture-v1"))]
+        self.ship_event_v0(event);
+    }
+
+    /// Ship over the V1 capture endpoint. Deliberately a single attempt with
+    /// no retry loop, matching v0 flag-event semantics: a lost
+    /// `$feature_flag_called` event is not worth retry traffic or extra
+    /// blocking time on the caller's thread.
+    #[cfg(feature = "capture-v1")]
+    fn ship_event_v1(&self, event: Event) {
+        let (headers, body) =
+            match super::v1_capture::build_flag_event_request(&self.options, &event) {
+                Ok(parts) => parts,
+                Err(e) => {
+                    debug!(error = %e, "failed to serialize $feature_flag_called event");
+                    return;
+                }
+            };
+        let result = self
+            .http_client
+            .post(&self.capture_url)
+            .headers(headers)
+            .body(body)
+            .send();
+        match result {
+            Ok(response) => {
+                let status = response.status().as_u16();
+                if !(200..=299).contains(&status) {
+                    let message = response
+                        .text()
+                        .unwrap_or_else(|_| "Unknown error".to_string());
+                    debug!(
+                        status,
+                        "$feature_flag_called event rejected by server: {message}"
+                    );
+                }
+            }
+            Err(e) => debug!(error = %e, "failed to send $feature_flag_called event"),
+        }
+    }
+
+    #[cfg(not(feature = "capture-v1"))]
+    fn ship_event_v0(&self, mut event: Event) {
         event.prepare_for_v0();
-        let inner_event = InnerEvent::new(event, self.api_key.clone());
+        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
             Err(e) => {
@@ -89,10 +141,9 @@ impl BlockingFlagEventHost {
                 return;
             }
         };
-        let url = self.endpoints.build_url(Endpoint::Capture);
         let result = self
             .http_client
-            .post(&url)
+            .post(&self.capture_url)
             .header(CONTENT_TYPE, "application/json")
             .body(payload)
             .send();
@@ -114,7 +165,9 @@ impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
             return;
         }
 
-        if let Some(event) = flag_called_event(params, self.disable_geoip, self.is_server) {
+        if let Some(event) =
+            flag_called_event(params, self.options.disable_geoip, self.options.is_server)
+        {
             self.ship_event(event);
         }
     }

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -45,12 +45,8 @@ pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<
 
 pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u32) -> HeaderMap {
     let version = env!("CARGO_PKG_VERSION");
-    // V1 SDK-identity standard: `<canonical-$lib-name>/<semver>`. The name
-    // segment MUST equal the value this SDK sends as `$lib` on the v0 path
-    // ("posthog-rs"); consumers parse by splitting at the LAST '/'. Capture
-    // materializes this header into `$lib`/`$lib_version` event properties
-    // server-side, so downstream surfaces (SDK Health, usage reports, Library
-    // columns) attribute v1 traffic correctly.
+    // SDK identity: `<canonical-$lib-name>/<semver>`. The name must match v0's
+    // `$lib` ("posthog-rs"); capture materializes it into `$lib`/`$lib_version`.
     let sdk_info = format!("posthog-rs/{version}");
 
     let mut headers = HeaderMap::new();
@@ -111,15 +107,10 @@ pub(crate) fn maybe_compress(
     payload
 }
 
-/// Build headers and (possibly compressed) body for a single-event,
-/// fire-and-forget `$feature_flag_called` ship over the V1 endpoint.
-///
-/// Always a single attempt (`posthog-attempt: 1`): the flag-event hosts
-/// mirror the v0 behavior where a lost `$feature_flag_called` event is not
-/// worth retry traffic, and shipping must never block flag reads. `$lib` /
-/// `$lib_version` are intentionally not injected into properties here — on
-/// the V1 path they are carried by the `posthog-sdk-info` header and
-/// materialized server-side by capture.
+/// Headers + (possibly compressed) body for a single-event, fire-and-forget
+/// `$feature_flag_called` ship over the V1 endpoint. Always one attempt:
+/// flag-event loss isn't worth retry traffic, and shipping must never block
+/// flag reads.
 pub(crate) fn build_flag_event_request(
     opts: &ClientOptions,
     event: &Event,
@@ -215,10 +206,8 @@ pub(crate) fn after_response(
     pending: &mut Vec<V1Event>,
     final_results: &mut HashMap<Uuid, EventResult>,
 ) -> Step {
-    // The backend returns exactly 200 on success today (per-event outcomes are
-    // carried in the JSON body, never via alternate 2xx codes), but accept the
-    // whole success class so a future 201/202/207 is not misclassified as a
-    // connection error.
+    // The backend sends exactly 200 today; accept the whole 2xx class so a
+    // future 201/202 isn't misclassified as a connection error.
     if (200..=299).contains(&status) {
         let batch_resp: CaptureResponse = match serde_json::from_str(body) {
             Ok(r) => r,
@@ -652,8 +641,7 @@ mod tests {
         }
     }
 
-    /// C3: a 2xx whose body is not a batch response is a Serialization error —
-    /// success classification must not silently swallow an unreadable body.
+    /// C3: a 2xx with an unreadable body is a Serialization error, not success.
     #[test]
     fn after_response_alternate_2xx_malformed_body_fails() {
         let opts = test_opts();
@@ -675,10 +663,8 @@ mod tests {
 
     // -- build_headers SDK identity -------------------------------------------
 
-    /// C4: pins the v1 SDK-identity wire format `<canonical-$lib-name>/<semver>`.
-    /// The name segment must be "posthog-rs" — the same value the v0 path sends
-    /// as `$lib` — because capture materializes this header into
-    /// `$lib`/`$lib_version` properties server-side.
+    /// C4: pins the wire identity `posthog-rs/<semver>` — the name must equal
+    /// v0's `$lib` so capture's `$lib`/`$lib_version` materialization is correct.
     #[test]
     fn build_headers_sdk_info_is_canonical_lib_slash_version() {
         let opts = test_opts();

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -45,7 +45,13 @@ pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<
 
 pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u32) -> HeaderMap {
     let version = env!("CARGO_PKG_VERSION");
-    let sdk_info = format!("posthog-rust/{version}");
+    // V1 SDK-identity standard: `<canonical-$lib-name>/<semver>`. The name
+    // segment MUST equal the value this SDK sends as `$lib` on the v0 path
+    // ("posthog-rs"); consumers parse by splitting at the LAST '/'. Capture
+    // materializes this header into `$lib`/`$lib_version` event properties
+    // server-side, so downstream surfaces (SDK Health, usage reports, Library
+    // columns) attribute v1 traffic correctly.
+    let sdk_info = format!("posthog-rs/{version}");
 
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -56,13 +62,11 @@ pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u3
     );
     headers.insert(
         "user-agent",
-        HeaderValue::from_str(&sdk_info)
-            .unwrap_or_else(|_| HeaderValue::from_static("posthog-rust")),
+        HeaderValue::from_str(&sdk_info).unwrap_or_else(|_| HeaderValue::from_static("posthog-rs")),
     );
     headers.insert(
         "posthog-sdk-info",
-        HeaderValue::from_str(&sdk_info)
-            .unwrap_or_else(|_| HeaderValue::from_static("posthog-rust")),
+        HeaderValue::from_str(&sdk_info).unwrap_or_else(|_| HeaderValue::from_static("posthog-rs")),
     );
     headers.insert(
         "posthog-attempt",
@@ -105,6 +109,34 @@ pub(crate) fn maybe_compress(
         }
     }
     payload
+}
+
+/// Build headers and (possibly compressed) body for a single-event,
+/// fire-and-forget `$feature_flag_called` ship over the V1 endpoint.
+///
+/// Always a single attempt (`posthog-attempt: 1`): the flag-event hosts
+/// mirror the v0 behavior where a lost `$feature_flag_called` event is not
+/// worth retry traffic, and shipping must never block flag reads. `$lib` /
+/// `$lib_version` are intentionally not injected into properties here — on
+/// the V1 path they are carried by the `posthog-sdk-info` header and
+/// materialized server-side by capture.
+pub(crate) fn build_flag_event_request(
+    opts: &ClientOptions,
+    event: &Event,
+) -> Result<(HeaderMap, Vec<u8>), Error> {
+    use crate::event_v1::V1BatchRequestRef;
+
+    let batch = build_events(std::slice::from_ref(event), &opts.capture_defaults());
+    let created_at = Utc::now().to_rfc3339();
+    let req = V1BatchRequestRef {
+        created_at: &created_at,
+        historical_migration: None,
+        batch: &batch,
+    };
+    let payload = serde_json::to_vec(&req).map_err(|e| Error::Serialization(e.to_string()))?;
+    let mut headers = build_headers(opts, &Uuid::now_v7(), 1);
+    let body = maybe_compress(opts.capture_compression, &mut headers, payload);
+    Ok((headers, body))
 }
 
 // ---------------------------------------------------------------------------
@@ -183,7 +215,11 @@ pub(crate) fn after_response(
     pending: &mut Vec<V1Event>,
     final_results: &mut HashMap<Uuid, EventResult>,
 ) -> Step {
-    if status == 200 {
+    // The backend returns exactly 200 on success today (per-event outcomes are
+    // carried in the JSON body, never via alternate 2xx codes), but accept the
+    // whole success class so a future 201/202/207 is not misclassified as a
+    // connection error.
+    if (200..=299).contains(&status) {
         let batch_resp: CaptureResponse = match serde_json::from_str(body) {
             Ok(r) => r,
             Err(e) => return Step::Fail(Error::Serialization(e.to_string())),
@@ -583,5 +619,150 @@ mod tests {
             &mut final_results,
         );
         assert!(matches!(step, Step::Fail(Error::Serialization(_))));
+    }
+
+    /// C3: any 2xx with a well-formed body is success, not a connection error.
+    #[test]
+    fn after_response_alternate_2xx_statuses_succeed() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        for status in [201u16, 202, 204, 207, 299] {
+            let e = dummy_v1_event();
+            let body = serde_json::json!({
+                "results": { e.uuid.to_string(): { "result": "ok" } }
+            })
+            .to_string();
+            let mut pending = vec![e];
+            let mut final_results = HashMap::new();
+            let step = after_response(
+                &opts,
+                &rid,
+                1,
+                status,
+                None,
+                &body,
+                &mut pending,
+                &mut final_results,
+            );
+            assert!(
+                matches!(step, Step::Done),
+                "HTTP {status} should be treated as success"
+            );
+            assert_eq!(final_results.len(), 1);
+        }
+    }
+
+    /// C3: a 2xx whose body is not a batch response is a Serialization error —
+    /// success classification must not silently swallow an unreadable body.
+    #[test]
+    fn after_response_alternate_2xx_malformed_body_fails() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let mut pending = vec![dummy_v1_event()];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            1,
+            201,
+            None,
+            "not json",
+            &mut pending,
+            &mut final_results,
+        );
+        assert!(matches!(step, Step::Fail(Error::Serialization(_))));
+    }
+
+    // -- build_headers SDK identity -------------------------------------------
+
+    /// C4: pins the v1 SDK-identity wire format `<canonical-$lib-name>/<semver>`.
+    /// The name segment must be "posthog-rs" — the same value the v0 path sends
+    /// as `$lib` — because capture materializes this header into
+    /// `$lib`/`$lib_version` properties server-side.
+    #[test]
+    fn build_headers_sdk_info_is_canonical_lib_slash_version() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let headers = build_headers(&opts, &rid, 1);
+
+        let sdk_info = headers.get("posthog-sdk-info").unwrap().to_str().unwrap();
+        let expected = format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"));
+        assert_eq!(sdk_info, expected);
+
+        // Parse the way capture does: split at the last '/'.
+        let (lib, version) = sdk_info.rsplit_once('/').unwrap();
+        assert_eq!(lib, "posthog-rs");
+        assert_eq!(version, env!("CARGO_PKG_VERSION"));
+        assert!(!version.is_empty());
+
+        // user-agent mirrors the same identity string.
+        let ua = headers.get("user-agent").unwrap().to_str().unwrap();
+        assert_eq!(ua, expected);
+    }
+
+    // -- build_flag_event_request ----------------------------------------------
+
+    fn flag_called_test_event() -> Event {
+        let mut event = Event::new("$feature_flag_called", "user-1");
+        event.insert_prop("$feature_flag", "my-flag").unwrap();
+        event.insert_prop("$feature_flag_response", true).unwrap();
+        event
+    }
+
+    #[test]
+    fn build_flag_event_request_single_event_batch() {
+        let opts = test_opts();
+        let (headers, body) = build_flag_event_request(&opts, &flag_called_test_event()).unwrap();
+
+        assert_eq!(headers.get("content-type").unwrap(), "application/json");
+        assert_eq!(headers.get("posthog-attempt").unwrap(), "1");
+        assert!(headers.get("posthog-request-id").is_some());
+        assert_eq!(
+            headers.get("authorization").unwrap().to_str().unwrap(),
+            "Bearer phc_test"
+        );
+        assert!(headers.get("content-encoding").is_none());
+
+        let parsed: crate::event_v1::V1BatchRequest = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.batch.len(), 1);
+        assert_eq!(parsed.batch[0].event, "$feature_flag_called");
+        assert_eq!(parsed.batch[0].distinct_id, "user-1");
+        assert!(parsed.historical_migration.is_none());
+        let props = parsed.batch[0].properties.as_object().unwrap();
+        assert_eq!(props.get("$feature_flag").unwrap(), "my-flag");
+        // V1 carries SDK identity in headers, not properties.
+        assert!(!props.contains_key("$lib"));
+        assert!(!props.contains_key("$lib_version"));
+    }
+
+    #[test]
+    fn build_flag_event_request_applies_capture_defaults() {
+        let opts = ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .disable_geoip(true)
+            .is_server(true)
+            .build()
+            .unwrap();
+        let (_, body) = build_flag_event_request(&opts, &flag_called_test_event()).unwrap();
+        let parsed: crate::event_v1::V1BatchRequest = serde_json::from_slice(&body).unwrap();
+        let props = parsed.batch[0].properties.as_object().unwrap();
+        assert_eq!(
+            props.get("$geoip_disable").unwrap(),
+            &serde_json::json!(true)
+        );
+        assert_eq!(props.get("$is_server").unwrap(), &serde_json::json!(true));
+    }
+
+    #[test]
+    fn build_flag_event_request_compresses_when_configured() {
+        let opts = ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .capture_compression(CaptureCompression::Gzip)
+            .build()
+            .unwrap();
+        let (headers, body) = build_flag_event_request(&opts, &flag_called_test_event()).unwrap();
+        assert_eq!(headers.get("content-encoding").unwrap(), "gzip");
+        // gzip magic bytes — the body is actually compressed.
+        assert_eq!(&body[..2], &[0x1f, 0x8b]);
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -313,6 +313,8 @@ pub struct BatchRequest {
 }
 
 // This exists so that the client doesn't have to specify the API key over and over
+// With `capture-v1` enabled nothing outside tests builds the V0 wire format.
+#[cfg_attr(feature = "capture-v1", allow(dead_code))]
 #[derive(Serialize)]
 pub struct InnerEvent {
     api_key: String,
@@ -326,6 +328,7 @@ pub struct InnerEvent {
 impl InnerEvent {
     /// Construct the V0 wire event. Expects that [`Event::prepare_for_v0`] has
     /// already been called so properties are fully decorated.
+    #[cfg_attr(feature = "capture-v1", allow(dead_code))]
     pub fn new(event: Event, api_key: String) -> Self {
         Self {
             api_key,

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -4,6 +4,24 @@ use serde_json::{json, Value};
 #[cfg(feature = "async-client")]
 use std::time::Duration;
 
+/// Capture endpoint `$feature_flag_called` events ship to: the V1 analytics
+/// path with `capture-v1`, the legacy v0 path otherwise.
+#[cfg(feature = "capture-v1")]
+const CAPTURE_PATH: &str = "/i/v1/analytics/events";
+#[cfg(not(feature = "capture-v1"))]
+const CAPTURE_PATH: &str = "/i/v0/e/";
+
+/// Feature-aware mock for the capture endpoint. The JSON body is required by
+/// the V1 client and harmlessly ignored by the v0 flag-event host.
+fn capture_path_mock(server: &MockServer) -> httpmock::Mock<'_> {
+    server.mock(|when, then| {
+        when.method(POST).path(CAPTURE_PATH);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    })
+}
+
 fn flags_response_fixture() -> Value {
     json!({
         "flags": {
@@ -80,10 +98,7 @@ mod blocking {
             when.method(POST).path("/flags/").query_param("v", "2");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
 
         let client = create_test_client(server.base_url());
         let snapshot = client
@@ -104,10 +119,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url());
         let _snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -123,10 +135,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url());
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -154,10 +163,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url());
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -177,10 +183,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url());
 
         let snap_1 = client
@@ -231,10 +234,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url());
         let snap = client
             .evaluate_flags(
@@ -294,10 +294,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url());
         let snapshot = client
             .evaluate_flags("", EvaluateFlagsOptions::default())
@@ -316,10 +313,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url());
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -354,10 +348,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        capture_path_mock(&server);
         let client = create_test_client(server.base_url());
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -391,10 +382,7 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(response);
         });
-        server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        capture_path_mock(&server);
         let client = create_test_client(server.base_url());
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -464,6 +452,69 @@ mod blocking {
         );
     }
 
+    /// C5: with `capture-v1`, `$feature_flag_called` ships through the V1
+    /// analytics endpoint (single attempt, SDK identity in headers) and
+    /// nothing hits the legacy v0 path.
+    #[cfg(feature = "capture-v1")]
+    #[test]
+    fn flag_called_event_routes_to_v1_endpoint() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let v1_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "1")
+                .header(
+                    "posthog-sdk-info",
+                    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION")),
+                )
+                .body_contains("$feature_flag_called")
+                .body_contains("\"$feature_flag\":\"alpha\"");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "results": {} }));
+        });
+        let v0_mock = server.mock(|when, then| {
+            when.method(POST).path("/i/v0/e/");
+            then.status(200);
+        });
+        let client = create_test_client(server.base_url());
+        let snapshot = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .unwrap();
+        assert!(snapshot.is_enabled("alpha"));
+        v1_mock.assert_hits(1);
+        v0_mock.assert_hits(0);
+    }
+
+    /// C5: a failed V1 flag-event ship is fire-and-forget — exactly one
+    /// attempt, no retry loop, and no error surfaced to the flag read.
+    #[cfg(feature = "capture-v1")]
+    #[test]
+    fn flag_called_event_v1_failure_is_single_attempt_and_silent() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let v1_mock = server.mock(|when, then| {
+            when.method(POST).path("/i/v1/analytics/events");
+            then.status(503)
+                .header("content-type", "application/json")
+                .json_body(json!({ "error": "service_unavailable" }));
+        });
+        let client = create_test_client(server.base_url());
+        let snapshot = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .unwrap();
+        // The flag read still succeeds; the ship is attempted exactly once.
+        assert!(snapshot.is_enabled("alpha"));
+        v1_mock.assert_hits(1);
+    }
+
     #[test]
     fn disabled_client_returns_empty_snapshot() {
         let server = MockServer::start();
@@ -531,10 +582,7 @@ mod async_tests {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url()).await;
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -582,10 +630,7 @@ mod async_tests {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url()).await;
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -624,10 +669,7 @@ mod async_tests {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url()).await;
         let snapshot = client
             .evaluate_flags("", EvaluateFlagsOptions::default())
@@ -639,6 +681,73 @@ mod async_tests {
         capture_mock.assert_hits(0);
     }
 
+    /// C5: with `capture-v1`, `$feature_flag_called` ships through the V1
+    /// analytics endpoint (single attempt, SDK identity in headers) and
+    /// nothing hits the legacy v0 path.
+    #[cfg(feature = "capture-v1")]
+    #[tokio::test]
+    async fn flag_called_event_routes_to_v1_endpoint() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let v1_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "1")
+                .header(
+                    "posthog-sdk-info",
+                    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION")),
+                )
+                .body_contains("$feature_flag_called")
+                .body_contains("\"$feature_flag\":\"alpha\"");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "results": {} }));
+        });
+        let v0_mock = server.mock(|when, then| {
+            when.method(POST).path("/i/v0/e/");
+            then.status(200);
+        });
+        let client = create_test_client(server.base_url()).await;
+        let snapshot = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .await
+            .unwrap();
+        assert!(snapshot.is_enabled("alpha"));
+        flush_spawned_events().await;
+        v1_mock.assert_hits(1);
+        v0_mock.assert_hits(0);
+    }
+
+    /// C5: a failed V1 flag-event ship is fire-and-forget — exactly one
+    /// attempt, no retry loop, and no error surfaced to the flag read.
+    #[cfg(feature = "capture-v1")]
+    #[tokio::test]
+    async fn flag_called_event_v1_failure_is_single_attempt_and_silent() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let v1_mock = server.mock(|when, then| {
+            when.method(POST).path("/i/v1/analytics/events");
+            then.status(503)
+                .header("content-type", "application/json")
+                .json_body(json!({ "error": "service_unavailable" }));
+        });
+        let client = create_test_client(server.base_url()).await;
+        let snapshot = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .await
+            .unwrap();
+        // The flag read still succeeds; the ship is attempted exactly once.
+        assert!(snapshot.is_enabled("alpha"));
+        flush_spawned_events().await;
+        v1_mock.assert_hits(1);
+    }
+
     #[cfg(not(feature = "capture-v1"))]
     #[tokio::test]
     async fn event_with_flags_attaches_properties_without_extra_request() {
@@ -647,10 +756,7 @@ mod async_tests {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v0/e/");
-            then.status(200);
-        });
+        let capture_mock = capture_path_mock(&server);
         let client = create_test_client(server.base_url()).await;
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -4,15 +4,13 @@ use serde_json::{json, Value};
 #[cfg(feature = "async-client")]
 use std::time::Duration;
 
-/// Capture endpoint `$feature_flag_called` events ship to: the V1 analytics
-/// path with `capture-v1`, the legacy v0 path otherwise.
+/// Where `$feature_flag_called` ships: V1 analytics with `capture-v1`, else v0.
 #[cfg(feature = "capture-v1")]
 const CAPTURE_PATH: &str = "/i/v1/analytics/events";
 #[cfg(not(feature = "capture-v1"))]
 const CAPTURE_PATH: &str = "/i/v0/e/";
 
-/// Feature-aware mock for the capture endpoint. The JSON body is required by
-/// the V1 client and harmlessly ignored by the v0 flag-event host.
+/// Feature-aware capture mock; the JSON body is required by V1, ignored by v0.
 fn capture_path_mock(server: &MockServer) -> httpmock::Mock<'_> {
     server.mock(|when, then| {
         when.method(POST).path(CAPTURE_PATH);
@@ -452,9 +450,7 @@ mod blocking {
         );
     }
 
-    /// C5: with `capture-v1`, `$feature_flag_called` ships through the V1
-    /// analytics endpoint (single attempt, SDK identity in headers) and
-    /// nothing hits the legacy v0 path.
+    /// C5: `$feature_flag_called` ships via the V1 endpoint, never the v0 path.
     #[cfg(feature = "capture-v1")]
     #[test]
     fn flag_called_event_routes_to_v1_endpoint() {
@@ -490,8 +486,7 @@ mod blocking {
         v0_mock.assert_hits(0);
     }
 
-    /// C5: a failed V1 flag-event ship is fire-and-forget — exactly one
-    /// attempt, no retry loop, and no error surfaced to the flag read.
+    /// C5: a failed ship is fire-and-forget — one attempt, no surfaced error.
     #[cfg(feature = "capture-v1")]
     #[test]
     fn flag_called_event_v1_failure_is_single_attempt_and_silent() {
@@ -681,9 +676,7 @@ mod async_tests {
         capture_mock.assert_hits(0);
     }
 
-    /// C5: with `capture-v1`, `$feature_flag_called` ships through the V1
-    /// analytics endpoint (single attempt, SDK identity in headers) and
-    /// nothing hits the legacy v0 path.
+    /// C5: `$feature_flag_called` ships via the V1 endpoint, never the v0 path.
     #[cfg(feature = "capture-v1")]
     #[tokio::test]
     async fn flag_called_event_routes_to_v1_endpoint() {
@@ -721,8 +714,7 @@ mod async_tests {
         v0_mock.assert_hits(0);
     }
 
-    /// C5: a failed V1 flag-event ship is fire-and-forget — exactly one
-    /// attempt, no retry loop, and no error surfaced to the flag read.
+    /// C5: a failed ship is fire-and-forget — one attempt, no surfaced error.
     #[cfg(feature = "capture-v1")]
     #[tokio::test]
     async fn flag_called_event_v1_failure_is_single_attempt_and_silent() {

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -726,6 +726,56 @@ async fn v1_capture_request_id_stable_across_retries() {
     );
 }
 
+/// C3: a non-200 success status (e.g. a future 201/202) with a well-formed
+/// batch response body must be treated as success, not a connection error.
+#[tokio::test]
+async fn v1_capture_accepts_alternate_2xx_status() {
+    let server = MockServer::start();
+
+    let uuid = uuid::Uuid::now_v7();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "results": {
+                    uuid.to_string(): { "result": "ok" }
+                }
+            }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test", "user-1");
+    event.set_uuid(uuid);
+
+    let result = client.capture(event).await;
+    assert!(result.is_ok(), "201 should be accepted as success");
+    mock.assert_hits(1);
+}
+
+/// C4: pins the SDK identity sent on the wire — capture parses
+/// `posthog-sdk-info` (`<canonical-$lib-name>/<semver>`) into
+/// `$lib`/`$lib_version`, so the name segment must be "posthog-rs".
+#[tokio::test]
+async fn v1_capture_sends_canonical_sdk_info_header() {
+    let server = MockServer::start();
+
+    let expected = format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"));
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .header("posthog-sdk-info", &expected)
+            .header("user-agent", &expected);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
 #[tokio::test]
 async fn v1_capture_disabled_client_noop() {
     let options = ClientOptionsBuilder::default()

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -726,8 +726,7 @@ async fn v1_capture_request_id_stable_across_retries() {
     );
 }
 
-/// C3: a non-200 success status (e.g. a future 201/202) with a well-formed
-/// batch response body must be treated as success, not a connection error.
+/// C3: a non-200 2xx with a well-formed body is success, not a connection error.
 #[tokio::test]
 async fn v1_capture_accepts_alternate_2xx_status() {
     let server = MockServer::start();
@@ -753,9 +752,8 @@ async fn v1_capture_accepts_alternate_2xx_status() {
     mock.assert_hits(1);
 }
 
-/// C4: pins the SDK identity sent on the wire — capture parses
-/// `posthog-sdk-info` (`<canonical-$lib-name>/<semver>`) into
-/// `$lib`/`$lib_version`, so the name segment must be "posthog-rs".
+/// C4: pins the wire identity `posthog-rs/<semver>` that capture parses
+/// into `$lib`/`$lib_version`.
 #[tokio::test]
 async fn v1_capture_sends_canonical_sdk_info_header() {
     let server = MockServer::start();


### PR DESCRIPTION
## Summary
Follow-on that needed to land prior to un-gating capture v1, and misc. papercuts identified in smoke testing.

- **`$feature_flag_called` routes through v1** when `capture-v1` is enabled
    - This previously went around the std SDK capture path
    - v1 support stays fire-and-forget with a **single attempt and no retry loop** on both async and blocking hosts
- **Accept any 2xx as success** in `v1_capture::after_response` (was exactly 200), so a future 201/202/207 from capture is not misclassified as a connection error. Malformed bodies on 2xx still surface as `Error::Serialization`.
- **Canonical SDK identity**: `posthog-sdk-info` / `user-agent` now send `posthog-rs/<version>` (was `posthog-rust/<version>`)
    - The name segment now matches the `$lib` value the v0 path sends, so  v1 backend attributes correctly in SDK Health, usage reports, and Library columns
- **CI**:  ensure full matrix of v1-relevant Rust build features are exercised in CI unit test runs

## Test plan

- [x] `cargo test` (async, v0): 183 pass
- [x] `cargo test --features capture-v1`: 226 pass
- [x] `cargo test --no-default-features` (blocking, v0): 185 pass
- [x] `cargo test --no-default-features --features capture-v1`: 225 pass
- [x] `cargo test --workspace`, `cargo fmt --check`, `cargo clippy -- -D warnings`
- [x] New tests: 2xx-range unit + e2e (201), sdk-info format pin (unit + e2e), `build_flag_event_request` (batch shape, defaults, compression), v1 flag-event routing + single-attempt-failure (async + blocking)