### PR TITLE
fix: send user agent on v0 capture requests

### DIFF
--- a/.sampo/changesets/v0-user-agent.md
+++ b/.sampo/changesets/v0-user-agent.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Send the default SDK User-Agent on V0 capture requests.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -176,6 +176,7 @@ impl AsyncFlagEventHost {
             let response = match http_client
                 .post(&url)
                 .header(CONTENT_TYPE, "application/json")
+                .header(USER_AGENT, get_default_user_agent())
                 .body(payload)
                 .send()
                 .await
@@ -508,6 +509,7 @@ impl Client {
                 .client
                 .post(&url)
                 .header(CONTENT_TYPE, "application/json")
+                .header(USER_AGENT, get_default_user_agent())
                 .body(body.clone());
             if let Some(token) = encoding {
                 request = request.header(reqwest::header::CONTENT_ENCODING, token);

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -160,6 +160,7 @@ impl BlockingFlagEventHost {
             .http_client
             .post(&self.capture_url)
             .header(CONTENT_TYPE, "application/json")
+            .header(USER_AGENT, get_default_user_agent())
             .body(payload)
             .send();
         match result {
@@ -485,6 +486,7 @@ impl Client {
                 .client
                 .post(&url)
                 .header(CONTENT_TYPE, "application/json")
+                .header(USER_AGENT, get_default_user_agent())
                 .body(body.clone());
             if let Some(token) = encoding {
                 request = request.header(reqwest::header::CONTENT_ENCODING, token);

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -532,6 +532,7 @@ async fn test_capture_batch_sends_to_batch_endpoint() {
     let batch_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/batch/")
+            .header(USER_AGENT.to_string(), default_user_agent())
             .body_contains(r#""historical_migration":false"#);
         then.status(200);
     });
@@ -618,6 +619,7 @@ async fn v0_capture_injects_is_server_by_default() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v0/e/")
+            .header(USER_AGENT.to_string(), default_user_agent())
             .body_contains("\"$is_server\":true");
         then.status(200).body("ok");
     });

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -347,6 +347,7 @@ fn test_capture_batch_sends_to_batch_endpoint() {
     let batch_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/batch/")
+            .header(USER_AGENT.to_string(), default_user_agent())
             .body_contains(r#""historical_migration":false"#);
         then.status(200);
     });
@@ -433,6 +434,7 @@ fn v0_capture_injects_is_server_by_default() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v0/e/")
+            .header(USER_AGENT.to_string(), default_user_agent())
             .body_contains("\"$is_server\":true");
         then.status(200).body("ok");
     });


### PR DESCRIPTION
## :bulb: Motivation and Context

PR #143 added the canonical `posthog-rs/<version>` User-Agent to feature flag, local evaluation, and v1 capture requests. The remaining v0 capture paths still only sent `Content-Type`, so v0 capture and `$feature_flag_called` requests could reach PostHog without the SDK identity header.

This makes the v0 capture paths send the same default SDK User-Agent as the rest of the Rust SDK.


## :green_heart: How did you test it?

- `cargo fmt --check`
- `cargo test test_capture_batch_sends_to_batch_endpoint`
- `cargo test v0_capture_injects_is_server_by_default`
- `cargo test --no-default-features test_capture_batch_sends_to_batch_endpoint`
- `cargo test --no-default-features v0_capture_injects_is_server_by_default`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
