### PR TITLE
feat: Add custom user agent support

### DIFF
--- a/.sampo/changesets/chivalrous-count-erika.md
+++ b/.sampo/changesets/chivalrous-count-erika.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Add custom user agent support

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -6,12 +6,14 @@ use std::time::Duration;
 
 #[cfg(feature = "capture-v1")]
 use chrono::Utc;
+use reqwest::header::USER_AGENT;
 use reqwest::{header::CONTENT_TYPE, Client as HttpClient};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
 #[cfg(feature = "capture-v1")]
 use uuid::Uuid;
 
+use super::get_default_user_agent;
 use crate::endpoints::Endpoint;
 #[cfg(feature = "error-tracking")]
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
@@ -690,6 +692,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -893,6 +896,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -1118,6 +1122,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -6,12 +6,16 @@ use std::time::Duration;
 
 #[cfg(feature = "capture-v1")]
 use chrono::Utc;
-use reqwest::{blocking::Client as HttpClient, header::CONTENT_TYPE};
+use reqwest::{
+    blocking::Client as HttpClient,
+    header::{CONTENT_TYPE, USER_AGENT},
+};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
 #[cfg(feature = "capture-v1")]
 use uuid::Uuid;
 
+use super::get_default_user_agent;
 use crate::endpoints::Endpoint;
 #[cfg(feature = "error-tracking")]
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
@@ -654,6 +658,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -852,6 +857,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,
@@ -1075,6 +1081,7 @@ impl Client {
             .client
             .post(&flags_endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, get_default_user_agent())
             .json(&payload)
             .timeout(Duration::from_secs(
                 self.options.feature_flags_request_timeout_seconds,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -85,6 +85,7 @@ impl BeforeSendHook {
         (hook)(event)
     }
 }
+
 pub(crate) const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 const SDK_USERAGENT_NAME: &str = "posthog-rs";
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -85,6 +85,12 @@ impl BeforeSendHook {
         (hook)(event)
     }
 }
+pub(crate) const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
+const SDK_USERAGENT_NAME: &str = "posthog-rs";
+
+pub(crate) fn get_default_user_agent() -> String {
+    format!("{}/{}", SDK_USERAGENT_NAME, CRATE_VERSION)
+}
 
 /// Configuration options for the PostHog client.
 ///

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -15,6 +15,7 @@ use super::retry::{backoff_duration, is_retryable_status};
 // `v1_capture::parse_retry_after` / `v1_capture::Step`.
 pub(crate) use super::retry::{parse_retry_after, Step};
 use super::{common::apply_runtime_context, CaptureCompression, CaptureDefaults, ClientOptions};
+use crate::client::get_default_user_agent;
 use crate::error::Error;
 use crate::event::Event;
 use crate::event_v1::{CaptureResponse, EventResult, EventStatus, V1ErrorResponse, V1Event};
@@ -46,10 +47,7 @@ pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<
 }
 
 pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u32) -> HeaderMap {
-    let version = env!("CARGO_PKG_VERSION");
-    // SDK identity: `<canonical-$lib-name>/<semver>`. The name must match v0's
-    // `$lib` ("posthog-rs"); capture materializes it into `$lib`/`$lib_version`.
-    let sdk_info = format!("posthog-rs/{version}");
+    let sdk_info = get_default_user_agent();
 
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,6 +5,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::client::CRATE_VERSION;
 use crate::feature_flag_evaluations::FeatureFlagEvaluations;
 use crate::Error;
 
@@ -265,7 +266,7 @@ impl Event {
             );
         }
 
-        let version_str = env!("CARGO_PKG_VERSION");
+        let version_str = CRATE_VERSION;
         if !self.properties.contains_key("$lib_version") {
             self.properties.insert(
                 "$lib_version".into(),

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -1,9 +1,10 @@
+use crate::client::get_default_user_agent;
 use crate::feature_flags::{
     match_feature_flag, match_feature_flag_with_context, CohortDefinition, EvaluationContext,
     FeatureFlag, FlagValue, InconclusiveMatchError,
 };
 use crate::Error;
-use reqwest::header::{HeaderMap, ETAG, IF_NONE_MATCH};
+use reqwest::header::{HeaderMap, ETAG, IF_NONE_MATCH, USER_AGENT};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -257,7 +258,8 @@ impl FlagPoller {
                         "Authorization",
                         format!("Bearer {}", config.personal_api_key),
                     )
-                    .header("X-PostHog-Project-Api-Key", &config.project_api_key);
+                    .header("X-PostHog-Project-Api-Key", &config.project_api_key)
+                    .header(USER_AGENT, get_default_user_agent());
 
                 if let Some(ref etag) = last_etag {
                     request = request.header(IF_NONE_MATCH, etag.as_str());
@@ -317,6 +319,7 @@ impl FlagPoller {
                 format!("Bearer {}", self.config.personal_api_key),
             )
             .header("X-PostHog-Project-Api-Key", &self.config.project_api_key)
+            .header(USER_AGENT, get_default_user_agent())
             .send()
             .map_err(|e| {
                 error!(error = %e, "Connection error loading flags");
@@ -448,7 +451,8 @@ impl AsyncFlagPoller {
                         let mut request = client
                             .get(&url)
                             .header("Authorization", format!("Bearer {}", config.personal_api_key))
-                            .header("X-PostHog-Project-Api-Key", &config.project_api_key);
+                            .header("X-PostHog-Project-Api-Key", &config.project_api_key)
+                            .header(USER_AGENT, get_default_user_agent());
 
                         if let Some(ref etag) = last_etag {
                             request = request.header(IF_NONE_MATCH, etag.as_str());
@@ -513,6 +517,7 @@ impl AsyncFlagPoller {
                 format!("Bearer {}", self.config.personal_api_key),
             )
             .header("X-PostHog-Project-Api-Key", &self.config.project_api_key)
+            .header(USER_AGENT, get_default_user_agent())
             .send()
             .await
             .map_err(|e| {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,3 @@
+pub fn default_user_agent() -> String {
+    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
+}

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -8,8 +8,13 @@
 
 use httpmock::prelude::*;
 use posthog_rs::FlagValue;
+use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
+
+fn default_user_agent() -> String {
+    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
+}
 
 async fn create_test_client(base_url: String) -> posthog_rs::Client {
     // Use the From implementation to ensure endpoint_manager is set up correctly
@@ -76,6 +81,31 @@ async fn test_get_all_feature_flags() {
 
     assert!(payloads.contains_key("variant-flag"));
 
+    flags_mock.assert();
+}
+
+#[tokio::test]
+async fn test_sends_default_useragent() {
+    let server = MockServer::start();
+
+    let mock_response = json!({});
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/flags/")
+            .header(USER_AGENT.to_string(), default_user_agent())
+            .query_param("v", "2");
+
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(mock_response);
+    });
+
+    let client = create_test_client(server.base_url()).await;
+
+    let _ = client
+        .get_feature_flags("test-user".to_string(), None, None, None)
+        .await;
     flags_mock.assert();
 }
 

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -6,15 +6,14 @@
 // `tests/test_evaluate_flags.rs`.
 #![allow(deprecated)]
 
+mod common;
+
+use common::default_user_agent;
 use httpmock::prelude::*;
 use posthog_rs::FlagValue;
 use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
-
-fn default_user_agent() -> String {
-    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
-}
 
 async fn create_test_client(base_url: String) -> posthog_rs::Client {
     // Use the From implementation to ensure endpoint_manager is set up correctly

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -8,8 +8,13 @@
 
 use httpmock::prelude::*;
 use posthog_rs::FlagValue;
+use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
+
+fn default_user_agent() -> String {
+    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
+}
 
 fn create_test_client(base_url: String) -> posthog_rs::Client {
     // Use the From implementation to ensure endpoint_manager is set up correctly
@@ -70,6 +75,29 @@ fn test_get_all_feature_flags() {
 
     assert!(payloads.contains_key("variant-flag"));
 
+    flags_mock.assert();
+}
+
+#[test]
+fn test_sends_default_useragent() {
+    let server = MockServer::start();
+
+    let mock_response = json!({});
+
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/flags/")
+            .header(USER_AGENT.to_string(), default_user_agent())
+            .query_param("v", "2");
+
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(mock_response);
+    });
+
+    let client = create_test_client(server.base_url());
+
+    let _ = client.get_feature_flags("test-user".to_string(), None, None, None);
     flags_mock.assert();
 }
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -6,15 +6,14 @@
 // `tests/test_evaluate_flags.rs`.
 #![allow(deprecated)]
 
+mod common;
+
+use common::default_user_agent;
 use httpmock::prelude::*;
 use posthog_rs::FlagValue;
 use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
-
-fn default_user_agent() -> String {
-    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
-}
 
 fn create_test_client(base_url: String) -> posthog_rs::Client {
     // Use the From implementation to ensure endpoint_manager is set up correctly

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -1,3 +1,6 @@
+mod common;
+
+use common::default_user_agent;
 use httpmock::prelude::*;
 use serde_json::{json, Value};
 
@@ -9,10 +12,6 @@ use std::time::Duration;
 const CAPTURE_PATH: &str = "/i/v1/analytics/events";
 #[cfg(not(feature = "capture-v1"))]
 const CAPTURE_PATH: &str = "/i/v0/e/";
-
-fn default_user_agent() -> String {
-    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
-}
 
 /// Feature-aware capture mock; the JSON body is required by V1, ignored by v0.
 fn capture_path_mock(server: &MockServer) -> httpmock::Mock<'_> {

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -10,6 +10,10 @@ const CAPTURE_PATH: &str = "/i/v1/analytics/events";
 #[cfg(not(feature = "capture-v1"))]
 const CAPTURE_PATH: &str = "/i/v0/e/";
 
+fn default_user_agent() -> String {
+    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
+}
+
 /// Feature-aware capture mock; the JSON body is required by V1, ignored by v0.
 fn capture_path_mock(server: &MockServer) -> httpmock::Mock<'_> {
     server.mock(|when, then| {
@@ -83,6 +87,7 @@ fn flags_response_fixture() -> Value {
 mod blocking {
     use super::*;
     use posthog_rs::{EvaluateFlagsOptions, Event, FlagValue};
+    use reqwest::header::USER_AGENT;
 
     fn create_test_client(base_url: String) -> posthog_rs::Client {
         let options: posthog_rs::ClientOptions = ("test_api_key", base_url.as_str()).into();
@@ -108,6 +113,22 @@ mod blocking {
         assert_eq!(keys, vec!["alpha", "beta", "variant-flag"]);
         flags_mock.assert_hits(1);
         capture_mock.assert_hits(0);
+    }
+
+    #[test]
+    fn evaluate_flags_uses_default_useragent() {
+        let server = MockServer::start();
+        let flags_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/flags/")
+                .header(USER_AGENT.to_string(), default_user_agent());
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let client = create_test_client(server.base_url());
+        let _ = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .unwrap();
+        flags_mock.assert();
     }
 
     #[test]
@@ -540,6 +561,7 @@ mod async_tests {
     #[cfg(not(feature = "capture-v1"))]
     use posthog_rs::Event;
     use posthog_rs::{EvaluateFlagsOptions, FlagValue};
+    use reqwest::header::USER_AGENT;
 
     async fn create_test_client(base_url: String) -> posthog_rs::Client {
         let options: posthog_rs::ClientOptions = ("test_api_key", base_url.as_str()).into();
@@ -568,6 +590,23 @@ mod async_tests {
         keys.sort();
         assert_eq!(keys, vec!["alpha", "beta", "variant-flag"]);
         flags_mock.assert_hits(1);
+    }
+
+    #[tokio::test]
+    async fn evaluate_flags_uses_default_useragent() {
+        let server = MockServer::start();
+        let flags_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/flags/")
+                .header(USER_AGENT.to_string(), default_user_agent());
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let client = create_test_client(server.base_url()).await;
+        let _ = client
+            .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+            .await
+            .unwrap();
+        flags_mock.assert();
     }
 
     #[tokio::test]

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -11,9 +11,16 @@ use posthog_rs::{
     FlagPoller, FlagValue, LocalEvaluationConfig, LocalEvaluationResponse, LocalEvaluator,
     Property,
 };
+#[cfg(feature = "async-client")]
+use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::Duration;
+
+#[cfg(feature = "async-client")]
+fn default_user_agent() -> String {
+    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
+}
 
 #[test]
 fn test_local_evaluation_basic() {
@@ -226,6 +233,50 @@ async fn test_local_evaluation_with_mock_server() {
         .await;
 
     assert!(result.unwrap() == Some(FlagValue::Boolean(true)));
+
+    eval_mock.assert();
+}
+
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn test_local_evaluation_with_mock_server_sends_default_user_agent() {
+    let server = MockServer::start();
+
+    // Mock the local evaluation endpoint
+    let mock_flags = json!({
+        "flags": [],
+        "group_type_mapping": {},
+        "cohorts": {}
+    });
+
+    let eval_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/flags/definitions/")
+            .header("Authorization", "Bearer test_personal_key")
+            .header("X-PostHog-Project-Api-Key", "test_project_key")
+            .header(USER_AGENT.to_string(), default_user_agent())
+            .query_param("send_cohorts", "");
+        then.status(200).json_body(mock_flags);
+    });
+
+    // Create client with local evaluation enabled
+    let options = ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .api_key("test_project_key".to_string())
+        .personal_api_key("test_personal_key".to_string())
+        .enable_local_evaluation(true)
+        .poll_interval_seconds(60)
+        .build()
+        .unwrap();
+
+    let client = posthog_rs::client(options).await;
+
+    // Give it a moment to load initial flags
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let _ = client
+        .get_feature_flag("feature-b", "", None, None, None)
+        .await;
 
     eval_mock.assert();
 }

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -3,6 +3,9 @@
 // during the transition window.
 #![allow(deprecated)]
 
+mod common;
+
+use common::default_user_agent;
 use httpmock::prelude::*;
 #[cfg(feature = "async-client")]
 use posthog_rs::AsyncFlagPoller;
@@ -11,16 +14,10 @@ use posthog_rs::{
     FlagPoller, FlagValue, LocalEvaluationConfig, LocalEvaluationResponse, LocalEvaluator,
     Property,
 };
-#[cfg(feature = "async-client")]
 use reqwest::header::USER_AGENT;
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::Duration;
-
-#[cfg(feature = "async-client")]
-fn default_user_agent() -> String {
-    format!("posthog-rs/{}", env!("CARGO_PKG_VERSION"))
-}
 
 #[test]
 fn test_local_evaluation_basic() {
@@ -277,6 +274,41 @@ async fn test_local_evaluation_with_mock_server_sends_default_user_agent() {
     let _ = client
         .get_feature_flag("feature-b", "", None, None, None)
         .await;
+
+    eval_mock.assert();
+}
+
+#[test]
+fn test_sync_local_evaluation_with_mock_server_sends_default_user_agent() {
+    let server = MockServer::start();
+
+    let mock_flags = json!({
+        "flags": [],
+        "group_type_mapping": {},
+        "cohorts": {}
+    });
+
+    let eval_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/flags/definitions/")
+            .header("Authorization", "Bearer test_personal_key")
+            .header("X-PostHog-Project-Api-Key", "test_project_key")
+            .header(USER_AGENT.to_string(), default_user_agent())
+            .query_param("send_cohorts", "");
+        then.status(200).json_body(mock_flags);
+    });
+
+    let cache = FlagCache::new();
+    let config = LocalEvaluationConfig {
+        personal_api_key: "test_personal_key".to_string(),
+        project_api_key: "test_project_key".to_string(),
+        api_host: server.base_url(),
+        poll_interval: Duration::from_secs(60),
+        request_timeout: Duration::from_secs(5),
+    };
+
+    let poller = FlagPoller::new(config, cache);
+    poller.load_flags().unwrap();
 
     eval_mock.assert();
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds custom user agent support for PostHog Rust SDK requests, based on the work from the original contributor PR: https://github.com/PostHog/posthog-rs/pull/131.

This opens the same change from a fresh `main` branch because the original fork PR has maintainer edits disabled and could not be updated directly.


## :green_heart: How did you test it?

- `cargo fmt --check`
- `scripts/check-public-api.sh`
- `cargo test --features capture-v1`
- `cargo test --no-default-features --features capture-v1`
- `cargo test --no-default-features --features error-tracking,capture-v1`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
