### PR TITLE
feat: capture instruction addresses and debug images for symbolication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1793,7 @@ dependencies = [
  "ctor",
  "derive_builder",
  "dotenv",
+ "findshlibs",
  "flate2",
  "futures",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ derive_builder = "0.20.2"
 uuid = { version = "1.13.2", features = ["serde", "v7"] }
 # Pinned: backtrace 0.3.75+ raises its MSRV to 1.82, above this crate's 1.78 (see rust-version).
 backtrace = { version = "=0.3.74", optional = true }
+findshlibs = { version = "0.10", optional = true }
 sha1 = "0.10"
 regex = "1.10"
 tracing = "0.1"
@@ -51,7 +52,7 @@ e2e-test = []
 async-client = ["tokio"]
 capture-v1 = ["brotli", "zstd"]
 test-harness = []
-error-tracking = ["dep:backtrace"]
+error-tracking = ["dep:backtrace", "dep:findshlibs"]
 
 [workspace]
 members = [".", "compliance/adapter"]

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -239,6 +239,9 @@ pub struct Exception {
     // trimming, stacktrace opt-out), applied in finalize_exception and attached
     // to items[0].
     captured_frames: Option<Vec<StackFrame>>,
+    // Loaded modules referenced by captured_frames; becomes the event-level
+    // $debug_images property after trimming.
+    captured_images: Vec<DebugImage>,
     fingerprint: Option<String>,
     level: String,
 }
@@ -275,9 +278,11 @@ impl Exception {
 
         link_exception_chain(&mut items);
 
+        let (frames, images) = capture_raw_application_stack();
         Self {
             items,
-            captured_frames: Some(capture_raw_application_frames()),
+            captured_frames: Some(frames),
+            captured_images: images,
             fingerprint: None,
             level: "error".to_string(),
         }
@@ -288,6 +293,7 @@ impl Exception {
     // Only exercised by tests today; kept as the message-capture seam.
     #[allow(dead_code)]
     pub fn from_message<T: Into<String>, V: Into<String>>(exception_type: T, value: V) -> Self {
+        let (frames, images) = capture_raw_application_stack();
         Self {
             items: vec![ExceptionItem {
                 exception_type: exception_type.into(),
@@ -295,7 +301,8 @@ impl Exception {
                 mechanism: ExceptionMechanism::default(),
                 stacktrace: None,
             }],
-            captured_frames: Some(capture_raw_application_frames()),
+            captured_frames: Some(frames),
+            captured_images: images,
             fingerprint: None,
             level: "error".to_string(),
         }
@@ -304,6 +311,7 @@ impl Exception {
     /// Build an exception from a panic, capturing the current stacktrace.
     #[allow(deprecated)]
     fn from_panic_info(panic_info: &panic::PanicInfo<'_>) -> Self {
+        let (frames, images) = capture_raw_panic_frames();
         Self {
             items: vec![ExceptionItem {
                 exception_type: "Panic".to_string(),
@@ -317,7 +325,8 @@ impl Exception {
                 },
                 stacktrace: None,
             }],
-            captured_frames: Some(capture_raw_panic_frames()),
+            captured_frames: Some(frames),
+            captured_images: images,
             fingerprint: None,
             level: "error".to_string(),
         }
@@ -367,6 +376,7 @@ pub(crate) fn finalize_exception(
     let Exception {
         mut items,
         captured_frames,
+        captured_images,
         fingerprint,
         level,
     } = exception;
@@ -375,13 +385,28 @@ pub(crate) fn finalize_exception(
     }
 
     items.truncate(options.max_error_sources().max(1));
+    let mut debug_images = Vec::new();
     if options.capture_stacktrace() {
         if let Some(mut frames) = captured_frames {
             for frame in frames.iter_mut() {
                 let function = (!frame.function.is_empty()).then_some(frame.function.as_str());
-                frame.in_app = options.is_in_app_frame(frame.filename.as_deref(), function);
+                // Frames without any symbol information keep their capture-time
+                // image-based classification; the path/function rules have
+                // nothing to act on.
+                if function.is_some() || frame.filename.is_some() {
+                    frame.in_app = options.is_in_app_frame(frame.filename.as_deref(), function);
+                }
             }
             trim_to_max_frames(&mut frames, options.max_frames());
+            // Only report modules still referenced after trimming.
+            debug_images = captured_images
+                .into_iter()
+                .filter(|image| {
+                    frames
+                        .iter()
+                        .any(|f| f.image_addr.as_deref() == Some(image.image_addr.as_str()))
+                })
+                .collect();
             items[0].stacktrace = Some(ExceptionStacktrace::raw(frames));
         }
     }
@@ -389,6 +414,9 @@ pub(crate) fn finalize_exception(
     event.insert_prop("$exception_level", level)?;
     if let Some(fingerprint) = fingerprint {
         event.insert_prop("$exception_fingerprint", fingerprint)?;
+    }
+    if !debug_images.is_empty() {
+        event.insert_prop("$debug_images", debug_images)?;
     }
     event.insert_prop("$exception_list", items)?;
     Ok(())
@@ -451,6 +479,11 @@ impl ExceptionStacktrace {
 }
 
 /// A normalized stack frame.
+///
+/// Frames carry the raw `instruction_addr` for server-side symbolication
+/// against uploaded debug symbols (`posthog-cli debug-symbols upload`), plus
+/// best-effort client-side enrichment (`function`/`filename`/`lineno`) used
+/// for display when no debug symbols are available.
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct StackFrame {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -458,18 +491,173 @@ pub struct StackFrame {
     #[serde(rename = "lineno")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_no: Option<u32>,
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub function: String,
     pub lang: String,
     pub in_app: bool,
     pub synthetic: bool,
-    pub resolved: bool,
     pub platform: String,
+    /// Absolute address of the instruction, as a hex string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instruction_addr: Option<String>,
+    /// Start address of the enclosing symbol, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol_addr: Option<String>,
+    /// Load address of the module containing the instruction, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_addr: Option<String>,
+}
+
+/// A loaded module (binary image) referenced by captured stack frames. Sent as
+/// the event-level `$debug_images` property so the server can map instruction
+/// addresses onto uploaded debug symbols.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct DebugImage {
+    #[serde(rename = "type")]
+    pub image_type: String,
+    /// The debug identifier matching the uploaded symbol set (derived from
+    /// the GNU build id on ELF, `LC_UUID` on Mach-O).
+    pub debug_id: String,
+    /// The full code identifier (e.g. complete GNU build id), when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_id: Option<String>,
+    pub image_addr: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_vmaddr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_file: Option<String>,
+    pub arch: String,
+}
+
+/// A module mapped into the process, used to attach load addresses to frames
+/// and build the `$debug_images` list.
+struct LoadedModule {
+    base: u64,
+    end: u64,
+    is_main: bool,
+    image: DebugImage,
+}
+
+const fn native_image_type() -> &'static str {
+    if cfg!(any(target_os = "macos", target_os = "ios")) {
+        "macho"
+    } else if cfg!(target_os = "windows") {
+        "pe"
+    } else {
+        "elf"
+    }
+}
+
+/// Derive a debug id from a GNU build id, matching how the server and CLI
+/// derive it from the binary: the first 16 bytes interpreted as a
+/// little-endian GUID (first three fields byte-swapped), zero-padded when the
+/// build id is shorter.
+fn debug_id_from_gnu_build_id(build_id: &[u8]) -> Option<String> {
+    if build_id.is_empty() {
+        return None;
+    }
+    let mut data = [0u8; 16];
+    let len = build_id.len().min(16);
+    data[..len].copy_from_slice(&build_id[..len]);
+    data[0..4].reverse();
+    data[4..6].reverse();
+    data[6..8].reverse();
+    Some(uuid::Uuid::from_bytes(data).to_string())
+}
+
+fn debug_id_for(id: &findshlibs::SharedLibraryId) -> Option<(String, Option<String>)> {
+    use findshlibs::SharedLibraryId;
+
+    match id {
+        SharedLibraryId::GnuBuildId(bytes) => {
+            let code_id = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
+            debug_id_from_gnu_build_id(bytes).map(|debug_id| (debug_id, Some(code_id)))
+        }
+        SharedLibraryId::Uuid(bytes) => Some((uuid::Uuid::from_bytes(*bytes).to_string(), None)),
+        SharedLibraryId::PdbSignature(guid, age) => {
+            let uuid = uuid::Uuid::from_bytes(*guid).to_string();
+            let debug_id = if *age > 0 {
+                format!("{uuid}-{age:x}")
+            } else {
+                uuid
+            };
+            Some((debug_id, None))
+        }
+        // PE timestamp/size signatures carry no debug id we can match symbols to.
+        _ => None,
+    }
+}
+
+/// Enumerate the modules currently mapped into the process, sorted by load
+/// address. Modules without a usable debug id are kept for address matching
+/// (frames still get an `image_addr`) but marked so they're never reported
+/// in `$debug_images`.
+fn collect_loaded_modules() -> Vec<LoadedModule> {
+    use findshlibs::{IterationControl, SharedLibrary, TargetSharedLibrary};
+
+    let mut modules = Vec::new();
+    let mut is_first = true;
+
+    TargetSharedLibrary::each(|shlib| {
+        let base = shlib.actual_load_addr().0 as u64;
+        let size = shlib.len() as u64;
+        // The first module reported is the main executable on all supported
+        // platforms; its name can be empty on Linux.
+        let is_main = is_first;
+        is_first = false;
+
+        let name = shlib.name().to_string_lossy().into_owned();
+        let code_file = if name.is_empty() {
+            std::env::current_exe()
+                .ok()
+                .map(|p| p.to_string_lossy().into_owned())
+        } else {
+            Some(name)
+        };
+
+        let ids = shlib.id().as_ref().and_then(debug_id_for);
+        let (debug_id, code_id) = match ids {
+            Some((debug_id, code_id)) => (debug_id, code_id),
+            None => (String::new(), None),
+        };
+
+        modules.push(LoadedModule {
+            base,
+            end: base.saturating_add(size),
+            is_main,
+            image: DebugImage {
+                image_type: native_image_type().to_string(),
+                debug_id,
+                code_id,
+                image_addr: format!("0x{base:x}"),
+                image_size: Some(size),
+                image_vmaddr: Some(format!("0x{:x}", shlib.stated_load_addr().0 as u64)),
+                code_file,
+                arch: std::env::consts::ARCH.to_string(),
+            },
+        });
+
+        IterationControl::Continue
+    });
+
+    modules.sort_by_key(|m| m.base);
+    modules
+}
+
+fn find_module(modules: &[LoadedModule], addr: u64) -> Option<&LoadedModule> {
+    let idx = modules.partition_point(|m| m.base <= addr);
+    let module = modules[..idx].last()?;
+    (addr < module.end).then_some(module)
 }
 
 // Captures raw Rust stack traces for Error Tracking. Frames are unclassified
 // at this point: in-app classification and trimming are client policy, applied
-// at capture time by finalize_exception.
-fn capture_frames_current_first(skip: usize) -> Vec<StackFrame> {
+// at capture time by finalize_exception. Every frame carries its instruction
+// address; function/file/line enrichment is best-effort and missing entirely
+// in stripped release builds.
+fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<StackFrame> {
     let mut frames = Vec::new();
     let mut skipped = 0usize;
 
@@ -478,6 +666,10 @@ fn capture_frames_current_first(skip: usize) -> Vec<StackFrame> {
             skipped += 1;
             return true;
         }
+
+        let instruction_addr = frame.ip() as u64;
+        let symbol_addr = frame.symbol_address() as u64;
+        let module = find_module(modules, instruction_addr);
 
         let mut pushed = false;
         backtrace::resolve_frame(frame, |symbol| {
@@ -501,11 +693,32 @@ fn capture_frames_current_first(skip: usize) -> Vec<StackFrame> {
                 lang: "rust".to_string(),
                 in_app: false,
                 synthetic: false,
-                resolved: true,
-                platform: "rust".to_string(),
+                platform: "native".to_string(),
+                instruction_addr: Some(format!("0x{instruction_addr:x}")),
+                symbol_addr: (symbol_addr != 0).then(|| format!("0x{symbol_addr:x}")),
+                image_addr: module.map(|m| m.image.image_addr.clone()),
             });
             pushed = true;
         });
+
+        if !pushed {
+            // No symbol information (e.g. stripped binary): keep the frame as
+            // an address-only entry for server-side symbolication. In-app
+            // classification has no names to work with, so default by module:
+            // the main executable is application code, shared libraries aren't.
+            frames.push(StackFrame {
+                filename: None,
+                line_no: None,
+                function: String::new(),
+                lang: "rust".to_string(),
+                in_app: module.is_some_and(|m| m.is_main),
+                synthetic: false,
+                platform: "native".to_string(),
+                instruction_addr: Some(format!("0x{instruction_addr:x}")),
+                symbol_addr: (symbol_addr != 0).then(|| format!("0x{symbol_addr:x}")),
+                image_addr: module.map(|m| m.image.image_addr.clone()),
+            });
+        }
 
         true
     });
@@ -523,9 +736,11 @@ fn trim_to_max_frames(frames: &mut Vec<StackFrame>, max_frames: usize) {
 
 /// Capture the current raw stacktrace in wire order — outermost frame first,
 /// crash/capture-site frame last, matching the other PostHog SDKs — dropping
-/// the SDK's own capture frames.
-fn capture_raw_application_frames() -> Vec<StackFrame> {
-    let mut frames = capture_frames_current_first(0);
+/// the SDK's own capture frames. Also returns the loaded modules referenced
+/// by the captured frames, for the `$debug_images` property.
+fn capture_raw_application_stack() -> (Vec<StackFrame>, Vec<DebugImage>) {
+    let modules = collect_loaded_modules();
+    let mut frames = capture_frames_current_first(0, &modules);
     while frames
         .first()
         .map(|frame| is_internal_capture_frame(&frame.function))
@@ -535,13 +750,31 @@ fn capture_raw_application_frames() -> Vec<StackFrame> {
     }
 
     frames.reverse();
-    frames
+
+    let images = referenced_images(modules, &frames);
+    (frames, images)
+}
+
+/// Only report modules that frames actually point into, and only those with a
+/// usable debug id; the final filtering against the trimmed frame list happens
+/// in finalize_exception.
+fn referenced_images(modules: Vec<LoadedModule>, frames: &[StackFrame]) -> Vec<DebugImage> {
+    modules
+        .into_iter()
+        .filter(|m| !m.image.debug_id.is_empty())
+        .map(|m| m.image)
+        .filter(|image| {
+            frames
+                .iter()
+                .any(|f| f.image_addr.as_deref() == Some(image.image_addr.as_str()))
+        })
+        .collect()
 }
 
 fn is_internal_capture_frame(function: &str) -> bool {
     function.starts_with("backtrace::")
         || function.contains("capture_frames_current_first")
-        || function.contains("capture_raw_application_frames")
+        || function.contains("capture_raw_application_stack")
         || function.contains("Exception::from_error")
         || function.contains("Exception::from_message")
         || function.contains("build_exception_event")
@@ -551,8 +784,10 @@ fn is_internal_capture_frame(function: &str) -> bool {
 
 /// Capture the panic stacktrace in wire order — outermost frame first, panic
 /// site last — dropping the panic machinery and the SDK's own hook frames.
-fn capture_raw_panic_frames() -> Vec<StackFrame> {
-    let mut frames = capture_frames_current_first(0);
+/// Also returns the loaded modules referenced by the captured frames.
+fn capture_raw_panic_frames() -> (Vec<StackFrame>, Vec<DebugImage>) {
+    let modules = collect_loaded_modules();
+    let mut frames = capture_frames_current_first(0, &modules);
     while frames
         .first()
         .map(|frame| is_internal_panic_frame(&frame.function))
@@ -562,7 +797,9 @@ fn capture_raw_panic_frames() -> Vec<StackFrame> {
     }
 
     frames.reverse();
-    frames
+
+    let images = referenced_images(modules, &frames);
+    (frames, images)
 }
 
 fn is_internal_panic_frame(function: &str) -> bool {
@@ -1010,9 +1247,14 @@ mod tests {
             .expect("expected stack frames");
         // Wire order is outermost first, crash/capture frame last
         let crash_frame = frames.last().expect("expected crash frame");
-        assert_eq!(crash_frame["platform"], "rust");
+        assert_eq!(crash_frame["platform"], "native");
         assert_eq!(crash_frame["lang"], "rust");
-        assert_eq!(crash_frame["resolved"], true);
+        let instruction_addr = crash_frame["instruction_addr"].as_str().unwrap_or_default();
+        assert!(
+            instruction_addr.starts_with("0x"),
+            "expected hex instruction_addr, got {:?}",
+            instruction_addr
+        );
         let crash_function = crash_frame["function"].as_str().unwrap_or_default();
         assert!(
             crash_function.contains("from_error_builds_exception_list_with_stacktrace"),
@@ -1174,9 +1416,117 @@ mod tests {
     }
 
     #[test]
+    fn gnu_build_ids_convert_to_debug_ids_like_the_server() {
+        // Vector verified against symbolic's ElfObject::debug_id (which the
+        // server and CLI use): the first 16 bytes as a little-endian GUID.
+        let build_id: Vec<u8> = (0..20)
+            .map(|i| {
+                u8::from_str_radix(
+                    &"555398ebd01c90285a3d85138a19cbf9bbcec352"[i * 2..i * 2 + 2],
+                    16,
+                )
+                .unwrap()
+            })
+            .collect();
+        assert_eq!(
+            debug_id_from_gnu_build_id(&build_id).as_deref(),
+            Some("eb985355-1cd0-2890-5a3d-85138a19cbf9")
+        );
+
+        // Short build ids are zero-padded to 16 bytes
+        assert_eq!(
+            debug_id_from_gnu_build_id(&[0xab, 0xcd]).as_deref(),
+            Some("0000cdab-0000-0000-0000-000000000000")
+        );
+        assert_eq!(debug_id_from_gnu_build_id(&[]), None);
+    }
+
+    #[test]
+    fn find_module_matches_address_ranges() {
+        let module_at = |base: u64, size: u64, is_main: bool| LoadedModule {
+            base,
+            end: base + size,
+            is_main,
+            image: DebugImage {
+                image_type: "elf".to_string(),
+                debug_id: "test".to_string(),
+                code_id: None,
+                image_addr: format!("0x{base:x}"),
+                image_size: Some(size),
+                image_vmaddr: None,
+                code_file: None,
+                arch: "x86_64".to_string(),
+            },
+        };
+
+        let modules = vec![
+            module_at(0x1000, 0x1000, true),
+            module_at(0x4000, 0x1000, false),
+        ];
+
+        assert!(find_module(&modules, 0x1500).is_some_and(|m| m.is_main));
+        assert!(find_module(&modules, 0x4000).is_some_and(|m| !m.is_main));
+        assert!(find_module(&modules, 0x2000).is_none()); // gap between modules
+        assert!(find_module(&modules, 0x500).is_none()); // before first module
+        assert!(find_module(&modules, 0x5000).is_none()); // past the last module
+    }
+
+    #[test]
+    fn captured_stacks_reference_loaded_debug_images() {
+        let json = finalized_json(
+            Exception::from_message("AddrCheck", "captures addresses").into_event_anon(),
+        );
+
+        let frames = json["properties"]["$exception_list"][0]["stacktrace"]["frames"]
+            .as_array()
+            .expect("expected stack frames");
+
+        // Every frame carries a parseable instruction address
+        for frame in frames {
+            let addr = frame["instruction_addr"].as_str().unwrap_or_default();
+            assert!(
+                addr.starts_with("0x") && u64::from_str_radix(&addr[2..], 16).is_ok(),
+                "expected hex instruction_addr, got {:?}",
+                frame["instruction_addr"]
+            );
+        }
+
+        // The test binary itself is a loaded module with a debug id on the
+        // platforms we capture modules on, so $debug_images must be present
+        // and every entry must be referenced by at least one frame.
+        let images = json["properties"]["$debug_images"]
+            .as_array()
+            .expect("expected $debug_images");
+        assert!(!images.is_empty());
+        let expected_type = super::native_image_type();
+        for image in images {
+            assert_eq!(image["type"].as_str(), Some(expected_type));
+            assert_eq!(
+                image["arch"].as_str(),
+                Some(std::env::consts::ARCH),
+                "arch should match the running process"
+            );
+            let debug_id = image["debug_id"].as_str().unwrap_or_default();
+            assert!(
+                debug_id.len() >= 36,
+                "expected uuid-shaped debug_id, got {:?}",
+                debug_id
+            );
+            let image_addr = image["image_addr"].as_str().unwrap_or_default();
+            assert!(
+                frames
+                    .iter()
+                    .any(|f| f["image_addr"].as_str() == Some(image_addr)),
+                "image {} not referenced by any frame",
+                image_addr
+            );
+        }
+    }
+
+    #[test]
     fn stacktrace_keeps_crash_frame_last() {
         fn capture() -> ExceptionStacktrace {
-            let mut frames = capture_raw_application_frames();
+            let (mut frames, _images) = capture_raw_application_stack();
             trim_to_max_frames(&mut frames, 8);
             ExceptionStacktrace::raw(frames)
         }

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1580,9 +1580,13 @@ mod tests {
         let expected_type = super::native_image_type();
         for image in images {
             assert_eq!(image["type"].as_str(), Some(expected_type));
+            let expected_arch = match std::env::consts::ARCH {
+                "aarch64" => "arm64",
+                arch => arch,
+            };
             assert_eq!(
                 image["arch"].as_str(),
-                Some(std::env::consts::ARCH),
+                Some(expected_arch),
                 "arch should match the running process"
             );
             let debug_id = image["debug_id"].as_str().unwrap_or_default();

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -665,6 +665,10 @@ fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<St
         let instruction_addr = frame.ip() as u64;
         let frame_symbol_addr = frame.symbol_address() as u64;
         let module = find_module(modules, instruction_addr);
+        // Only send addresses the server can actually resolve: without a
+        // module carrying a debug id there is no `$debug_images` entry to
+        // match, and the frame should pass through as purely client-resolved.
+        let resolvable = module.is_some_and(|m| !m.image.debug_id.is_empty());
 
         let mut pushed = false;
         backtrace::resolve_frame(frame, |symbol| {
@@ -699,9 +703,11 @@ fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<St
                 in_app: false,
                 synthetic: false,
                 platform: "native".to_string(),
-                instruction_addr: Some(format!("0x{instruction_addr:x}")),
-                symbol_addr: (symbol_addr != 0).then(|| format!("0x{symbol_addr:x}")),
-                image_addr: module.map(|m| m.image.image_addr.clone()),
+                instruction_addr: resolvable.then(|| format!("0x{instruction_addr:x}")),
+                symbol_addr: (resolvable && symbol_addr != 0).then(|| format!("0x{symbol_addr:x}")),
+                image_addr: resolvable
+                    .then(|| module.map(|m| m.image.image_addr.clone()))
+                    .flatten(),
             });
             pushed = true;
         });
@@ -719,9 +725,12 @@ fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<St
                 in_app: module.is_some_and(|m| m.is_main),
                 synthetic: false,
                 platform: "native".to_string(),
-                instruction_addr: Some(format!("0x{instruction_addr:x}")),
-                symbol_addr: (frame_symbol_addr != 0).then(|| format!("0x{frame_symbol_addr:x}")),
-                image_addr: module.map(|m| m.image.image_addr.clone()),
+                instruction_addr: resolvable.then(|| format!("0x{instruction_addr:x}")),
+                symbol_addr: (resolvable && frame_symbol_addr != 0)
+                    .then(|| format!("0x{frame_symbol_addr:x}")),
+                image_addr: resolvable
+                    .then(|| module.map(|m| m.image.image_addr.clone()))
+                    .flatten(),
             });
         }
 

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -525,8 +525,9 @@ const fn native_image_type() -> &'static str {
 
 /// Render 16 bytes laid out as a little-endian GUID (Microsoft convention:
 /// the first three fields are stored byte-swapped) as a canonical UUID
-/// string. This matches how symbolic's `DebugId` — used by the server and
-/// CLI — interprets GNU build ids and CodeView PDB signatures.
+/// string. The swap is unconditional — not gated on this target's endianness —
+/// because it must match the ids computed at upload time by symbolic running
+/// on PostHog's (little-endian) servers and the CLI.
 fn guid_le_to_uuid(mut data: [u8; 16]) -> String {
     data[0..4].reverse();
     data[4..6].reverse();
@@ -551,7 +552,11 @@ fn debug_id_for(id: &findshlibs::SharedLibraryId) -> Option<String> {
 
     match id {
         SharedLibraryId::GnuBuildId(bytes) => debug_id_from_gnu_build_id(bytes),
-        SharedLibraryId::Uuid(bytes) => Some(uuid::Uuid::from_bytes(*bytes).to_string()),
+        // Uppercase to match the chunk_ids stored by `posthog-cli dsym
+        // upload`, which takes them verbatim from dwarfdump output.
+        SharedLibraryId::Uuid(bytes) => {
+            Some(uuid::Uuid::from_bytes(*bytes).to_string().to_uppercase())
+        }
         SharedLibraryId::PdbSignature(guid, age) => {
             let uuid = guid_le_to_uuid(*guid);
             Some(if *age > 0 {
@@ -746,6 +751,12 @@ fn capture_raw_application_stack() -> (Vec<StackFrame>, Vec<DebugImage>) {
     // name-based check below has nothing to match. The unwinder's frames sit
     // inner-most (before ours), so dropping through the last match removes
     // them too.
+    //
+    // Platform caveat: entry addresses come from the unwinder
+    // (`_Unwind_FindEnclosingFunction` on Linux/glibc) or symbol tables. On
+    // fully stripped Apple/Windows builds neither is available and the
+    // captured stack keeps the SDK prefix as address-only frames; they regain
+    // names through server-side symbolication.
     let pinned_entries = [
         capture_frames_current_first as usize as u64,
         capture_raw_application_stack as usize as u64,

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -201,7 +201,9 @@ where
         level,
     } = options;
 
-    let mut exception = Exception::from_error(error);
+    // Pair error_items with from_items_captured directly so the capture
+    // happens one frame below this builder and its own frame gets stripped.
+    let mut exception = Exception::from_items_captured(error_items(error));
     if let Some(fingerprint) = fingerprint {
         exception.set_fingerprint(fingerprint);
     }
@@ -253,31 +255,29 @@ impl Exception {
     where
         E: StdError + ?Sized,
     {
-        let mut items = vec![ExceptionItem {
-            exception_type: simple_type_name(type_name::<E>()),
-            value: error_value(error),
+        Self::from_items_captured(error_items(error))
+    }
+
+    /// Build an exception from an arbitrary type/message pair, capturing the
+    /// current stacktrace.
+    // Only exercised by tests today; kept as the message-capture seam.
+    #[allow(dead_code)]
+    pub fn from_message<T: Into<String>, V: Into<String>>(exception_type: T, value: V) -> Self {
+        Self::from_items_captured(vec![ExceptionItem {
+            exception_type: exception_type.into(),
+            value: value.into(),
             mechanism: ExceptionMechanism::default(),
             stacktrace: None,
-        }];
+        }])
+    }
 
-        let mut source = error.source();
-        while let Some(err) = source {
-            // Hard safety bound for pathological/cyclic source chains; the
-            // client's max_error_sources is applied at capture time.
-            if items.len() >= DEFAULT_MAX_ERROR_SOURCES {
-                break;
-            }
-            items.push(ExceptionItem {
-                exception_type: source_type_name(err),
-                value: error_value(err),
-                mechanism: ExceptionMechanism::default(),
-                stacktrace: None,
-            });
-            source = err.source();
-        }
-
-        link_exception_chain(&mut items);
-
+    /// Monomorphic capture chokepoint for every API that captures the current
+    /// stacktrace. Its entry address is pinned by the SDK-frame stripping in
+    /// `capture_raw_application_stack`, which also drops the frame directly
+    /// above it — the (generic, otherwise unpinnable) constructor or client
+    /// convenience wrapper that called it.
+    #[inline(never)]
+    pub(crate) fn from_items_captured(items: Vec<ExceptionItem>) -> Self {
         let (frames, images) = capture_raw_application_stack();
         Self {
             items,
@@ -288,48 +288,21 @@ impl Exception {
         }
     }
 
-    /// Build an exception from an arbitrary type/message pair, capturing the
-    /// current stacktrace.
-    // Only exercised by tests today; kept as the message-capture seam.
-    #[allow(dead_code)]
-    pub fn from_message<T: Into<String>, V: Into<String>>(exception_type: T, value: V) -> Self {
-        let (frames, images) = capture_raw_application_stack();
-        Self {
-            items: vec![ExceptionItem {
-                exception_type: exception_type.into(),
-                value: value.into(),
-                mechanism: ExceptionMechanism::default(),
-                stacktrace: None,
-            }],
-            captured_frames: Some(frames),
-            captured_images: images,
-            fingerprint: None,
-            level: "error".to_string(),
-        }
-    }
-
     /// Build an exception from a panic, capturing the current stacktrace.
     #[allow(deprecated)]
     fn from_panic_info(panic_info: &panic::PanicInfo<'_>) -> Self {
-        let (frames, images) = capture_raw_panic_frames();
-        Self {
-            items: vec![ExceptionItem {
-                exception_type: "Panic".to_string(),
-                value: panic_message(panic_info),
-                mechanism: ExceptionMechanism {
-                    mechanism_type: "panic".to_string(),
-                    handled: false,
-                    synthetic: false,
-                    exception_id: None,
-                    parent_id: None,
-                },
-                stacktrace: None,
-            }],
-            captured_frames: Some(frames),
-            captured_images: images,
-            fingerprint: None,
-            level: "error".to_string(),
-        }
+        Self::from_items_captured(vec![ExceptionItem {
+            exception_type: "Panic".to_string(),
+            value: panic_message(panic_info),
+            mechanism: ExceptionMechanism {
+                mechanism_type: "panic".to_string(),
+                handled: false,
+                synthetic: false,
+                exception_id: None,
+                parent_id: None,
+            },
+            stacktrace: None,
+        }])
     }
 
     /// Set a custom exception fingerprint.
@@ -683,7 +656,7 @@ fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<St
         }
 
         let instruction_addr = frame.ip() as u64;
-        let symbol_addr = frame.symbol_address() as u64;
+        let frame_symbol_addr = frame.symbol_address() as u64;
         let module = find_module(modules, instruction_addr);
 
         let mut pushed = false;
@@ -700,6 +673,16 @@ fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<St
             if filename.is_none() && function.is_none() {
                 return;
             }
+
+            // The resolver's symbol.addr() is the actual symbol entry; the
+            // frame's symbol_address() can fall back to the instruction
+            // pointer on some platforms. The entry address is what the
+            // pinned-function stripping compares against.
+            let symbol_addr = symbol
+                .addr()
+                .map(|a| a as u64)
+                .filter(|a| *a != 0)
+                .unwrap_or(frame_symbol_addr);
 
             frames.push(StackFrame {
                 filename,
@@ -730,7 +713,7 @@ fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<St
                 synthetic: false,
                 platform: "native".to_string(),
                 instruction_addr: Some(format!("0x{instruction_addr:x}")),
-                symbol_addr: (symbol_addr != 0).then(|| format!("0x{symbol_addr:x}")),
+                symbol_addr: (frame_symbol_addr != 0).then(|| format!("0x{frame_symbol_addr:x}")),
                 image_addr: module.map(|m| m.image.image_addr.clone()),
             });
         }
@@ -766,6 +749,7 @@ fn capture_raw_application_stack() -> (Vec<StackFrame>, Vec<DebugImage>) {
     let pinned_entries = [
         capture_frames_current_first as usize as u64,
         capture_raw_application_stack as usize as u64,
+        Exception::from_items_captured as usize as u64,
     ];
     let scan = frames.len().min(16);
     let matches_pinned = |frame: &StackFrame| {
@@ -776,13 +760,14 @@ fn capture_raw_application_stack() -> (Vec<StackFrame>, Vec<DebugImage>) {
             .is_some_and(|addr| pinned_entries.contains(&addr))
     };
     if let Some(last_sdk) = frames[..scan].iter().rposition(matches_pinned) {
-        // Also drop the frame directly above the pinned capture function: it
-        // is always an `Exception` constructor, the only callers of
-        // capture_raw_application_stack. Higher SDK wrappers (e.g.
-        // Client::capture_error) are generic, so they can only be removed by
-        // the name-based pass below and remain in fully stripped builds.
-        let constructor = (last_sdk + 1).min(frames.len().saturating_sub(1));
-        frames.drain(..=constructor);
+        // Also drop the frame directly above the outermost pinned function:
+        // `from_items_captured` is only ever called by an `Exception`
+        // constructor or a client convenience wrapper, both generic and
+        // otherwise unpinnable. Deeper delegators (the `global::` one-liners)
+        // can only be removed by the name-based pass below, leaving at most
+        // one SDK frame in fully stripped builds.
+        let api_entry = (last_sdk + 1).min(frames.len().saturating_sub(1));
+        frames.drain(..=api_entry);
     }
 
     while frames
@@ -819,39 +804,17 @@ fn is_internal_capture_frame(function: &str) -> bool {
     function.starts_with("backtrace::")
         || function.contains("capture_frames_current_first")
         || function.contains("capture_raw_application_stack")
+        || function.contains("from_items_captured")
         || function.contains("Exception::from_error")
         || function.contains("Exception::from_message")
+        || function.contains("Exception::from_panic_info")
         || function.contains("build_exception_event")
         || function.contains("Client::capture_exception")
         || function.contains("global::capture_exception")
-}
-
-/// Capture the panic stacktrace in wire order — outermost frame first, panic
-/// site last — dropping the panic machinery and the SDK's own hook frames.
-/// Also returns the loaded modules referenced by the captured frames.
-fn capture_raw_panic_frames() -> (Vec<StackFrame>, Vec<DebugImage>) {
-    let modules = collect_loaded_modules();
-    let mut frames = capture_frames_current_first(0, &modules);
-    while frames
-        .first()
-        .map(|frame| is_internal_panic_frame(&frame.function))
-        .unwrap_or(false)
-    {
-        frames.remove(0);
-    }
-
-    frames.reverse();
-
-    let images = referenced_images(modules, &frames);
-    (frames, images)
-}
-
-fn is_internal_panic_frame(function: &str) -> bool {
-    is_internal_capture_frame(function)
+        // Panic-hook machinery: these sit between the hook closure and the
+        // panic site, so they form part of the strippable prefix.
         || function.contains("capture_panic")
-        || function.contains("capture_raw_panic_frames")
         || function.contains("install_panic_hook")
-        || function.contains("Exception::from_panic_info")
         || function.contains("AssertUnwindSafe")
         || function.starts_with("core::ops::function::FnOnce::call_once")
         || function.starts_with("std::panicking::")
@@ -998,6 +961,41 @@ where
     } else {
         value
     }
+}
+
+/// Build the normalized exception items for an error and its `source()`
+/// chain, without capturing a stacktrace. Client convenience wrappers pair
+/// this with [`Exception::from_items_captured`] directly so that the capture
+/// happens one frame below them and their own frame gets stripped.
+pub(crate) fn error_items<E>(error: &E) -> Vec<ExceptionItem>
+where
+    E: StdError + ?Sized,
+{
+    let mut items = vec![ExceptionItem {
+        exception_type: simple_type_name(type_name::<E>()),
+        value: error_value(error),
+        mechanism: ExceptionMechanism::default(),
+        stacktrace: None,
+    }];
+
+    let mut source = error.source();
+    while let Some(err) = source {
+        // Hard safety bound for pathological/cyclic source chains; the
+        // client's max_error_sources is applied at capture time.
+        if items.len() >= DEFAULT_MAX_ERROR_SOURCES {
+            break;
+        }
+        items.push(ExceptionItem {
+            exception_type: source_type_name(err),
+            value: error_value(err),
+            mechanism: ExceptionMechanism::default(),
+            stacktrace: None,
+        });
+        source = err.source();
+    }
+
+    link_exception_chain(&mut items);
+    items
 }
 
 fn normalize_function_name(function: &str) -> String {

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -567,23 +567,19 @@ fn debug_id_from_gnu_build_id(build_id: &[u8]) -> Option<String> {
     Some(uuid::Uuid::from_bytes(data).to_string())
 }
 
-fn debug_id_for(id: &findshlibs::SharedLibraryId) -> Option<(String, Option<String>)> {
+fn debug_id_for(id: &findshlibs::SharedLibraryId) -> Option<String> {
     use findshlibs::SharedLibraryId;
 
     match id {
-        SharedLibraryId::GnuBuildId(bytes) => {
-            let code_id = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
-            debug_id_from_gnu_build_id(bytes).map(|debug_id| (debug_id, Some(code_id)))
-        }
-        SharedLibraryId::Uuid(bytes) => Some((uuid::Uuid::from_bytes(*bytes).to_string(), None)),
+        SharedLibraryId::GnuBuildId(bytes) => debug_id_from_gnu_build_id(bytes),
+        SharedLibraryId::Uuid(bytes) => Some(uuid::Uuid::from_bytes(*bytes).to_string()),
         SharedLibraryId::PdbSignature(guid, age) => {
             let uuid = uuid::Uuid::from_bytes(*guid).to_string();
-            let debug_id = if *age > 0 {
+            Some(if *age > 0 {
                 format!("{uuid}-{age:x}")
             } else {
                 uuid
-            };
-            Some((debug_id, None))
+            })
         }
         // PE timestamp/size signatures carry no debug id we can match symbols to.
         _ => None,
@@ -617,10 +613,19 @@ fn collect_loaded_modules() -> Vec<LoadedModule> {
             Some(name)
         };
 
-        let ids = shlib.id().as_ref().and_then(debug_id_for);
-        let (debug_id, code_id) = match ids {
-            Some((debug_id, code_id)) => (debug_id, code_id),
-            None => (String::new(), None),
+        // debug_id() (PDB GUID+age on Windows, same as id() elsewhere) is the
+        // identifier that matches uploaded symbols; id() supplies the full
+        // code identifier (e.g. complete GNU build id).
+        let debug_id = shlib
+            .debug_id()
+            .as_ref()
+            .and_then(debug_id_for)
+            .unwrap_or_default();
+        let code_id = match shlib.id() {
+            Some(findshlibs::SharedLibraryId::GnuBuildId(bytes)) => {
+                Some(bytes.iter().map(|b| format!("{b:02x}")).collect::<String>())
+            }
+            _ => None,
         };
 
         modules.push(LoadedModule {
@@ -657,6 +662,10 @@ fn find_module(modules: &[LoadedModule], addr: u64) -> Option<&LoadedModule> {
 // at capture time by finalize_exception. Every frame carries its instruction
 // address; function/file/line enrichment is best-effort and missing entirely
 // in stripped release builds.
+//
+// inline(never): the entry address of this function identifies the SDK's own
+// frames for address-based stripping, which must survive symbol-less builds.
+#[inline(never)]
 fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<StackFrame> {
     let mut frames = Vec::new();
     let mut skipped = 0usize;
@@ -738,9 +747,32 @@ fn trim_to_max_frames(frames: &mut Vec<StackFrame>, max_frames: usize) {
 /// crash/capture-site frame last, matching the other PostHog SDKs — dropping
 /// the SDK's own capture frames. Also returns the loaded modules referenced
 /// by the captured frames, for the `$debug_images` property.
+#[inline(never)]
 fn capture_raw_application_stack() -> (Vec<StackFrame>, Vec<DebugImage>) {
     let modules = collect_loaded_modules();
     let mut frames = capture_frames_current_first(0, &modules);
+
+    // Address-based stripping first: identify the SDK's own capture frames by
+    // function entry address, which works even in stripped builds where the
+    // name-based check below has nothing to match. The unwinder's frames sit
+    // inner-most (before ours), so dropping through the last match removes
+    // them too.
+    let pinned_entries = [
+        capture_frames_current_first as usize as u64,
+        capture_raw_application_stack as usize as u64,
+    ];
+    let scan = frames.len().min(16);
+    let matches_pinned = |frame: &StackFrame| {
+        frame
+            .symbol_addr
+            .as_deref()
+            .and_then(|addr| u64::from_str_radix(addr.trim_start_matches("0x"), 16).ok())
+            .is_some_and(|addr| pinned_entries.contains(&addr))
+    };
+    if let Some(last_sdk) = frames[..scan].iter().rposition(matches_pinned) {
+        frames.drain(..=last_sdk);
+    }
+
     while frames
         .first()
         .map(|frame| is_internal_capture_frame(&frame.function))

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -550,10 +550,19 @@ const fn native_image_type() -> &'static str {
     }
 }
 
-/// Derive a debug id from a GNU build id, matching how the server and CLI
-/// derive it from the binary: the first 16 bytes interpreted as a
-/// little-endian GUID (first three fields byte-swapped), zero-padded when the
-/// build id is shorter.
+/// Render 16 bytes laid out as a little-endian GUID (Microsoft convention:
+/// the first three fields are stored byte-swapped) as a canonical UUID
+/// string. This matches how symbolic's `DebugId` — used by the server and
+/// CLI — interprets GNU build ids and CodeView PDB signatures.
+fn guid_le_to_uuid(mut data: [u8; 16]) -> String {
+    data[0..4].reverse();
+    data[4..6].reverse();
+    data[6..8].reverse();
+    uuid::Uuid::from_bytes(data).to_string()
+}
+
+/// Derive a debug id from a GNU build id: the first 16 bytes as a
+/// little-endian GUID, zero-padded when the build id is shorter.
 fn debug_id_from_gnu_build_id(build_id: &[u8]) -> Option<String> {
     if build_id.is_empty() {
         return None;
@@ -561,10 +570,7 @@ fn debug_id_from_gnu_build_id(build_id: &[u8]) -> Option<String> {
     let mut data = [0u8; 16];
     let len = build_id.len().min(16);
     data[..len].copy_from_slice(&build_id[..len]);
-    data[0..4].reverse();
-    data[4..6].reverse();
-    data[6..8].reverse();
-    Some(uuid::Uuid::from_bytes(data).to_string())
+    Some(guid_le_to_uuid(data))
 }
 
 fn debug_id_for(id: &findshlibs::SharedLibraryId) -> Option<String> {
@@ -574,7 +580,7 @@ fn debug_id_for(id: &findshlibs::SharedLibraryId) -> Option<String> {
         SharedLibraryId::GnuBuildId(bytes) => debug_id_from_gnu_build_id(bytes),
         SharedLibraryId::Uuid(bytes) => Some(uuid::Uuid::from_bytes(*bytes).to_string()),
         SharedLibraryId::PdbSignature(guid, age) => {
-            let uuid = uuid::Uuid::from_bytes(*guid).to_string();
+            let uuid = guid_le_to_uuid(*guid);
             Some(if *age > 0 {
                 format!("{uuid}-{age:x}")
             } else {
@@ -770,7 +776,13 @@ fn capture_raw_application_stack() -> (Vec<StackFrame>, Vec<DebugImage>) {
             .is_some_and(|addr| pinned_entries.contains(&addr))
     };
     if let Some(last_sdk) = frames[..scan].iter().rposition(matches_pinned) {
-        frames.drain(..=last_sdk);
+        // Also drop the frame directly above the pinned capture function: it
+        // is always an `Exception` constructor, the only callers of
+        // capture_raw_application_stack. Higher SDK wrappers (e.g.
+        // Client::capture_error) are generic, so they can only be removed by
+        // the name-based pass below and remain in fully stripped builds.
+        let constructor = (last_sdk + 1).min(frames.len().saturating_sub(1));
+        frames.drain(..=constructor);
     }
 
     while frames
@@ -1557,13 +1569,16 @@ mod tests {
 
     #[test]
     fn stacktrace_keeps_crash_frame_last() {
-        fn capture() -> ExceptionStacktrace {
-            let (mut frames, _images) = capture_raw_application_stack();
-            trim_to_max_frames(&mut frames, 8);
-            ExceptionStacktrace::raw(frames)
+        // Use the real constructor path: capture_raw_application_stack drops
+        // its direct caller as the constructor frame, so calling it from
+        // anywhere else would eat an application frame.
+        #[inline(never)]
+        fn user_capture_site() -> Exception {
+            Exception::from_message("Ordering", "wire order check")
         }
 
-        let frames = capture().frames;
+        let exception = user_capture_site();
+        let frames = exception.captured_frames.expect("expected captured frames");
         let functions: Vec<&str> = frames
             .iter()
             .map(|frame| frame.function.as_str())
@@ -1572,8 +1587,10 @@ mod tests {
 
         let capture_index = functions
             .iter()
-            .position(|function| function.contains("stacktrace_keeps_crash_frame_last::capture"))
-            .expect("expected capture frame");
+            .position(|function| {
+                function.contains("stacktrace_keeps_crash_frame_last::user_capture_site")
+            })
+            .expect("expected capture-site frame");
         let test_index = functions
             .iter()
             .position(|function| function.ends_with("stacktrace_keeps_crash_frame_last"))

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -186,6 +186,9 @@ impl CaptureExceptionOptions {
 }
 
 /// Build a `$exception` [`Event`] from a Rust error and capture options.
+// inline(never): direct callers of from_items_captured must stay physical
+// frames — see the contract on from_items_captured.
+#[inline(never)]
 pub(crate) fn build_exception_event<E>(
     error: &E,
     options: CaptureExceptionOptions,
@@ -252,7 +255,10 @@ impl Exception {
     /// Build an exception from an arbitrary type/message pair, capturing the
     /// current stacktrace.
     // Only exercised by tests today; kept as the message-capture seam.
+    // inline(never): direct callers of from_items_captured must stay physical
+    // frames — see the contract on from_items_captured.
     #[allow(dead_code)]
+    #[inline(never)]
     pub fn from_message<T: Into<String>, V: Into<String>>(exception_type: T, value: V) -> Self {
         Self::from_items_captured(vec![ExceptionItem {
             exception_type: exception_type.into(),
@@ -265,8 +271,12 @@ impl Exception {
     /// Monomorphic capture chokepoint for every API that captures the current
     /// stacktrace. Its entry address is pinned by the SDK-frame stripping in
     /// `capture_raw_application_stack`, which also drops the frame directly
-    /// above it — the (generic, otherwise unpinnable) constructor or client
-    /// convenience wrapper that called it.
+    /// above it — the (generic, otherwise unpinnable) constructor or wrapper
+    /// that called it.
+    ///
+    /// Contract: every direct caller must be `#[inline(never)]`, otherwise the
+    /// caller can inline into application code and the dropped frame would be
+    /// the user's own.
     #[inline(never)]
     pub(crate) fn from_items_captured(items: Vec<ExceptionItem>) -> Self {
         let (frames, images) = capture_raw_application_stack();
@@ -281,6 +291,7 @@ impl Exception {
 
     /// Build an exception from a panic, capturing the current stacktrace.
     #[allow(deprecated)]
+    #[inline(never)]
     fn from_panic_info(panic_info: &panic::PanicInfo<'_>) -> Self {
         Self::from_items_captured(vec![ExceptionItem {
             exception_type: "Panic".to_string(),
@@ -743,11 +754,14 @@ fn capture_raw_application_stack() -> (Vec<StackFrame>, Vec<DebugImage>) {
     // inner-most (before ours), so dropping through the last match removes
     // them too.
     //
-    // Platform caveat: entry addresses come from the unwinder
-    // (`_Unwind_FindEnclosingFunction` on Linux/glibc) or symbol tables. On
-    // fully stripped Apple/Windows builds neither is available and the
-    // captured stack keeps the SDK prefix as address-only frames; they regain
-    // names through server-side symbolication.
+    // Platform caveat: this only works where the frame's symbol address is
+    // the runtime function entry (Linux/glibc via
+    // `_Unwind_FindEnclosingFunction`). On macOS the symbolization backend
+    // reports the queried address rather than the function entry, so the
+    // address pass never matches there and the name-based pass below does the
+    // stripping instead; fully stripped Apple/Windows builds keep the SDK
+    // prefix as address-only frames, which regain names through server-side
+    // symbolication.
     let pinned_entries = [
         capture_frames_current_first as usize as u64,
         capture_raw_application_stack as usize as u64,
@@ -1114,6 +1128,14 @@ mod tests {
         finalized_json(exception.into_event_anon())
     }
 
+    // Pinned like the production wrappers (the address pass drops it as the
+    // chokepoint's caller where that works), and named so the name-based pass
+    // strips it on every other platform.
+    #[inline(never)]
+    fn from_items_captured_test_entry<E: StdError + ?Sized>(error: &E) -> Exception {
+        Exception::from_items_captured(error_items(error))
+    }
+
     #[allow(deprecated)]
     type PanicHook = Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static>;
 
@@ -1263,9 +1285,7 @@ mod tests {
     #[test]
     fn from_error_builds_exception_list_with_stacktrace() {
         let error = OuterError { source: InnerError };
-        let json = finalized_json(
-            Exception::from_items_captured(error_items(&error)).into_event("user-1"),
-        );
+        let json = finalized_json(from_items_captured_test_entry(&error).into_event("user-1"));
 
         assert_eq!(json["event"], "$exception");
         assert_eq!(json["distinct_id"], "user-1");
@@ -1317,7 +1337,7 @@ mod tests {
     fn from_error_accepts_borrowed_error_types() {
         let message = String::from("borrowed parse failure");
         let error = BorrowedError(&message);
-        let json = event_json(Exception::from_items_captured(error_items(&error)));
+        let json = event_json(from_items_captured_test_entry(&error));
 
         assert_eq!(
             json["properties"]["$exception_list"][0]["value"],
@@ -1355,7 +1375,7 @@ mod tests {
             .build()
             .unwrap();
         let error = OuterError { source: InnerError };
-        let mut event = Exception::from_items_captured(error_items(&error)).into_event_anon();
+        let mut event = from_items_captured_test_entry(&error).into_event_anon();
         let json = finalized_json_with(&mut event, &options);
 
         let exception_list = json["properties"]["$exception_list"].as_array().unwrap();

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -249,15 +249,6 @@ pub struct Exception {
 }
 
 impl Exception {
-    /// Build an exception from a Rust error, capturing the current stacktrace
-    /// and walking the `source()` chain.
-    pub fn from_error<E>(error: &E) -> Self
-    where
-        E: StdError + ?Sized,
-    {
-        Self::from_items_captured(error_items(error))
-    }
-
     /// Build an exception from an arbitrary type/message pair, capturing the
     /// current stacktrace.
     // Only exercised by tests today; kept as the message-capture seam.
@@ -816,7 +807,6 @@ fn is_internal_capture_frame(function: &str) -> bool {
         || function.contains("capture_frames_current_first")
         || function.contains("capture_raw_application_stack")
         || function.contains("from_items_captured")
-        || function.contains("Exception::from_error")
         || function.contains("Exception::from_message")
         || function.contains("Exception::from_panic_info")
         || function.contains("build_exception_event")
@@ -1273,7 +1263,9 @@ mod tests {
     #[test]
     fn from_error_builds_exception_list_with_stacktrace() {
         let error = OuterError { source: InnerError };
-        let json = finalized_json(Exception::from_error(&error).into_event("user-1"));
+        let json = finalized_json(
+            Exception::from_items_captured(error_items(&error)).into_event("user-1"),
+        );
 
         assert_eq!(json["event"], "$exception");
         assert_eq!(json["distinct_id"], "user-1");
@@ -1325,7 +1317,7 @@ mod tests {
     fn from_error_accepts_borrowed_error_types() {
         let message = String::from("borrowed parse failure");
         let error = BorrowedError(&message);
-        let json = event_json(Exception::from_error(&error));
+        let json = event_json(Exception::from_items_captured(error_items(&error)));
 
         assert_eq!(
             json["properties"]["$exception_list"][0]["value"],
@@ -1363,7 +1355,7 @@ mod tests {
             .build()
             .unwrap();
         let error = OuterError { source: InnerError };
-        let mut event = Exception::from_error(&error).into_event_anon();
+        let mut event = Exception::from_items_captured(error_items(&error)).into_event_anon();
         let json = finalized_json_with(&mut event, &options);
 
         let exception_list = json["properties"]["$exception_list"].as_array().unwrap();

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -626,7 +626,12 @@ fn collect_loaded_modules() -> Vec<LoadedModule> {
                 image_size: Some(size),
                 image_vmaddr: Some(format!("0x{:x}", shlib.stated_load_addr().0 as u64)),
                 code_file,
-                arch: std::env::consts::ARCH.to_string(),
+                // Align with the arch vocabulary used by other native SDKs
+                // (informational; image matching is by debug_id and address)
+                arch: match std::env::consts::ARCH {
+                    "aarch64" => "arm64".to_string(),
+                    arch => arch.to_string(),
+                },
             },
         });
 

--- a/tests/test_error_tracking.rs
+++ b/tests/test_error_tracking.rs
@@ -98,7 +98,7 @@ mod blocking {
                 .body_contains(r#""$process_person_profile":false"#)
                 .body_contains(r#""$exception_level":"error""#)
                 .body_contains(r#""value":"payment failed""#)
-                .body_contains(r#""platform":"rust""#)
+                .body_contains(r#""platform":"native""#)
                 .body_contains(r#""lang":"rust""#)
                 .matches(request_has_capture_exception_user_frame_last);
             then.status(200);
@@ -213,7 +213,7 @@ mod async_client {
                 .body_contains(r#""$process_person_profile":false"#)
                 .body_contains(r#""$exception_level":"error""#)
                 .body_contains(r#""value":"payment failed""#)
-                .body_contains(r#""platform":"rust""#)
+                .body_contains(r#""platform":"native""#)
                 .body_contains(r#""lang":"rust""#)
                 .matches(request_has_capture_exception_user_frame_last);
             then.status(200);


### PR DESCRIPTION
## :bulb: Motivation and Context

Production Rust builds strip debug info, so client-side `backtrace` resolution yields empty or mangled frames. This makes the SDK emit what PostHog's server-side native symbolication needs (mirroring the iOS SDK contract): raw `instruction_addr`/`symbol_addr`/`image_addr` per frame under `platform: "native"`, plus an event-level `$debug_images` list (debug id, load address, size, code file, arch) built from the modules loaded in the process. Debug symbols are uploaded separately via `posthog-cli debug-symbols upload` (ELF) or `dsym upload` (macOS).

Client-side enrichment (`function`/`filename`/`lineno`) still rides along as the fallback for un-uploaded symbols. Second of two stacked PRs (on the frame-order fix).

Key mechanics:

- Module enumeration via `findshlibs` (one pass per capture, no file IO): GNU build ids → debug ids using the same little-endian GUID interpretation as `symbolic` on the upload side (vector-pinned in tests, deliberately not gated on target endianness since the upload pipeline computes ids on little-endian hosts); Mach-O `LC_UUID` uppercased to match `dsym upload` chunk ids; PDB GUID+age handled for the future Windows path.
- Address-only frames (stripped builds) default `in_app` by module: main executable yes, shared libraries no; named frames keep the existing path/function rules.
- SDK-frame stripping no longer depends on symbol names: capture flows through a monomorphic `#[inline(never)]` chokepoint (`Exception::from_items_captured`) whose entry address is compared against frame symbol addresses; the frame directly above it (constructor or client wrapper, both generic) is dropped with it. Documented caveat: fully stripped Apple/Windows builds can't resolve entry addresses (no `_Unwind_FindEnclosingFunction`), so the SDK prefix survives there as address-only frames — within the agreed v1 platform scope (Linux is the fully-supported target).
- `$debug_images` is filtered to images referenced by frames that survive `max_frames` trimming.
- `StackFrame` drops the `resolved` field and gains the address fields — a breaking shape change to a struct only exposed on the unreleased `error-tracking` feature branch; no published version carries it.

## :green_heart: How did you test it?

Agent-authored (Claude Code, directed by @cat-ph); automated tests only:

- New tests: build-id → debug-id conversion vectors (verified against `symbolic`'s output for the cymbal test fixtures), module range matching, and a self-referential capture test asserting every frame has a parseable address, `$debug_images` is present with the right `type`/`arch`, and every image is referenced by a frame.
- Full gate on both feature sets: `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (202 + 204 passed).
- Three second-model review rounds drove real fixes (PDB `debug_id()` accessor + GUID byte-swap, symbol-entry vs ip addresses, wrapper-frame stripping); the two remaining findings were rejected with rationale documented in code comments (Apple/Windows stripped-build stripping is v1-out-of-scope; endianness gating would mismatch our little-endian upload pipeline).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file — covered by the branch's existing `rust-error-tracking` changeset; extends unreleased behavior.

