### PR TITLE
feat: add runtime context properties

### DIFF
--- a/.sampo/changesets/sullen-seer-aurelien.md
+++ b/.sampo/changesets/sullen-seer-aurelien.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Add OS runtime context properties to captured events.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +697,16 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -1600,6 +1619,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1649,165 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1818,22 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "parking"
@@ -1744,6 +1950,7 @@ dependencies = [
  "flate2",
  "futures",
  "httpmock",
+ "os_info",
  "regex",
  "reqwest",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.64"
 semver = "1.0.24"
 derive_builder = "0.20.2"
 uuid = { version = "1.13.2", features = ["serde", "v7"] }
+os_info = "3.14"
 sha1 = "0.10"
 regex = "1.10"
 tracing = "0.1"

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -118,7 +118,6 @@ pub(super) fn flag_called_event(
     if is_server {
         event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
     }
-    apply_runtime_context(&mut event);
     Some(event)
 }
 
@@ -336,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn flag_called_event_adds_runtime_context() {
+    fn flag_called_event_leaves_runtime_context_to_capture_path() {
         let event = flag_called_event(
             flag_params(HashMap::new(), HashMap::new(), None),
             false,
@@ -344,8 +343,8 @@ mod tests {
         )
         .expect("valid flag-called event");
 
-        assert!(event.properties().contains_key("$os"));
-        assert!(event.properties().contains_key("$os_version"));
+        assert!(!event.properties().contains_key("$os"));
+        assert!(!event.properties().contains_key("$os_version"));
         assert!(!event.properties().contains_key("$os_arch"));
     }
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 use crate::feature_flag_evaluations::{EvaluatedFlagRecord, FlagCalledEventParams};
 use crate::feature_flags::{FeatureFlagsResponse, FlagDetail, FlagMetadata, FlagValue};
@@ -10,6 +10,32 @@ use crate::Event;
 pub(super) const MAX_FLAG_CALLED_CACHE_SIZE: usize = 50_000;
 
 pub(super) type FlagEventDedupCache = Mutex<HashMap<String, HashSet<String>>>;
+
+struct RuntimeContext {
+    os: String,
+    os_version: String,
+}
+
+static RUNTIME_CONTEXT: OnceLock<RuntimeContext> = OnceLock::new();
+
+fn runtime_context() -> &'static RuntimeContext {
+    RUNTIME_CONTEXT.get_or_init(|| {
+        let info = os_info::get();
+        RuntimeContext {
+            os: info.os_type().to_string(),
+            os_version: info.version().to_string(),
+        }
+    })
+}
+
+pub(super) fn apply_runtime_context(event: &mut Event) {
+    let context = runtime_context();
+    event.insert_prop_default("$os", serde_json::Value::String(context.os.clone()));
+    event.insert_prop_default(
+        "$os_version",
+        serde_json::Value::String(context.os_version.clone()),
+    );
+}
 
 pub(super) fn flag_event_dedup_cache() -> FlagEventDedupCache {
     Mutex::new(HashMap::new())
@@ -92,6 +118,7 @@ pub(super) fn flag_called_event(
     if is_server {
         event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
     }
+    apply_runtime_context(&mut event);
     Some(event)
 }
 
@@ -294,5 +321,31 @@ mod tests {
 
         assert_eq!(event.properties().get("$is_server"), Some(&json!(true)));
         assert_eq!(event.properties().get("$geoip_disable"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn runtime_context_adds_missing_os_properties_only() {
+        let mut event = Event::new("test", "user-1");
+        event.insert_prop("$os", "custom-os").unwrap();
+
+        apply_runtime_context(&mut event);
+
+        assert_eq!(event.properties().get("$os"), Some(&json!("custom-os")));
+        assert!(event.properties().contains_key("$os_version"));
+        assert!(!event.properties().contains_key("$os_arch"));
+    }
+
+    #[test]
+    fn flag_called_event_adds_runtime_context() {
+        let event = flag_called_event(
+            flag_params(HashMap::new(), HashMap::new(), None),
+            false,
+            true,
+        )
+        .expect("valid flag-called event");
+
+        assert!(event.properties().contains_key("$os"));
+        assert!(event.properties().contains_key("$os_version"));
+        assert!(!event.properties().contains_key("$os_arch"));
     }
 }

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -7,7 +7,7 @@ use reqwest::blocking::RequestBuilder;
 #[cfg(feature = "async-client")]
 use reqwest::RequestBuilder;
 
-use super::{CaptureDefaults, ClientOptions};
+use super::{common::apply_runtime_context, CaptureDefaults, ClientOptions};
 use crate::error::Error;
 use crate::event::{BatchRequest, Event, InnerEvent};
 
@@ -26,6 +26,7 @@ pub(crate) fn prepare_event(event: &mut Event, defaults: &CaptureDefaults) {
     if defaults.is_server {
         event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
     }
+    apply_runtime_context(event);
     event.prepare_for_v0();
 }
 

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -14,7 +14,7 @@ use super::retry::{backoff_duration, is_retryable_status};
 // Re-exported so the V1 capture loops in the client modules can reach them as
 // `v1_capture::parse_retry_after` / `v1_capture::Step`.
 pub(crate) use super::retry::{parse_retry_after, Step};
-use super::{CaptureCompression, CaptureDefaults, ClientOptions};
+use super::{common::apply_runtime_context, CaptureCompression, CaptureDefaults, ClientOptions};
 use crate::error::Error;
 use crate::event::Event;
 use crate::event_v1::{CaptureResponse, EventResult, EventStatus, V1ErrorResponse, V1Event};
@@ -27,7 +27,9 @@ pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<
     events
         .iter()
         .map(|event| {
-            let mut v1 = V1Event::from_event(event);
+            let mut event = event.clone();
+            apply_runtime_context(&mut event);
+            let mut v1 = V1Event::from_event(&event);
             if let serde_json::Value::Object(ref mut map) = v1.properties {
                 if defaults.disable_geoip {
                     map.entry("$geoip_disable")

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -584,6 +584,48 @@ async fn v0_capture_injects_is_server_by_default() {
 
 #[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
+async fn v0_capture_injects_runtime_context() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v0/e/")
+            .body_contains("\"$os\":")
+            .body_contains("\"$os_version\":");
+        then.status(200).body("ok");
+    });
+
+    let client = create_test_client(server.base_url()).await;
+    client
+        .capture(posthog_rs::Event::new("test_event", "user-1"))
+        .await
+        .unwrap();
+    mock.assert();
+}
+
+#[cfg(not(feature = "capture-v1"))]
+#[tokio::test]
+async fn v0_capture_caller_override_wins_for_runtime_context() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v0/e/")
+            .body_contains("\"$os\":\"custom-os\"")
+            .body_contains("\"$os_version\":\"custom-version\"");
+        then.status(200).body("ok");
+    });
+
+    let client = create_test_client(server.base_url()).await;
+    let mut event = posthog_rs::Event::new("test_event", "user-1");
+    event.insert_prop("$os", "custom-os").unwrap();
+    event.insert_prop("$os_version", "custom-version").unwrap();
+    client.capture(event).await.unwrap();
+    mock.assert();
+}
+
+#[cfg(not(feature = "capture-v1"))]
+#[tokio::test]
 async fn v0_capture_caller_override_wins_for_is_server() {
     let server = MockServer::start();
 

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -584,44 +584,34 @@ async fn v0_capture_injects_is_server_by_default() {
 
 #[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
-async fn v0_capture_injects_runtime_context() {
-    let server = MockServer::start();
+async fn v0_capture_applies_runtime_context_defaults_and_preserves_caller_values() {
+    for (caller_values, expected_os, expected_os_version) in [
+        (None, "\"$os\":", "\"$os_version\":"),
+        (
+            Some(("custom-os", "custom-version")),
+            "\"$os\":\"custom-os\"",
+            "\"$os_version\":\"custom-version\"",
+        ),
+    ] {
+        let server = MockServer::start();
 
-    let mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/i/v0/e/")
-            .body_contains("\"$os\":")
-            .body_contains("\"$os_version\":");
-        then.status(200).body("ok");
-    });
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v0/e/")
+                .body_contains(expected_os)
+                .body_contains(expected_os_version);
+            then.status(200).body("ok");
+        });
 
-    let client = create_test_client(server.base_url()).await;
-    client
-        .capture(posthog_rs::Event::new("test_event", "user-1"))
-        .await
-        .unwrap();
-    mock.assert();
-}
-
-#[cfg(not(feature = "capture-v1"))]
-#[tokio::test]
-async fn v0_capture_caller_override_wins_for_runtime_context() {
-    let server = MockServer::start();
-
-    let mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/i/v0/e/")
-            .body_contains("\"$os\":\"custom-os\"")
-            .body_contains("\"$os_version\":\"custom-version\"");
-        then.status(200).body("ok");
-    });
-
-    let client = create_test_client(server.base_url()).await;
-    let mut event = posthog_rs::Event::new("test_event", "user-1");
-    event.insert_prop("$os", "custom-os").unwrap();
-    event.insert_prop("$os_version", "custom-version").unwrap();
-    client.capture(event).await.unwrap();
-    mock.assert();
+        let client = create_test_client(server.base_url()).await;
+        let mut event = posthog_rs::Event::new("test_event", "user-1");
+        if let Some((os, os_version)) = caller_values {
+            event.insert_prop("$os", os).unwrap();
+            event.insert_prop("$os_version", os_version).unwrap();
+        }
+        client.capture(event).await.unwrap();
+        mock.assert();
+    }
 }
 
 #[cfg(not(feature = "capture-v1"))]

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -451,6 +451,47 @@ async fn v1_capture_injects_is_server_by_default() {
 }
 
 #[tokio::test]
+async fn v1_capture_injects_runtime_context() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$os\":")
+            .body_contains("\"$os_version\":");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn v1_capture_caller_override_wins_for_runtime_context() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/i/v1/analytics/events")
+            .body_contains("\"$os\":\"custom-os\"")
+            .body_contains("\"$os_version\":\"custom-version\"");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let mut event = Event::new("test", "user-1");
+    event.insert_prop("$os", "custom-os").unwrap();
+    event.insert_prop("$os_version", "custom-version").unwrap();
+    client.capture(event).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
 async fn v1_capture_caller_override_wins_for_is_server() {
     let server = MockServer::start();
 

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -451,44 +451,36 @@ async fn v1_capture_injects_is_server_by_default() {
 }
 
 #[tokio::test]
-async fn v1_capture_injects_runtime_context() {
-    let server = MockServer::start();
+async fn v1_capture_applies_runtime_context_defaults_and_preserves_caller_values() {
+    for (caller_values, expected_os, expected_os_version) in [
+        (None, "\"$os\":", "\"$os_version\":"),
+        (
+            Some(("custom-os", "custom-version")),
+            "\"$os\":\"custom-os\"",
+            "\"$os_version\":\"custom-version\"",
+        ),
+    ] {
+        let server = MockServer::start();
 
-    let mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/i/v1/analytics/events")
-            .body_contains("\"$os\":")
-            .body_contains("\"$os_version\":");
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(json!({ "results": {} }));
-    });
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .body_contains(expected_os)
+                .body_contains(expected_os_version);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "results": {} }));
+        });
 
-    let client = create_v1_client(server.base_url()).await;
-    client.capture(Event::new("test", "user-1")).await.unwrap();
-    mock.assert();
-}
-
-#[tokio::test]
-async fn v1_capture_caller_override_wins_for_runtime_context() {
-    let server = MockServer::start();
-
-    let mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/i/v1/analytics/events")
-            .body_contains("\"$os\":\"custom-os\"")
-            .body_contains("\"$os_version\":\"custom-version\"");
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(json!({ "results": {} }));
-    });
-
-    let client = create_v1_client(server.base_url()).await;
-    let mut event = Event::new("test", "user-1");
-    event.insert_prop("$os", "custom-os").unwrap();
-    event.insert_prop("$os_version", "custom-version").unwrap();
-    client.capture(event).await.unwrap();
-    mock.assert();
+        let client = create_v1_client(server.base_url()).await;
+        let mut event = Event::new("test", "user-1");
+        if let Some((os, os_version)) = caller_values {
+            event.insert_prop("$os", os).unwrap();
+            event.insert_prop("$os_version", os_version).unwrap();
+        }
+        client.capture(event).await.unwrap();
+        mock.assert();
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds missing runtime context enrichment to captured events so the Rust SDK includes OS metadata consistently. The SDK now adds `$os` and `$os_version` when those properties are not already provided by the caller.

## :green_heart: How did you test it?

- `cargo test -q`
- `cargo test -q --features 'async-client capture-v1'`
- `cargo test -q --no-default-features`
- `cargo clippy --all-targets --all-features -- -D warnings`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
