### PR TITLE
test: add public API snapshot CI probe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,9 @@ mod global;
 mod local_evaluation;
 
 // Public interface - any change to this is breaking!
+/// Temporary public API used to verify CI detects unchecked public API changes.
+pub const PUBLIC_API_SNAPSHOT_CI_PROBE: &str = "public-api-snapshot-ci-probe";
+
 // Client
 pub use client::client;
 pub use client::BeforeSendHook;


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This intentionally adds a new exported Rust API without updating `api/public-api.txt` so the Public API CI check added in #141 can be verified on a pull request.

## :green_heart: How did you test it?

- `cargo fmt -- --check`
- `cargo check`
- `scripts/check-public-api.sh` (expected failure; reports `PUBLIC_API_SNAPSHOT_CI_PROBE` missing from the snapshot)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
