### PR TITLE
feat: add before_send hooks

### DIFF
--- a/.sampo/changesets/stalwart-forgemaster-aino.md
+++ b/.sampo/changesets/stalwart-forgemaster-aino.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Add before_send hooks for mutating or dropping events before capture.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -21,12 +21,14 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{event::InnerEvent, Error, Event};
 
+#[cfg(feature = "capture-v1")]
+use super::common::apply_capture_defaults;
 use super::common::{
     already_reported, apply_before_send_hooks, build_dedup_key, extract_flag_details,
     flag_called_event, flag_event_dedup_cache, local_record, remote_record_from_detail,
     DetailedFlagsResponse, FlagEventDedupCache,
 };
-use super::ClientOptions;
+use super::{BeforeSendHook, ClientOptions};
 
 async fn check_response(response: reqwest::Response) -> Result<(), Error> {
     let status = response.status().as_u16();
@@ -61,7 +63,7 @@ struct AsyncFlagEventHost {
     disabled: bool,
     disable_geoip: bool,
     is_server: bool,
-    before_send: Vec<super::BeforeSendHook>,
+    before_send: Vec<BeforeSendHook>,
     dedup_cache: FlagEventDedupCache,
     /// Tokio runtime handle captured at host construction (which always runs
     /// inside the runtime that hosts `evaluate_flags`). This lets snapshot
@@ -231,6 +233,9 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
+            let mut event = event;
+            let defaults = self.options.capture_defaults();
+            apply_capture_defaults(&mut event, &defaults);
             let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
                 return Ok(());
             };
@@ -265,9 +270,13 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
+            let defaults = self.options.capture_defaults();
             let events: Vec<_> = events
                 .into_iter()
-                .filter_map(|event| apply_before_send_hooks(&self.options.before_send, event))
+                .filter_map(|mut event| {
+                    apply_capture_defaults(&mut event, &defaults);
+                    apply_before_send_hooks(&self.options.before_send, event)
+                })
                 .collect();
             if events.is_empty() {
                 return Ok(());

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -22,9 +22,9 @@ use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig,
 use crate::{event::InnerEvent, Error, Event};
 
 use super::common::{
-    already_reported, build_dedup_key, extract_flag_details, flag_called_event,
-    flag_event_dedup_cache, local_record, remote_record_from_detail, DetailedFlagsResponse,
-    FlagEventDedupCache,
+    already_reported, apply_before_send_hooks, build_dedup_key, extract_flag_details,
+    flag_called_event, flag_event_dedup_cache, local_record, remote_record_from_detail,
+    DetailedFlagsResponse, FlagEventDedupCache,
 };
 use super::ClientOptions;
 
@@ -61,6 +61,7 @@ struct AsyncFlagEventHost {
     disabled: bool,
     disable_geoip: bool,
     is_server: bool,
+    before_send: Vec<super::BeforeSendHook>,
     dedup_cache: FlagEventDedupCache,
     /// Tokio runtime handle captured at host construction (which always runs
     /// inside the runtime that hosts `evaluate_flags`). This lets snapshot
@@ -80,6 +81,7 @@ impl AsyncFlagEventHost {
             disabled: options.is_disabled(),
             disable_geoip: options.disable_geoip,
             is_server: options.is_server,
+            before_send: options.before_send.clone(),
             dedup_cache: flag_event_dedup_cache(),
             runtime: tokio::runtime::Handle::current(),
         }
@@ -90,6 +92,9 @@ impl AsyncFlagEventHost {
             return;
         }
         event.prepare_for_v0();
+        let Some(event) = apply_before_send_hooks(&self.before_send, event) else {
+            return;
+        };
         let inner_event = InnerEvent::new(event, self.api_key.clone());
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
@@ -226,6 +231,9 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
+            let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
+                return Ok(());
+            };
             return self.capture_v1(vec![event], false).await.map(|_| ());
         }
 
@@ -257,6 +265,13 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
+            let events: Vec<_> = events
+                .into_iter()
+                .filter_map(|event| apply_before_send_hooks(&self.options.before_send, event))
+                .collect();
+            if events.is_empty() {
+                return Ok(());
+            }
             return self
                 .capture_v1(events, historical_migration)
                 .await
@@ -271,6 +286,9 @@ impl Client {
     async fn capture_v0(&self, mut event: Event) -> Result<(), Error> {
         let defaults = self.options.capture_defaults();
         super::v0_capture::prepare_event(&mut event, &defaults);
+        let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
+            return Ok(());
+        };
         let payload =
             super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
         let url = self.options.endpoints().build_url(Endpoint::Capture);
@@ -285,12 +303,16 @@ impl Client {
         historical_migration: bool,
     ) -> Result<(), Error> {
         let defaults = self.options.capture_defaults();
-        let payload = super::v0_capture::build_batch_payload(
+        let Some(payload) = super::v0_capture::build_batch_payload(
             events,
             self.options.api_key.clone(),
             historical_migration,
             &defaults,
-        )?;
+            &self.options.before_send,
+        )?
+        else {
+            return Ok(());
+        };
         let url = self.options.endpoints().build_url(Endpoint::Batch);
         let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
         self.send_v0_with_retry(&url, body, encoding).await

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -21,12 +21,14 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{event::InnerEvent, Error, Event};
 
+#[cfg(feature = "capture-v1")]
+use super::common::apply_capture_defaults;
 use super::common::{
     already_reported, apply_before_send_hooks, build_dedup_key, extract_flag_details,
     flag_called_event, flag_event_dedup_cache, local_record, remote_record_from_detail,
     DetailedFlagsResponse, FlagEventDedupCache,
 };
-use super::ClientOptions;
+use super::{BeforeSendHook, ClientOptions};
 
 fn check_response(response: reqwest::blocking::Response) -> Result<(), Error> {
     let status = response.status().as_u16();
@@ -60,7 +62,7 @@ struct BlockingFlagEventHost {
     disabled: bool,
     disable_geoip: bool,
     is_server: bool,
-    before_send: Vec<super::BeforeSendHook>,
+    before_send: Vec<BeforeSendHook>,
     dedup_cache: FlagEventDedupCache,
 }
 
@@ -215,6 +217,9 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
+            let mut event = event;
+            let defaults = self.options.capture_defaults();
+            apply_capture_defaults(&mut event, &defaults);
             let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
                 return Ok(());
             };
@@ -251,9 +256,13 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
+            let defaults = self.options.capture_defaults();
             let events: Vec<_> = events
                 .into_iter()
-                .filter_map(|event| apply_before_send_hooks(&self.options.before_send, event))
+                .filter_map(|mut event| {
+                    apply_capture_defaults(&mut event, &defaults);
+                    apply_before_send_hooks(&self.options.before_send, event)
+                })
                 .collect();
             if events.is_empty() {
                 return Ok(());

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -22,9 +22,9 @@ use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, Loca
 use crate::{event::InnerEvent, Error, Event};
 
 use super::common::{
-    already_reported, build_dedup_key, extract_flag_details, flag_called_event,
-    flag_event_dedup_cache, local_record, remote_record_from_detail, DetailedFlagsResponse,
-    FlagEventDedupCache,
+    already_reported, apply_before_send_hooks, build_dedup_key, extract_flag_details,
+    flag_called_event, flag_event_dedup_cache, local_record, remote_record_from_detail,
+    DetailedFlagsResponse, FlagEventDedupCache,
 };
 use super::ClientOptions;
 
@@ -60,6 +60,7 @@ struct BlockingFlagEventHost {
     disabled: bool,
     disable_geoip: bool,
     is_server: bool,
+    before_send: Vec<super::BeforeSendHook>,
     dedup_cache: FlagEventDedupCache,
 }
 
@@ -72,6 +73,7 @@ impl BlockingFlagEventHost {
             disabled: options.is_disabled(),
             disable_geoip: options.disable_geoip,
             is_server: options.is_server,
+            before_send: options.before_send.clone(),
             dedup_cache: flag_event_dedup_cache(),
         }
     }
@@ -81,6 +83,9 @@ impl BlockingFlagEventHost {
             return;
         }
         event.prepare_for_v0();
+        let Some(event) = apply_before_send_hooks(&self.before_send, event) else {
+            return;
+        };
         let inner_event = InnerEvent::new(event, self.api_key.clone());
         let payload = match serde_json::to_string(&inner_event) {
             Ok(p) => p,
@@ -210,6 +215,9 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
+            let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
+                return Ok(());
+            };
             return self.capture_v1(vec![event], false).map(|_| ());
         }
 
@@ -243,6 +251,13 @@ impl Client {
 
         #[cfg(feature = "capture-v1")]
         {
+            let events: Vec<_> = events
+                .into_iter()
+                .filter_map(|event| apply_before_send_hooks(&self.options.before_send, event))
+                .collect();
+            if events.is_empty() {
+                return Ok(());
+            }
             return self.capture_v1(events, historical_migration).map(|_| ());
         }
 
@@ -254,6 +269,9 @@ impl Client {
     fn capture_v0(&self, mut event: Event) -> Result<(), Error> {
         let defaults = self.options.capture_defaults();
         super::v0_capture::prepare_event(&mut event, &defaults);
+        let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
+            return Ok(());
+        };
         let payload =
             super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
         let url = self.options.endpoints().build_url(Endpoint::Capture);
@@ -268,12 +286,16 @@ impl Client {
         historical_migration: bool,
     ) -> Result<(), Error> {
         let defaults = self.options.capture_defaults();
-        let payload = super::v0_capture::build_batch_payload(
+        let Some(payload) = super::v0_capture::build_batch_payload(
             events,
             self.options.api_key.clone(),
             historical_migration,
             &defaults,
-        )?;
+            &self.options.before_send,
+        )?
+        else {
+            return Ok(());
+        };
         let url = self.options.endpoints().build_url(Endpoint::Batch);
         let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
         self.send_v0_with_retry(&url, body, encoding)

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
+use crate::client::BeforeSendHook;
 use crate::feature_flag_evaluations::{EvaluatedFlagRecord, FlagCalledEventParams};
 use crate::feature_flags::{FeatureFlagsResponse, FlagDetail, FlagMetadata, FlagValue};
 use crate::Event;
+use tracing::error;
 
 /// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
 /// dedup cache. On overflow the entire map is reset (matches the JS SDK).
@@ -13,6 +15,24 @@ pub(super) type FlagEventDedupCache = Mutex<HashMap<String, HashSet<String>>>;
 
 pub(super) fn flag_event_dedup_cache() -> FlagEventDedupCache {
     Mutex::new(HashMap::new())
+}
+
+pub(super) fn apply_before_send_hooks(hooks: &[BeforeSendHook], event: Event) -> Option<Event> {
+    let mut current = Some(event);
+
+    for hook in hooks {
+        let event = current.take().expect("event is present between hooks");
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| hook.apply(event))) {
+            Ok(Some(next)) => current = Some(next),
+            Ok(None) => return None,
+            Err(_) => {
+                error!("panic in PostHog before_send hook; dropping event");
+                return None;
+            }
+        }
+    }
+
+    current
 }
 
 /// Returns `true` when the helper has already shipped this
@@ -294,5 +314,45 @@ mod tests {
 
         assert_eq!(event.properties().get("$is_server"), Some(&json!(true)));
         assert_eq!(event.properties().get("$geoip_disable"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn before_send_hooks_mutate_and_drop_events() {
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("test-key".to_string())
+            .before_send(|mut event| {
+                event.insert_prop("from_hook", true).unwrap();
+                Some(event)
+            })
+            .before_send(|event| {
+                if event.event_name() == "drop" {
+                    None
+                } else {
+                    Some(event)
+                }
+            })
+            .build()
+            .unwrap();
+
+        let event = apply_before_send_hooks(&options.before_send, Event::new("keep", "user-1"))
+            .expect("event should be kept");
+        assert_eq!(event.properties().get("from_hook"), Some(&json!(true)));
+
+        assert!(
+            apply_before_send_hooks(&options.before_send, Event::new("drop", "user-1")).is_none()
+        );
+    }
+
+    #[test]
+    fn before_send_hook_panic_drops_event() {
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("test-key".to_string())
+            .before_send(|_event| panic!("boom"))
+            .build()
+            .unwrap();
+
+        assert!(
+            apply_before_send_hooks(&options.before_send, Event::new("test", "user-1")).is_none()
+        );
     }
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
 use crate::client::BeforeSendHook;
+use crate::client::CaptureDefaults;
 use crate::feature_flag_evaluations::{EvaluatedFlagRecord, FlagCalledEventParams};
 use crate::feature_flags::{FeatureFlagsResponse, FlagDetail, FlagMetadata, FlagValue};
 use crate::Event;
@@ -15,6 +16,15 @@ pub(super) type FlagEventDedupCache = Mutex<HashMap<String, HashSet<String>>>;
 
 pub(super) fn flag_event_dedup_cache() -> FlagEventDedupCache {
     Mutex::new(HashMap::new())
+}
+
+pub(super) fn apply_capture_defaults(event: &mut Event, defaults: &CaptureDefaults) {
+    if defaults.disable_geoip {
+        event.insert_prop_default("$geoip_disable", serde_json::Value::Bool(true));
+    }
+    if defaults.is_server {
+        event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
+    }
 }
 
 pub(super) fn apply_before_send_hooks(hooks: &[BeforeSendHook], event: Event) -> Option<Event> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,7 @@
+use std::sync::{Arc, Mutex};
+
 use crate::endpoints::{EndpointManager, DEFAULT_HOST};
+use crate::event::Event;
 use derive_builder::Builder;
 use tracing::warn;
 
@@ -48,6 +51,31 @@ mod async_client;
 pub use async_client::client;
 #[cfg(feature = "async-client")]
 pub use async_client::Client;
+
+/// Hook that can modify or discard events before they are sent.
+///
+/// Hooks run before serialization. Return `Some(event)` to continue sending the
+/// event, or `None` to drop it.
+#[derive(Clone)]
+pub struct BeforeSendHook(Arc<Mutex<Box<dyn FnMut(Event) -> Option<Event> + Send + 'static>>>);
+
+impl BeforeSendHook {
+    /// Create a new before-send hook.
+    pub fn new<F>(hook: F) -> Self
+    where
+        F: FnMut(Event) -> Option<Event> + Send + 'static,
+    {
+        Self(Arc::new(Mutex::new(Box::new(hook))))
+    }
+
+    pub(crate) fn apply(&self, event: Event) -> Option<Event> {
+        let mut hook = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        (hook)(event)
+    }
+}
 
 /// Configuration options for the PostHog client.
 ///
@@ -147,6 +175,10 @@ pub struct ClientOptions {
     #[builder(default, setter(strip_option))]
     pub(crate) capture_compression: Option<CaptureCompression>,
 
+    /// Hooks to modify, filter, or sample events before they are sent.
+    #[builder(default, setter(custom))]
+    pub(crate) before_send: Vec<BeforeSendHook>,
+
     /// Extra HTTP headers injected into every outbound capture request.
     /// Used by the SDK test harness adapter to attach `X-Test-Id` for
     /// parallel test isolation.
@@ -229,6 +261,17 @@ impl ClientOptions {
 }
 
 impl ClientOptionsBuilder {
+    /// Add a hook that can modify or discard events before they are sent.
+    pub fn before_send<F>(&mut self, hook: F) -> &mut Self
+    where
+        F: FnMut(Event) -> Option<Event> + Send + 'static,
+    {
+        self.before_send
+            .get_or_insert_with(Vec::new)
+            .push(BeforeSendHook::new(hook));
+        self
+    }
+
     /// Build sanitized [`ClientOptions`].
     ///
     /// Missing or whitespace-only API keys are allowed and disable the client so

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -52,12 +52,15 @@ pub use async_client::client;
 #[cfg(feature = "async-client")]
 pub use async_client::Client;
 
+type BeforeSendFn = dyn FnMut(Event) -> Option<Event> + Send + 'static;
+type SharedBeforeSendHook = Arc<Mutex<Box<BeforeSendFn>>>;
+
 /// Hook that can modify or discard events before they are sent.
 ///
 /// Hooks run before serialization. Return `Some(event)` to continue sending the
 /// event, or `None` to drop it.
 #[derive(Clone)]
-pub struct BeforeSendHook(Arc<Mutex<Box<dyn FnMut(Event) -> Option<Event> + Send + 'static>>>);
+pub struct BeforeSendHook(SharedBeforeSendHook);
 
 impl BeforeSendHook {
     /// Create a new before-send hook.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -59,6 +59,10 @@ type SharedBeforeSendHook = Arc<Mutex<Box<BeforeSendFn>>>;
 ///
 /// Hooks run before serialization. Return `Some(event)` to continue sending the
 /// event, or `None` to drop it.
+///
+/// Hook panics are caught and cause the current event to be dropped. If a hook
+/// keeps mutable state, a panic can leave that state partially updated; the SDK
+/// recovers the hook mutex and subsequent events continue through the same hook.
 #[derive(Clone)]
 pub struct BeforeSendHook(SharedBeforeSendHook);
 
@@ -265,6 +269,10 @@ impl ClientOptions {
 
 impl ClientOptionsBuilder {
     /// Add a hook that can modify or discard events before they are sent.
+    ///
+    /// Hooks should avoid panicking. Panics are caught and drop the current event,
+    /// but any mutable state captured by the hook may be left partially updated
+    /// and will be reused on subsequent calls.
     pub fn before_send<F>(&mut self, hook: F) -> &mut Self
     where
         F: FnMut(Event) -> Option<Event> + Send + 'static,

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -7,7 +7,10 @@ use reqwest::blocking::RequestBuilder;
 #[cfg(feature = "async-client")]
 use reqwest::RequestBuilder;
 
-use super::{common::apply_before_send_hooks, BeforeSendHook, CaptureDefaults, ClientOptions};
+use super::{
+    common::{apply_before_send_hooks, apply_capture_defaults},
+    BeforeSendHook, CaptureDefaults, ClientOptions,
+};
 use crate::error::Error;
 use crate::event::{BatchRequest, Event, InnerEvent};
 
@@ -20,12 +23,7 @@ use crate::event::{BatchRequest, Event, InnerEvent};
 /// Uses `insert_prop_default` so a caller who explicitly set a property on the
 /// event before calling `capture()` keeps their value.
 pub(crate) fn prepare_event(event: &mut Event, defaults: &CaptureDefaults) {
-    if defaults.disable_geoip {
-        event.insert_prop_default("$geoip_disable", serde_json::Value::Bool(true));
-    }
-    if defaults.is_server {
-        event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
-    }
+    apply_capture_defaults(event, defaults);
     event.prepare_for_v0();
 }
 

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -7,7 +7,7 @@ use reqwest::blocking::RequestBuilder;
 #[cfg(feature = "async-client")]
 use reqwest::RequestBuilder;
 
-use super::{CaptureDefaults, ClientOptions};
+use super::{common::apply_before_send_hooks, BeforeSendHook, CaptureDefaults, ClientOptions};
 use crate::error::Error;
 use crate::event::{BatchRequest, Event, InnerEvent};
 
@@ -45,21 +45,29 @@ pub(crate) fn build_batch_payload(
     api_key: String,
     historical_migration: bool,
     defaults: &CaptureDefaults,
-) -> Result<String, Error> {
+    before_send: &[BeforeSendHook],
+) -> Result<Option<String>, Error> {
     let inner_events: Vec<InnerEvent> = events
         .into_iter()
-        .map(|mut event| {
+        .filter_map(|mut event| {
             prepare_event(&mut event, defaults);
-            InnerEvent::new(event, api_key.clone())
+            apply_before_send_hooks(before_send, event)
+                .map(|event| InnerEvent::new(event, api_key.clone()))
         })
         .collect();
+
+    if inner_events.is_empty() {
+        return Ok(None);
+    }
 
     let batch_request = BatchRequest {
         api_key,
         historical_migration,
         batch: inner_events,
     };
-    serde_json::to_string(&batch_request).map_err(|e| Error::Serialization(e.to_string()))
+    serde_json::to_string(&batch_request)
+        .map(Some)
+        .map_err(|e| Error::Serialization(e.to_string()))
 }
 
 /// Encode the V0 JSON body, compressing when configured. Returns the bytes and

--- a/src/event.rs
+++ b/src/event.rs
@@ -112,6 +112,11 @@ impl Event {
         Ok(())
     }
 
+    /// Remove a property from the event and return its previous value, if any.
+    pub fn remove_prop(&mut self, key: &str) -> Option<serde_json::Value> {
+        self.properties.remove(key)
+    }
+
     /// Capture this as a group event.
     ///
     /// See <https://posthog.com/docs/product-analytics/group-analytics#how-to-capture-group-events>.
@@ -202,13 +207,15 @@ impl Event {
         &self.options
     }
 
+    /// Return the event name.
     #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
-    pub(crate) fn event_name(&self) -> &str {
+    pub fn event_name(&self) -> &str {
         &self.event
     }
 
+    /// Return the event distinct ID.
     #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
-    pub(crate) fn distinct_id(&self) -> &str {
+    pub fn distinct_id(&self) -> &str {
         &self.distinct_id
     }
 
@@ -222,8 +229,9 @@ impl Event {
         self.timestamp
     }
 
+    /// Return the event properties.
     #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
-    pub(crate) fn properties(&self) -> &HashMap<String, serde_json::Value> {
+    pub fn properties(&self) -> &HashMap<String, serde_json::Value> {
         &self.properties
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ mod local_evaluation;
 // Public interface - any change to this is breaking!
 // Client
 pub use client::client;
+pub use client::BeforeSendHook;
 pub use client::CaptureCompression;
 pub use client::Client;
 pub use client::ClientOptions;

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -471,6 +471,75 @@ async fn v1_capture_caller_override_wins_for_is_server() {
 }
 
 #[tokio::test]
+async fn v1_before_send_runs_after_capture_defaults() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"hook_saw_defaults\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .disable_geoip(true)
+        .before_send(|mut event| {
+            let saw_defaults = event.properties().get("$is_server") == Some(&json!(true))
+                && event.properties().get("$geoip_disable") == Some(&json!(true));
+            event
+                .insert_prop("hook_saw_defaults", saw_defaults)
+                .unwrap();
+            Some(event)
+        })
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_batch_before_send_runs_after_capture_defaults() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"hook_saw_defaults\":true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host(server.base_url())
+        .disable_geoip(true)
+        .before_send(|mut event| {
+            let saw_defaults = event.properties().get("$is_server") == Some(&json!(true))
+                && event.properties().get("$geoip_disable") == Some(&json!(true));
+            event
+                .insert_prop("hook_saw_defaults", saw_defaults)
+                .unwrap();
+            Some(event)
+        })
+        .build()
+        .unwrap();
+    let client = posthog_rs::client(options).await;
+
+    client
+        .capture_batch(vec![Event::new("test", "user-1")], false)
+        .await
+        .unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
 async fn v1_capture_batch_sets_historical_migration() {
     let server = MockServer::start();
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds a `before_send` hook API so users can centrally mutate, redact, sample, or drop events before capture requests are sent.

## :green_heart: How did you test it?

- `cargo test -q`
- `cargo test -q --features 'async-client capture-v1'`
- `cargo test -q --no-default-features`
- `cargo clippy --all-targets --all-features -- -D warnings`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
