### PR TITLE
chore: parallelize CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: ['1.78.0', stable]
+        toolchain: [stable]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,14 +98,19 @@ jobs:
       matrix:
         include:
           - name: Unit test (default features)
+            cache-key: default-features
             command: cargo test --verbose
           - name: Unit test (workspace)
+            cache-key: workspace
             command: cargo test --workspace --verbose
           - name: Unit test (capture-v1, async client)
+            cache-key: capture-v1-async-client
             command: cargo test --verbose --features capture-v1
           - name: Unit test (capture-v1, blocking client)
+            cache-key: capture-v1-blocking-client
             command: cargo test --verbose --no-default-features --features capture-v1
           - name: E2E test
+            cache-key: e2e
             command: cargo test --verbose --features e2e-test --no-default-features
     steps:
       - name: Checkout code
@@ -123,7 +128,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-test-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-test-${{ matrix.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-
             ${{ runner.os }}-cargo-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,50 +5,127 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
-    name: Run Tests
+  fmt:
+    name: Format
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Set up Rust
-      run: |
-        rustup update stable
-        rustup default stable
-        rustup component add rustfmt clippy
+      - name: Set up Rust
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add rustfmt
 
-    - name: Print Rust version
-      run: rustc --version
+      - name: Check formatting
+        run: cargo fmt -- --check
 
-    - name: Build
-      run: cargo build --verbose
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Unit test (default features)
-      run: cargo test --verbose
+      - name: Set up Rust
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add clippy
 
-    # The adapter only enables async-client + test-harness, so the workspace
-    # build does NOT unify capture-v1 in; it gets its own explicit steps below.
-    - name: Unit test (workspace)
-      run: cargo test --workspace --verbose
+      - name: Cache cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
-    - name: Unit test (capture-v1, async client)
-      run: cargo test --verbose --features capture-v1
+      - name: Clippy
+        run: cargo clippy -- -D warnings
 
-    - name: Unit test (capture-v1, blocking client)
-      run: cargo test --verbose --no-default-features --features capture-v1
+  build:
+    name: Build (${{ matrix.toolchain }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: ['1.78.0', stable]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    # TODO: when v1 endpoint ships, remove the capture-v1 feature gate;
-    # v1 e2e test (get_client_v1_async) will then run here automatically.
-    - name: E2E test
-      run: cargo test --verbose --features e2e-test --no-default-features
-      env:
-        POSTHOG_RS_E2E_TEST_API_KEY: "${{ secrets.POSTHOG_RS_E2E_TEST_API_KEY }}"
+      - name: Set up Rust ${{ matrix.toolchain }}
+        run: |
+          rustup toolchain install ${{ matrix.toolchain }} --profile minimal
+          rustup default ${{ matrix.toolchain }}
 
-    - name: Check formatting
-      run: cargo fmt -- --check
+      - name: Print Rust version
+        run: rustc --version
 
-    - name: Clippy
-      run: cargo clippy -- -D warnings
+      - name: Cache cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-build-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.toolchain }}-
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --verbose
+
+  test:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Unit test (default features)
+            command: cargo test --verbose
+          - name: Unit test (workspace)
+            command: cargo test --workspace --verbose
+          - name: Unit test (capture-v1, async client)
+            command: cargo test --verbose --features capture-v1
+          - name: Unit test (capture-v1, blocking client)
+            command: cargo test --verbose --no-default-features --features capture-v1
+          - name: E2E test
+            command: cargo test --verbose --features e2e-test --no-default-features
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Rust
+        run: |
+          rustup update stable
+          rustup default stable
+
+      - name: Cache cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: ${{ matrix.command }}
+        env:
+          POSTHOG_RS_E2E_TEST_API_KEY: ${{ secrets.POSTHOG_RS_E2E_TEST_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,6 +142,11 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Run tests
+        if: matrix.cache-key != 'e2e'
+        run: ${{ matrix.command }}
+
+      - name: Run E2E tests
+        if: matrix.cache-key == 'e2e'
         run: ${{ matrix.command }}
         env:
           POSTHOG_RS_E2E_TEST_API_KEY: ${{ secrets.POSTHOG_RS_E2E_TEST_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   fmt:
@@ -57,12 +57,20 @@ jobs:
         run: cargo clippy -- -D warnings
 
   build:
-    name: Build (${{ matrix.toolchain }})
+    name: Build (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable]
+        include:
+          - name: default features
+            toolchain: stable
+            cache-key: default-features
+            command: cargo build --verbose
+          - name: capture-v1
+            toolchain: stable
+            cache-key: capture-v1
+            command: cargo build --verbose --features capture-v1
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -82,13 +90,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-build-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-${{ matrix.toolchain }}-${{ matrix.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ matrix.toolchain }}-
             ${{ runner.os }}-cargo-
 
       - name: Build
-        run: cargo build --verbose
+        run: ${{ matrix.command }}
 
   test:
     name: ${{ matrix.name }}


### PR DESCRIPTION
## :bulb: Motivation and Context

CI previously ran build, tests, formatting, and clippy together in a single job, which made the workflow slower and less granular when failures occurred.

This change splits CI into dedicated format, clippy, build, and test jobs, limits `GITHUB_TOKEN` permissions to read-only contents access, and caches Cargo dependencies per job to speed up repeated workflow executions.

The workflow now cancels superseded in-progress runs only for pull requests, preserving `main` push runs. It also builds both default features and `capture-v1` in the build matrix, while tests continue to cover the existing feature combinations. The E2E API key secret is now only exposed to the E2E matrix entry.

## :green_heart: How did you test it?

Ran:

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yaml'); puts 'yaml ok'"`

The remaining validation is the updated GitHub Actions workflow running on the PR.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
