### PR TITLE
fix(capture): empty capture_batch is a no-op; pin body-less 2xx handling

### DIFF
--- a/.sampo/changesets/capture-empty-batch-noop.md
+++ b/.sampo/changesets/capture-empty-batch-noop.md
@@ -1,0 +1,8 @@
+---
+cargo/posthog-rs: patch
+---
+
+`capture_batch` with an empty event list is now a no-op on both clients and
+both capture paths — no HTTP request is sent (the v1 backend rejects empty
+batches). Also derives `Debug` for the internal retry `Step` and pins that a
+body-less 2xx response is a terminal serialization error, not a retry.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -313,7 +313,6 @@ impl Client {
             return Ok(());
         }
         if events.is_empty() {
-            trace!("Empty batch, skipping capture request");
             return Ok(());
         }
 

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -312,6 +312,10 @@ impl Client {
         if self.options.is_disabled() {
             return Ok(());
         }
+        if events.is_empty() {
+            trace!("Empty batch, skipping capture request");
+            return Ok(());
+        }
 
         #[cfg(feature = "capture-v1")]
         {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -290,6 +290,10 @@ impl Client {
             trace!("Client is disabled, skipping batch capture");
             return Ok(());
         }
+        if events.is_empty() {
+            trace!("Empty batch, skipping capture request");
+            return Ok(());
+        }
 
         #[cfg(feature = "capture-v1")]
         {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -291,7 +291,6 @@ impl Client {
             return Ok(());
         }
         if events.is_empty() {
-            trace!("Empty batch, skipping capture request");
             return Ok(());
         }
 

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -10,6 +10,7 @@ use crate::error::Error;
 /// Outcome of one capture attempt, computed without any I/O so both the async
 /// and blocking clients (and both V0 and V1) can share the decision logic and
 /// keep only the transport-specific loop.
+#[derive(Debug)]
 pub(crate) enum Step {
     Done,
     Backoff(Duration),

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -635,7 +635,8 @@ mod tests {
             );
             assert!(
                 matches!(step, Step::Done),
-                "HTTP {status} should be treated as success"
+                "HTTP {} should be treated as success",
+                status
             );
             assert_eq!(final_results.len(), 1);
         }
@@ -659,6 +660,36 @@ mod tests {
             &mut final_results,
         );
         assert!(matches!(step, Step::Fail(Error::Serialization(_))));
+    }
+
+    /// A body-less 2xx (e.g. 204 from beacon mode) is terminal on the first
+    /// attempt: Serialization error, no retry, final_results left empty.
+    /// posthog-rs never opts into beacon mode, so this is a safety net.
+    #[test]
+    fn after_response_204_empty_body_is_terminal_serialization_error() {
+        let opts = test_opts();
+        let rid = Uuid::now_v7();
+        let mut pending = vec![dummy_v1_event()];
+        let mut final_results = HashMap::new();
+        let step = after_response(
+            &opts,
+            &rid,
+            1,
+            204,
+            None,
+            "",
+            &mut pending,
+            &mut final_results,
+        );
+        assert!(
+            matches!(step, Step::Fail(Error::Serialization(_))),
+            "expected terminal Serialization error, got {:?}",
+            step
+        );
+        assert!(
+            final_results.is_empty(),
+            "no events should be finalized from a body-less 2xx"
+        );
     }
 
     // -- build_headers SDK identity -------------------------------------------

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -480,6 +480,23 @@ async fn assert_disabled_client_is_noop(api_key: Option<&str>) {
 
 #[cfg(not(feature = "capture-v1"))]
 #[tokio::test]
+async fn test_capture_batch_empty_is_noop() {
+    let server = MockServer::start();
+
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/batch/");
+        then.status(200).body("ok");
+    });
+
+    let client = create_test_client(server.base_url()).await;
+    let result = client.capture_batch(vec![], false).await;
+
+    assert!(result.is_ok());
+    batch_mock.assert_hits(0);
+}
+
+#[cfg(not(feature = "capture-v1"))]
+#[tokio::test]
 async fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -297,6 +297,23 @@ fn assert_disabled_client_is_noop(api_key: Option<&str>) {
 
 #[cfg(not(feature = "capture-v1"))]
 #[test]
+fn test_capture_batch_empty_is_noop() {
+    let server = MockServer::start();
+
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/batch/");
+        then.status(200).body("ok");
+    });
+
+    let client = create_test_client(server.base_url());
+    let result = client.capture_batch(vec![], false);
+
+    assert!(result.is_ok());
+    batch_mock.assert_hits(0);
+}
+
+#[cfg(not(feature = "capture-v1"))]
+#[test]
 fn test_capture_batch_sends_to_batch_endpoint() {
     let server = MockServer::start();
 

--- a/tests/test_v1_blocking.rs
+++ b/tests/test_v1_blocking.rs
@@ -639,6 +639,24 @@ fn v1_blocking_preserves_uuid_and_timestamp_across_retries() {
 }
 
 #[test]
+fn v1_blocking_capture_batch_empty_is_noop() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url());
+    let result = client.capture_batch(vec![], false);
+
+    assert!(result.is_ok());
+    mock.assert_hits(0);
+}
+
+#[test]
 fn v1_blocking_disabled_client_noop() {
     let options = ClientOptionsBuilder::default()
         .api_key("phc_test".to_string())

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -775,6 +775,24 @@ async fn v1_capture_sends_canonical_sdk_info_header() {
 }
 
 #[tokio::test]
+async fn v1_capture_batch_empty_is_noop() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/i/v1/analytics/events");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({ "results": {} }));
+    });
+
+    let client = create_v1_client(server.base_url()).await;
+    let result = client.capture_batch(vec![], false).await;
+
+    assert!(result.is_ok());
+    mock.assert_hits(0);
+}
+
+#[tokio::test]
 async fn v1_capture_disabled_client_noop() {
     let options = ClientOptionsBuilder::default()
         .api_key("phc_test".to_string())


### PR DESCRIPTION
## Summary

Follow-up to the empty-body 2xx review question on #132 (https://github.com/PostHog/posthog-rs/pull/132#discussion_r3385515258). These changes were written in response to that thread but missed the merge; landing them here.

- `capture_batch` with an empty event list is now a no-op on both clients and both capture paths — no HTTP request is sent (the v1 backend rejects empty batches, and v0 gains the same short-circuit for consistency)
- pins via unit test that a body-less 2xx (e.g. a 204) on the v1 path is a terminal `Serialization` error: single attempt, no retry, no events finalized
- derives `Debug` for the internal retry `Step` to support the new assertion

## Test plan

- [x] 5 new tests: empty-batch no-op on v0 async/blocking and v1 async/blocking; 204-empty-body terminal error in the sans-IO layer
- [x] `cargo test` (default), `cargo test --features capture-v1`, `cargo test --no-default-features --features capture-v1` — all green (228/227 passing)
- [x] `cargo clippy --all-targets -- -D warnings` on both feature sets; `cargo fmt --check`