### PR TITLE
chore: Add cargo publish dry run to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,32 @@ jobs:
       - name: Build
         run: ${{ matrix.command }}
 
+  package:
+    name: Cargo publish dry run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Rust
+        run: |
+          rustup update stable
+          rustup default stable
+
+      - name: Cache cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Publish dry run
+        run: cargo publish --dry-run
+
   test:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Publish dry run
-        run: cargo publish --dry-run
+        run: cargo publish --dry-run --locked
 
   test:
     name: ${{ matrix.name }}


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adds a CI package validation job so publish issues are caught before release. The new job runs `cargo publish --dry-run --locked` on Ubuntu with stable Rust and Cargo caching, ensuring the dry run uses the committed lockfile.

## :green_heart: How did you test it?

- `cargo publish --dry-run --locked`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
