### PR TITLE
perf: sender pool for the event transport (removes head-of-line blocking)

### DIFF
--- a/.sampo/changesets/runtime-independent-event-transport.md
+++ b/.sampo/changesets/runtime-independent-event-transport.md
@@ -1,0 +1,9 @@
+---
+posthog-rs: minor
+---
+
+Runtime-independent background event transport. `capture` and `capture_batch` are now non-blocking enqueues onto a background worker — a plain `std::thread` with a blocking HTTP client, independent of any async runtime — that batches events, retries transient failures with backoff (honoring `Retry-After`), and sends them. They no longer block on the network or return delivery errors.
+
+New public API: `flush()` (awaited on the async client, blocking on the blocking client), `shutdown()` (flush + stop the worker + join; idempotent; drops further captures), flush-on-`Drop`, and `pending_events()`. New `ClientOptions`: `flush_at`, `max_batch_size`, `flush_interval_ms`, and `max_queue_size` (a bounded queue that drops with a single warning when full). `before_send` hooks now run on the worker thread, so they apply to every queued event.
+
+Breaking change (0.x): `capture`/`capture_batch` return `Ok(())` as soon as the event is queued instead of awaiting delivery, and HTTP failures surface as logged warnings rather than `Err`. Call `flush()` or `shutdown()` before process exit to ensure queued events are delivered.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +1992,7 @@ dependencies = [
  "backtrace",
  "brotli",
  "chrono",
+ "crossbeam-channel",
  "ctor",
  "derive_builder",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ os_info = "3.14"
 sha1 = "0.10"
 regex = "1.10"
 tracing = "0.1"
+crossbeam-channel = "0.5"
 tokio = { version = "1", features = [
     "rt",
     "sync",

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -107,10 +107,15 @@ pub async fn posthog_rs::Client::capture_exception<E>(&self, &E) -> core::result
 pub async fn posthog_rs::Client::capture_exception_with<E>(&self, &E, posthog_rs::CaptureExceptionOptions) -> core::result::Result<(), posthog_rs::Error> where E: core::error::Error + ?core::marker::Sized
 pub fn posthog_rs::Client::evaluate_feature_flag_locally(&self, &posthog_rs::FeatureFlag, &str, &std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>, &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>, &std::collections::hash::map::HashMap<alloc::string::String, std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>) -> core::result::Result<posthog_rs::FlagValue, posthog_rs::Error>
 pub async fn posthog_rs::Client::evaluate_flags<S: core::convert::Into<alloc::string::String>>(&self, S, posthog_rs::EvaluateFlagsOptions) -> core::result::Result<posthog_rs::FeatureFlagEvaluations, posthog_rs::Error>
+pub async fn posthog_rs::Client::flush(&self)
 pub async fn posthog_rs::Client::get_feature_flag<K: core::convert::Into<alloc::string::String>, D: core::convert::Into<alloc::string::String>>(&self, K, D, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>>, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>>) -> core::result::Result<core::option::Option<posthog_rs::FlagValue>, posthog_rs::Error>
 pub async fn posthog_rs::Client::get_feature_flag_payload<K: core::convert::Into<alloc::string::String>, D: core::convert::Into<alloc::string::String>>(&self, K, D) -> core::result::Result<core::option::Option<serde_json::value::Value>, posthog_rs::Error>
 pub async fn posthog_rs::Client::get_feature_flags<S: core::convert::Into<alloc::string::String>>(&self, S, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>>, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>>) -> core::result::Result<(std::collections::hash::map::HashMap<alloc::string::String, posthog_rs::FlagValue>, std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>), posthog_rs::Error>
 pub async fn posthog_rs::Client::is_feature_enabled<K: core::convert::Into<alloc::string::String>, D: core::convert::Into<alloc::string::String>>(&self, K, D, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>>, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>, core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>>) -> core::result::Result<bool, posthog_rs::Error>
+pub fn posthog_rs::Client::pending_events(&self) -> usize
+pub async fn posthog_rs::Client::shutdown(&self)
+impl core::ops::drop::Drop for posthog_rs::Client
+pub fn posthog_rs::Client::drop(&mut self)
 pub struct posthog_rs::ClientOptions
 impl posthog_rs::ClientOptions
 pub fn posthog_rs::ClientOptions::is_disabled(&self) -> bool
@@ -128,10 +133,14 @@ pub fn posthog_rs::ClientOptionsBuilder::enable_local_evaluation(&mut self, bool
 pub fn posthog_rs::ClientOptionsBuilder::error_tracking(&mut self, posthog_rs::ErrorTrackingOptions) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::extra_capture_headers(&mut self, std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::feature_flags_request_timeout_seconds(&mut self, u64) -> &mut Self
+pub fn posthog_rs::ClientOptionsBuilder::flush_at(&mut self, usize) -> &mut Self
+pub fn posthog_rs::ClientOptionsBuilder::flush_interval_ms(&mut self, u64) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::host<VALUE: core::convert::Into<alloc::string::String>>(&mut self, VALUE) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::is_server(&mut self, bool) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::local_evaluation_only(&mut self, bool) -> &mut Self
+pub fn posthog_rs::ClientOptionsBuilder::max_batch_size(&mut self, usize) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::max_capture_attempts(&mut self, u32) -> &mut Self
+pub fn posthog_rs::ClientOptionsBuilder::max_queue_size(&mut self, usize) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::personal_api_key<VALUE: core::convert::Into<alloc::string::String>>(&mut self, VALUE) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::poll_interval_seconds(&mut self, u64) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::request_timeout_seconds(&mut self, u64) -> &mut Self
@@ -315,8 +324,10 @@ pub async fn posthog_rs::capture_exception<E>(&E) -> core::result::Result<(), po
 pub async fn posthog_rs::capture_exception_with<E>(&E, posthog_rs::CaptureExceptionOptions) -> core::result::Result<(), posthog_rs::Error> where E: core::error::Error + ?core::marker::Sized
 pub async fn posthog_rs::client<C: core::convert::Into<posthog_rs::ClientOptions>>(C) -> posthog_rs::Client
 pub fn posthog_rs::disable_global()
+pub async fn posthog_rs::flush()
 pub fn posthog_rs::global_is_disabled() -> bool
 pub async fn posthog_rs::init_global<C: core::convert::Into<posthog_rs::ClientOptions>>(C) -> core::result::Result<(), posthog_rs::Error>
 pub fn posthog_rs::match_feature_flag(&posthog_rs::FeatureFlag, &str, &std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>, &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>, &std::collections::hash::map::HashMap<alloc::string::String, std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>, &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::result::Result<posthog_rs::FlagValue, posthog_rs::InconclusiveMatchError>
 pub fn posthog_rs::match_feature_flag_with_context(&posthog_rs::FeatureFlag, &std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>, &posthog_rs::EvaluationContext<'_>) -> core::result::Result<posthog_rs::FlagValue, posthog_rs::InconclusiveMatchError>
 pub fn posthog_rs::match_property_with_context(&posthog_rs::Property, &std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>, &posthog_rs::EvaluationContext<'_>) -> core::result::Result<bool, posthog_rs::InconclusiveMatchError>
+pub async fn posthog_rs::shutdown()

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -146,6 +146,7 @@ pub fn posthog_rs::ClientOptionsBuilder::poll_interval_seconds(&mut self, u64) -
 pub fn posthog_rs::ClientOptionsBuilder::request_timeout_seconds(&mut self, u64) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::retry_initial_backoff_ms(&mut self, u64) -> &mut Self
 pub fn posthog_rs::ClientOptionsBuilder::retry_max_backoff_ms(&mut self, u64) -> &mut Self
+pub fn posthog_rs::ClientOptionsBuilder::shutdown_timeout_ms(&mut self, u64) -> &mut Self
 impl posthog_rs::ClientOptionsBuilder
 pub fn posthog_rs::ClientOptionsBuilder::before_send<F>(&mut self, F) -> &mut Self where F: core::ops::function::FnMut(posthog_rs::Event) -> core::option::Option<posthog_rs::Event> + core::marker::Send + 'static
 pub fn posthog_rs::ClientOptionsBuilder::build(&self) -> core::result::Result<posthog_rs::ClientOptions, posthog_rs::ClientOptionsBuilderError>

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -23,16 +23,14 @@ struct AppState {
 
 const DEFAULT_TEST_ID: &str = "_global";
 
+// The SDK now owns batching, retry, and the queue; the adapter just forwards
+// capture/flush/shutdown and tracks how many captures it handed off.
 #[derive(Default)]
 struct AdapterState {
     client: Option<Arc<Client>>,
     historical_migration: bool,
-    buffer: Vec<Event>,
-    flush_at: Option<u32>,
     total_events_captured: u64,
-    total_events_sent: u64,
     last_error: Option<String>,
-    pending_events: i64,
 }
 
 #[derive(Deserialize)]
@@ -41,7 +39,6 @@ struct InitRequest {
     host: String,
     #[serde(default)]
     flush_at: Option<u32>,
-    #[allow(dead_code)]
     #[serde(default)]
     flush_interval_ms: Option<u64>,
     #[serde(default)]
@@ -152,10 +149,17 @@ async fn init(
 
     *s = AdapterState::default();
     s.historical_migration = req.historical_migration.unwrap_or(false);
-    s.flush_at = req.flush_at;
 
     let mut builder = ClientOptionsBuilder::default();
     builder.api_key(req.api_key).host(req.host);
+
+    // Batching knobs are now owned by the SDK.
+    if let Some(flush_at) = req.flush_at {
+        builder.flush_at(flush_at as usize);
+    }
+    if let Some(interval_ms) = req.flush_interval_ms {
+        builder.flush_interval_ms(interval_ms);
+    }
 
     // The harness `max_retries` counts retries; the SDK option counts total
     // attempts (initial + retries), so add one.
@@ -199,52 +203,6 @@ async fn init(
     }
 }
 
-/// Drain pending events from the buffer under the lock, then send the batch
-/// without holding the lock, and finally re-acquire the lock to record the
-/// outcome. Returns the number of events flushed in this call.
-async fn flush_buffer(instances: &Mutex<HashMap<String, AdapterState>>, key: &str) -> u64 {
-    let (client, events, historical_migration) = {
-        let mut map = instances.lock().await;
-        let s = match map.get_mut(key) {
-            Some(s) => s,
-            None => return 0,
-        };
-        if s.buffer.is_empty() {
-            return 0;
-        }
-        let client = match &s.client {
-            Some(c) => c.clone(),
-            None => return 0,
-        };
-        let events = std::mem::take(&mut s.buffer);
-        (client, events, s.historical_migration)
-    };
-
-    let count = events.len() as u64;
-    let result = client.capture_batch(events, historical_migration).await;
-
-    let flushed = {
-        let mut map = instances.lock().await;
-        if let Some(s) = map.get_mut(key) {
-            match result {
-                Ok(()) => {
-                    s.pending_events = (s.pending_events - count as i64).max(0);
-                    s.total_events_sent += count;
-                    count
-                }
-                Err(e) => {
-                    s.last_error = Some(e.to_string());
-                    0
-                }
-            }
-        } else {
-            0
-        }
-    };
-
-    flushed
-}
-
 async fn capture_event(
     State(state): State<AppState>,
     Query(params): Query<TestIdParam>,
@@ -252,53 +210,49 @@ async fn capture_event(
 ) -> impl IntoResponse {
     let key = params.key().to_string();
 
-    let needs_flush = {
-        let mut instances = state.instances.lock().await;
-        let s = instances.entry(key.clone()).or_default();
+    let mut event = Event::new(req.event, req.distinct_id);
+    if let Some(props) = req.properties {
+        if let Some(obj) = props.as_object() {
+            for (k, v) in obj {
+                let _ = event.insert_prop(k.clone(), v.clone());
+            }
+        }
+    }
+    if let Some(ts_str) = req.timestamp {
+        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&ts_str) {
+            let _ = event.set_timestamp(ts);
+        }
+    }
+    #[cfg(feature = "capture-v1")]
+    if let Some(opts_val) = req.options {
+        if let Some(obj) = opts_val.as_object() {
+            for (k, v) in obj {
+                let _ = event.set_option(k, v.clone());
+            }
+        }
+    }
 
-        if s.client.is_none() {
+    // Snapshot the client out of the lock so the (non-blocking) enqueue and any
+    // awaits don't hold the instances mutex.
+    let (client, historical_migration) = {
+        let mut instances = state.instances.lock().await;
+        let s = instances.entry(key).or_default();
+        let Some(client) = s.client.clone() else {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({ "error": "SDK not initialized" })),
             )
                 .into_response();
-        }
-
-        let mut event = Event::new(req.event, req.distinct_id);
-
-        if let Some(props) = req.properties {
-            if let Some(obj) = props.as_object() {
-                for (k, v) in obj {
-                    let _ = event.insert_prop(k.clone(), v.clone());
-                }
-            }
-        }
-
-        if let Some(ts_str) = req.timestamp {
-            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&ts_str) {
-                let _ = event.set_timestamp(ts);
-            }
-        }
-
-        #[cfg(feature = "capture-v1")]
-        if let Some(opts_val) = req.options {
-            if let Some(obj) = opts_val.as_object() {
-                for (k, v) in obj {
-                    let _ = event.set_option(k, v.clone());
-                }
-            }
-        }
-
+        };
         s.total_events_captured += 1;
-        s.pending_events += 1;
-        s.buffer.push(event);
-
-        matches!(s.flush_at, Some(threshold) if s.buffer.len() as u32 >= threshold)
+        (client, s.historical_migration)
     };
 
-    if needs_flush {
-        flush_buffer(&state.instances, &key).await;
-    }
+    // capture_batch carries the historical_migration flag through to the worker;
+    // a single-event vec is just a non-blocking enqueue.
+    let _ = client
+        .capture_batch(vec![event], historical_migration)
+        .await;
 
     let uuid = uuid::Uuid::now_v7().to_string();
     Json(serde_json::json!({ "success": true, "uuid": uuid })).into_response()
@@ -308,13 +262,11 @@ async fn flush(
     State(state): State<AppState>,
     Query(params): Query<TestIdParam>,
 ) -> impl IntoResponse {
-    let key = params.key().to_string();
-
-    {
+    let client = {
         let instances = state.instances.lock().await;
-        match instances.get(&key) {
-            Some(s) if s.client.is_some() => {}
-            _ => {
+        match instances.get(params.key()).and_then(|s| s.client.clone()) {
+            Some(c) => c,
+            None => {
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(serde_json::json!({ "error": "SDK not initialized" })),
@@ -322,9 +274,11 @@ async fn flush(
                     .into_response();
             }
         }
-    }
+    };
 
-    let flushed = flush_buffer(&state.instances, &key).await;
+    let before = client.pending_events() as u64;
+    client.flush().await;
+    let flushed = before.saturating_sub(client.pending_events() as u64);
 
     Json(serde_json::json!({
         "success": true,
@@ -333,20 +287,45 @@ async fn flush(
     .into_response()
 }
 
+async fn shutdown(
+    State(state): State<AppState>,
+    Query(params): Query<TestIdParam>,
+) -> impl IntoResponse {
+    let client = {
+        let instances = state.instances.lock().await;
+        match instances.get(params.key()).and_then(|s| s.client.clone()) {
+            Some(c) => c,
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": "SDK not initialized" })),
+                )
+                    .into_response();
+            }
+        }
+    };
+
+    client.shutdown().await;
+    Json(serde_json::json!({ "success": true })).into_response()
+}
+
 async fn get_state(
     State(state): State<AppState>,
     Query(params): Query<TestIdParam>,
 ) -> impl IntoResponse {
     let instances = state.instances.lock().await;
     match instances.get(params.key()) {
-        Some(s) => Json(serde_json::json!(StateResponse {
-            pending_events: s.pending_events,
-            total_events_captured: s.total_events_captured,
-            total_events_sent: s.total_events_sent,
-            total_retries: 0,
-            last_error: s.last_error.clone(),
-        }))
-        .into_response(),
+        Some(s) => {
+            let pending = s.client.as_ref().map_or(0, |c| c.pending_events()) as i64;
+            Json(serde_json::json!(StateResponse {
+                pending_events: pending,
+                total_events_captured: s.total_events_captured,
+                total_events_sent: (s.total_events_captured as i64 - pending).max(0) as u64,
+                total_retries: 0,
+                last_error: s.last_error.clone(),
+            }))
+            .into_response()
+        }
         None => Json(serde_json::json!(StateResponse {
             pending_events: 0,
             total_events_captured: 0,
@@ -393,6 +372,7 @@ async fn main() {
         .route("/init", post(init))
         .route("/capture", post(capture_event))
         .route("/flush", post(flush))
+        .route("/shutdown", post(shutdown))
         .route("/state", get(get_state))
         .route("/reset", post(reset))
         .with_state(state);

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -316,6 +316,13 @@ async fn get_state(
     let instances = state.instances.lock().await;
     match instances.get(params.key()) {
         Some(s) => {
+            // `pending_events` reflects everything the SDK still holds in flight
+            // (channel + worker buffer + retries), so "sent" = captured - pending.
+            // Caveat: capture() is fire-and-forget, so an event dropped because the
+            // SDK queue was full still counts toward `total_events_captured` and is
+            // therefore counted as sent here. An exact sent-count would need an SDK
+            // delivery callback; the acceptance suite never fills the queue, so this
+            // approximation is accurate for it.
             let pending = s.client.as_ref().map_or(0, |c| c.pending_events()) as i64;
             Json(serde_json::json!(StateResponse {
                 pending_events: pending,

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -448,9 +448,9 @@ impl Client {
         Ok(())
     }
 
-    /// Number of events queued for delivery but not yet picked up by the worker.
-    /// Returns 0 for a disabled client. Does not count events already in flight
-    /// or held for retry.
+    /// Number of events accepted but not yet delivered or dropped — those still
+    /// in the channel, in the worker's current batch, or held for retry. Returns
+    /// 0 for a disabled client.
     pub fn pending_events(&self) -> usize {
         self.transport.as_ref().map_or(0, |t| t.pending())
     }

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -452,6 +452,10 @@ impl Client {
     /// Number of events accepted but not yet delivered or dropped — those still
     /// in the channel, in the worker's current batch, or held for retry. Returns
     /// 0 for a disabled client.
+    ///
+    /// Gated behind the `test-harness` feature: it exposes internal queue depth
+    /// for the SDK compliance harness and is not part of the normal public API.
+    #[cfg(feature = "test-harness")]
     pub fn pending_events(&self) -> usize {
         self.transport.as_ref().map_or(0, |t| t.pending())
     }

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -4,14 +4,10 @@ use std::error::Error as StdError;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-#[cfg(feature = "capture-v1")]
-use chrono::Utc;
 use reqwest::header::USER_AGENT;
 use reqwest::{header::CONTENT_TYPE, Client as HttpClient};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
-#[cfg(feature = "capture-v1")]
-use uuid::Uuid;
 
 use super::get_default_user_agent;
 use crate::endpoints::Endpoint;
@@ -19,8 +15,6 @@ use crate::endpoints::Endpoint;
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
 #[cfg(not(feature = "capture-v1"))]
 use crate::event::InnerEvent;
-#[cfg(feature = "capture-v1")]
-use crate::event_v1::CaptureResponse;
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
     FlagCalledEventParams,
@@ -29,13 +23,14 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
-#[cfg(feature = "capture-v1")]
-use super::common::apply_capture_defaults;
+#[cfg(not(feature = "capture-v1"))]
+use super::common::apply_before_send_hooks;
 use super::common::{
-    already_reported, apply_before_send_hooks, build_dedup_key, extract_flag_details,
-    flag_called_event, flag_event_dedup_cache, local_record, remote_record_from_detail,
-    DetailedFlagsResponse, FlagEventDedupCache,
+    already_reported, build_dedup_key, extract_flag_details, flag_called_event,
+    flag_event_dedup_cache, local_record, remote_record_from_detail, DetailedFlagsResponse,
+    FlagEventDedupCache,
 };
+use super::transport::{Completion, Control, TransportHandle};
 use super::{BeforeSendHook, ClientOptions};
 
 #[cfg(not(feature = "capture-v1"))]
@@ -59,6 +54,8 @@ pub struct Client {
     local_evaluator: Option<LocalEvaluator>,
     _flag_poller: Option<AsyncFlagPoller>,
     flag_event_host: OnceLock<Arc<dyn FeatureFlagEvaluationsHost>>,
+    /// Background event transport. `None` for disabled clients.
+    transport: Option<TransportHandle>,
 }
 
 /// Implementation of [`FeatureFlagEvaluationsHost`] that emits dedup-aware
@@ -264,12 +261,19 @@ pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
         (None, None)
     };
 
+    let transport = if options.is_disabled() {
+        None
+    } else {
+        Some(TransportHandle::spawn(options.clone()))
+    };
+
     Client {
         options,
         client,
         local_evaluator,
         _flag_poller: flag_poller,
         flag_event_host: OnceLock::new(),
+        transport,
     }
 }
 
@@ -291,26 +295,49 @@ impl Client {
     /// # Remarks
     ///
     /// Disabled clients skip the request and return `Ok(())`.
+    /// Enqueue `event` for delivery. Non-blocking: the event is handed to the
+    /// background worker, which batches, sends, and retries it. Returns once the
+    /// event is queued — not once it is delivered. Disabled clients and a full
+    /// queue drop the event (the latter with a single warning).
     #[instrument(skip(self, event), level = "debug")]
     pub async fn capture(&self, event: Event) -> Result<(), Error> {
-        if self.options.is_disabled() {
-            trace!("Client is disabled, skipping capture");
-            return Ok(());
+        if let Some(transport) = &self.transport {
+            transport.enqueue(event, false);
         }
+        Ok(())
+    }
 
-        #[cfg(feature = "capture-v1")]
-        {
-            let mut event = event;
-            let defaults = self.options.capture_defaults();
-            apply_capture_defaults(&mut event, &defaults);
-            let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
-                return Ok(());
-            };
-            return self.capture_v1(vec![event], false).await.map(|_| ());
+    /// Flush queued events, returning once the worker has attempted delivery of
+    /// everything queued before this call. Transient failures are kept for retry
+    /// (the call still returns without error). A no-op for disabled clients.
+    pub async fn flush(&self) {
+        let Some(transport) = &self.transport else {
+            return;
+        };
+        if transport.is_closed() {
+            return;
         }
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if transport.send_control(Control::Flush(Completion::Async(tx))) {
+            let _ = rx.await;
+        }
+    }
 
-        #[cfg(not(feature = "capture-v1"))]
-        self.capture_v0(event).await
+    /// Flush, stop the background worker, and join it. Idempotent: subsequent
+    /// calls are no-ops. After shutdown, `capture` drops events. A no-op for
+    /// disabled clients.
+    pub async fn shutdown(&self) {
+        let Some(transport) = &self.transport else {
+            return;
+        };
+        if !transport.begin_close() {
+            return;
+        }
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if transport.send_control(Control::Shutdown(Completion::Async(tx))) {
+            let _ = rx.await;
+        }
+        transport.join();
     }
 
     /// Capture a Rust error personlessly, sending it to PostHog Error Tracking.
@@ -413,211 +440,19 @@ impl Client {
         events: Vec<Event>,
         historical_migration: bool,
     ) -> Result<(), Error> {
-        if self.options.is_disabled() {
-            return Ok(());
-        }
-        if events.is_empty() {
-            return Ok(());
-        }
-
-        #[cfg(feature = "capture-v1")]
-        {
-            let defaults = self.options.capture_defaults();
-            let events: Vec<_> = events
-                .into_iter()
-                .filter_map(|mut event| {
-                    apply_capture_defaults(&mut event, &defaults);
-                    apply_before_send_hooks(&self.options.before_send, event)
-                })
-                .collect();
-            if events.is_empty() {
-                return Ok(());
-            }
-            return self
-                .capture_v1(events, historical_migration)
-                .await
-                .map(|_| ());
-        }
-
-        #[cfg(not(feature = "capture-v1"))]
-        self.capture_batch_v0(events, historical_migration).await
-    }
-
-    #[cfg(not(feature = "capture-v1"))]
-    async fn capture_v0(&self, mut event: Event) -> Result<(), Error> {
-        let defaults = self.options.capture_defaults();
-        super::v0_capture::prepare_event(&mut event, &defaults);
-        let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
-            return Ok(());
-        };
-        let payload =
-            super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
-        let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
-        self.send_v0_with_retry(&url, body, encoding).await
-    }
-
-    #[cfg(not(feature = "capture-v1"))]
-    async fn capture_batch_v0(
-        &self,
-        events: Vec<Event>,
-        historical_migration: bool,
-    ) -> Result<(), Error> {
-        let defaults = self.options.capture_defaults();
-        let Some(payload) = super::v0_capture::build_batch_payload(
-            events,
-            self.options.api_key.clone(),
-            historical_migration,
-            &defaults,
-            &self.options.before_send,
-        )?
-        else {
-            return Ok(());
-        };
-        let url = self.options.endpoints().build_url(Endpoint::Batch);
-        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
-        self.send_v0_with_retry(&url, body, encoding).await
-    }
-
-    /// POST `body` to `url`, retrying transient failures (transport errors and
-    /// 408/429/500/502/503/504) up to `max_capture_attempts`. The body is built
-    /// once by the caller and resent byte-for-byte, so a retried event keeps
-    /// its UUID and timestamp — which dedup relies on. The retry decision is the
-    /// shared sans-IO logic in [`super::retry`]; this loop is just the transport.
-    /// When `encoding` is `Some`, the request advertises that `Content-Encoding`
-    /// and a matching `compression=<token>` query param (capture reads the query
-    /// param on v0, not the header).
-    #[cfg(not(feature = "capture-v1"))]
-    async fn send_v0_with_retry(
-        &self,
-        url: &str,
-        body: Vec<u8>,
-        encoding: Option<&'static str>,
-    ) -> Result<(), Error> {
-        use super::retry::{v0_after_response, v0_after_transport_error, Step};
-
-        // v0 capture/batch URLs carry no query string, so capture reads the
-        // compression hint from this param (it does not consult Content-Encoding).
-        let url = match encoding {
-            Some(token) => format!("{url}?compression={token}"),
-            None => url.to_string(),
-        };
-        let mut attempt: u32 = 1;
-        loop {
-            let mut request = self
-                .client
-                .post(&url)
-                .header(CONTENT_TYPE, "application/json")
-                .body(body.clone());
-            if let Some(token) = encoding {
-                request = request.header(reqwest::header::CONTENT_ENCODING, token);
-            }
-            let request = super::v0_capture::apply_extra_headers(&self.options, request);
-
-            let step = match request.send().await {
-                Err(e) => v0_after_transport_error(&self.options, attempt, e.to_string()),
-                Ok(response) => {
-                    let status = response.status().as_u16();
-                    let retry_after = super::retry::parse_retry_after(response.headers());
-                    let body = response
-                        .text()
-                        .await
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    v0_after_response(&self.options, attempt, status, retry_after, &body)
-                }
-            };
-
-            match step {
-                Step::Done => return Ok(()),
-                Step::Fail(e) => return Err(e),
-                Step::Backoff(delay) => {
-                    tokio::time::sleep(delay).await;
-                    attempt += 1;
-                }
+        if let Some(transport) = &self.transport {
+            for event in events {
+                transport.enqueue(event, historical_migration);
             }
         }
+        Ok(())
     }
 
-    #[cfg(feature = "capture-v1")]
-    async fn capture_v1(
-        &self,
-        events: Vec<Event>,
-        historical_migration: bool,
-    ) -> Result<CaptureResponse, Error> {
-        use super::v1_capture::{self, Step};
-        use crate::event_v1::V1BatchRequestRef;
-
-        let request_id = Uuid::now_v7();
-        let created_at = Utc::now().to_rfc3339();
-        let mut attempt: u32 = 1;
-        let defaults = self.options.capture_defaults();
-        let mut pending = v1_capture::build_events(&events, &defaults);
-        let mut final_results = HashMap::new();
-        let historical_migration = historical_migration.then_some(true);
-        let url = self
-            .options
-            .endpoints()
-            .build_custom_url(v1_capture::V1_CAPTURE_PATH);
-
-        loop {
-            let req = V1BatchRequestRef {
-                created_at: &created_at,
-                historical_migration,
-                batch: &pending,
-            };
-            let payload =
-                serde_json::to_vec(&req).map_err(|e| Error::Serialization(e.to_string()))?;
-            let mut headers = v1_capture::build_headers(&self.options, &request_id, attempt);
-            let body =
-                v1_capture::maybe_compress(self.options.capture_compression, &mut headers, payload);
-
-            let step = match self
-                .client
-                .post(&url)
-                .headers(headers)
-                .body(body)
-                .send()
-                .await
-            {
-                Err(e) => v1_capture::after_transport_error(
-                    &self.options,
-                    &request_id,
-                    attempt,
-                    e.to_string(),
-                ),
-                Ok(resp) => {
-                    let status = resp.status().as_u16();
-                    let retry_after = v1_capture::parse_retry_after(resp.headers());
-                    let text = resp
-                        .text()
-                        .await
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    v1_capture::after_response(
-                        &self.options,
-                        &request_id,
-                        attempt,
-                        status,
-                        retry_after,
-                        &text,
-                        &mut pending,
-                        &mut final_results,
-                    )
-                }
-            };
-
-            match step {
-                Step::Done => break,
-                Step::Fail(e) => return Err(e),
-                Step::Backoff(d) => {
-                    attempt += 1;
-                    tokio::time::sleep(d).await;
-                }
-            }
-        }
-
-        Ok(CaptureResponse {
-            results: final_results,
-        })
+    /// Number of events queued for delivery but not yet picked up by the worker.
+    /// Returns 0 for a disabled client. Does not count events already in flight
+    /// or held for retry.
+    pub fn pending_events(&self) -> usize {
+        self.transport.as_ref().map_or(0, |t| t.pending())
     }
 
     /// Get all remote feature flags and payloads for a user.
@@ -1146,5 +981,24 @@ impl Client {
             Error::Serialization(format!("Failed to parse feature flags response: {e}"))
         })?;
         Ok(extract_flag_details(parsed))
+    }
+}
+
+impl Drop for Client {
+    /// Best-effort flush and worker join on drop. A blocking drain (the async
+    /// `shutdown` can't run in a destructor); an explicit `shutdown().await`
+    /// beforehand makes this a no-op.
+    fn drop(&mut self) {
+        let Some(transport) = &self.transport else {
+            return;
+        };
+        if !transport.begin_close() {
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
+            let _ = rx.recv();
+        }
+        transport.join();
     }
 }

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -423,9 +423,9 @@ impl Client {
         Ok(())
     }
 
-    /// Number of events queued for delivery but not yet picked up by the worker.
-    /// Returns 0 for a disabled client. Does not count events already in flight
-    /// or held for retry.
+    /// Number of events accepted but not yet delivered or dropped — those still
+    /// in the channel, in the worker's current batch, or held for retry. Returns
+    /// 0 for a disabled client.
     pub fn pending_events(&self) -> usize {
         self.transport.as_ref().map_or(0, |t| t.pending())
     }

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -427,6 +427,10 @@ impl Client {
     /// Number of events accepted but not yet delivered or dropped — those still
     /// in the channel, in the worker's current batch, or held for retry. Returns
     /// 0 for a disabled client.
+    ///
+    /// Gated behind the `test-harness` feature: it exposes internal queue depth
+    /// for the SDK compliance harness and is not part of the normal public API.
+    #[cfg(feature = "test-harness")]
     pub fn pending_events(&self) -> usize {
         self.transport.as_ref().map_or(0, |t| t.pending())
     }

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -4,16 +4,12 @@ use std::error::Error as StdError;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-#[cfg(feature = "capture-v1")]
-use chrono::Utc;
 use reqwest::{
     blocking::Client as HttpClient,
     header::{CONTENT_TYPE, USER_AGENT},
 };
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
-#[cfg(feature = "capture-v1")]
-use uuid::Uuid;
 
 use super::get_default_user_agent;
 use crate::endpoints::Endpoint;
@@ -21,8 +17,6 @@ use crate::endpoints::Endpoint;
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
 #[cfg(not(feature = "capture-v1"))]
 use crate::event::InnerEvent;
-#[cfg(feature = "capture-v1")]
-use crate::event_v1::CaptureResponse;
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
     FlagCalledEventParams,
@@ -31,13 +25,14 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
-#[cfg(feature = "capture-v1")]
-use super::common::apply_capture_defaults;
+#[cfg(not(feature = "capture-v1"))]
+use super::common::apply_before_send_hooks;
 use super::common::{
-    already_reported, apply_before_send_hooks, build_dedup_key, extract_flag_details,
-    flag_called_event, flag_event_dedup_cache, local_record, remote_record_from_detail,
-    DetailedFlagsResponse, FlagEventDedupCache,
+    already_reported, build_dedup_key, extract_flag_details, flag_called_event,
+    flag_event_dedup_cache, local_record, remote_record_from_detail, DetailedFlagsResponse,
+    FlagEventDedupCache,
 };
+use super::transport::{Completion, Control, TransportHandle};
 use super::{BeforeSendHook, ClientOptions};
 
 #[cfg(not(feature = "capture-v1"))]
@@ -60,6 +55,8 @@ pub struct Client {
     local_evaluator: Option<LocalEvaluator>,
     _flag_poller: Option<FlagPoller>,
     flag_event_host: OnceLock<Arc<dyn FeatureFlagEvaluationsHost>>,
+    /// Background event transport. `None` for disabled clients.
+    transport: Option<TransportHandle>,
 }
 
 /// Implementation of [`FeatureFlagEvaluationsHost`] that emits dedup-aware
@@ -242,12 +239,19 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
         (None, None)
     };
 
+    let transport = if options.is_disabled() {
+        None
+    } else {
+        Some(TransportHandle::spawn(options.clone()))
+    };
+
     Client {
         options,
         client,
         local_evaluator,
         _flag_poller: flag_poller,
         flag_event_host: OnceLock::new(),
+        transport,
     }
 }
 
@@ -269,28 +273,49 @@ impl Client {
     /// # Remarks
     ///
     /// Disabled clients skip the request and return `Ok(())`.
+    /// Enqueue `event` for delivery. Non-blocking: the event is handed to the
+    /// background worker, which batches, sends, and retries it. Returns once the
+    /// event is queued — not once it is delivered. Disabled clients and a full
+    /// queue drop the event (the latter with a single warning).
     #[instrument(skip(self, event), level = "debug")]
     pub fn capture(&self, event: Event) -> Result<(), Error> {
-        if self.options.is_disabled() {
-            trace!("Client is disabled, skipping capture");
-            return Ok(());
+        if let Some(transport) = &self.transport {
+            transport.enqueue(event, false);
         }
+        Ok(())
+    }
 
-        #[cfg(feature = "capture-v1")]
-        {
-            let mut event = event;
-            let defaults = self.options.capture_defaults();
-            apply_capture_defaults(&mut event, &defaults);
-            let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
-                return Ok(());
-            };
-            self.capture_v1(vec![event], false).map(|_| ())
+    /// Flush queued events, blocking until the worker has attempted delivery of
+    /// everything queued before this call. Transient failures are kept for retry
+    /// (the call still returns). A no-op for disabled clients.
+    pub fn flush(&self) {
+        let Some(transport) = &self.transport else {
+            return;
+        };
+        if transport.is_closed() {
+            return;
         }
+        let (tx, rx) = std::sync::mpsc::channel();
+        if transport.send_control(Control::Flush(Completion::Blocking(tx))) {
+            let _ = rx.recv();
+        }
+    }
 
-        #[cfg(not(feature = "capture-v1"))]
-        {
-            self.capture_v0(event)
+    /// Flush, stop the background worker, and join it. Idempotent: subsequent
+    /// calls are no-ops. After shutdown, `capture` drops events. A no-op for
+    /// disabled clients.
+    pub fn shutdown(&self) {
+        let Some(transport) = &self.transport else {
+            return;
+        };
+        if !transport.begin_close() {
+            return;
         }
+        let (tx, rx) = std::sync::mpsc::channel();
+        if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
+            let _ = rx.recv();
+        }
+        transport.join();
     }
 
     /// Capture a Rust error personlessly, sending it to PostHog Error Tracking.
@@ -390,200 +415,19 @@ impl Client {
         events: Vec<Event>,
         historical_migration: bool,
     ) -> Result<(), Error> {
-        if self.options.is_disabled() {
-            trace!("Client is disabled, skipping batch capture");
-            return Ok(());
-        }
-        if events.is_empty() {
-            return Ok(());
-        }
-
-        #[cfg(feature = "capture-v1")]
-        {
-            let defaults = self.options.capture_defaults();
-            let events: Vec<_> = events
-                .into_iter()
-                .filter_map(|mut event| {
-                    apply_capture_defaults(&mut event, &defaults);
-                    apply_before_send_hooks(&self.options.before_send, event)
-                })
-                .collect();
-            if events.is_empty() {
-                return Ok(());
-            }
-            self.capture_v1(events, historical_migration).map(|_| ())
-        }
-
-        #[cfg(not(feature = "capture-v1"))]
-        {
-            self.capture_batch_v0(events, historical_migration)
-        }
-    }
-
-    #[cfg(not(feature = "capture-v1"))]
-    fn capture_v0(&self, mut event: Event) -> Result<(), Error> {
-        let defaults = self.options.capture_defaults();
-        super::v0_capture::prepare_event(&mut event, &defaults);
-        let Some(event) = apply_before_send_hooks(&self.options.before_send, event) else {
-            return Ok(());
-        };
-        let payload =
-            super::v0_capture::build_capture_payload(event, self.options.api_key.clone())?;
-        let url = self.options.endpoints().build_url(Endpoint::Capture);
-        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
-        self.send_v0_with_retry(&url, body, encoding)
-    }
-
-    #[cfg(not(feature = "capture-v1"))]
-    fn capture_batch_v0(
-        &self,
-        events: Vec<Event>,
-        historical_migration: bool,
-    ) -> Result<(), Error> {
-        let defaults = self.options.capture_defaults();
-        let Some(payload) = super::v0_capture::build_batch_payload(
-            events,
-            self.options.api_key.clone(),
-            historical_migration,
-            &defaults,
-            &self.options.before_send,
-        )?
-        else {
-            return Ok(());
-        };
-        let url = self.options.endpoints().build_url(Endpoint::Batch);
-        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
-        self.send_v0_with_retry(&url, body, encoding)
-    }
-
-    /// POST `body` to `url`, retrying transient failures (transport errors and
-    /// 408/429/500/502/503/504) up to `max_capture_attempts`. The body is built
-    /// once by the caller and resent byte-for-byte, so a retried event keeps
-    /// its UUID and timestamp — which dedup relies on. The retry decision is the
-    /// shared sans-IO logic in [`super::retry`]; this loop is just the transport.
-    /// When `encoding` is `Some`, the request advertises that `Content-Encoding`
-    /// and a matching `compression=<token>` query param (capture reads the query
-    /// param on v0, not the header).
-    #[cfg(not(feature = "capture-v1"))]
-    fn send_v0_with_retry(
-        &self,
-        url: &str,
-        body: Vec<u8>,
-        encoding: Option<&'static str>,
-    ) -> Result<(), Error> {
-        use super::retry::{v0_after_response, v0_after_transport_error, Step};
-
-        // v0 capture/batch URLs carry no query string, so capture reads the
-        // compression hint from this param (it does not consult Content-Encoding).
-        let url = match encoding {
-            Some(token) => format!("{url}?compression={token}"),
-            None => url.to_string(),
-        };
-        let mut attempt: u32 = 1;
-        loop {
-            let mut request = self
-                .client
-                .post(&url)
-                .header(CONTENT_TYPE, "application/json")
-                .body(body.clone());
-            if let Some(token) = encoding {
-                request = request.header(reqwest::header::CONTENT_ENCODING, token);
-            }
-            let request = super::v0_capture::apply_extra_headers(&self.options, request);
-
-            let step = match request.send() {
-                Err(e) => v0_after_transport_error(&self.options, attempt, e.to_string()),
-                Ok(response) => {
-                    let status = response.status().as_u16();
-                    let retry_after = super::retry::parse_retry_after(response.headers());
-                    let body = response
-                        .text()
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    v0_after_response(&self.options, attempt, status, retry_after, &body)
-                }
-            };
-
-            match step {
-                Step::Done => return Ok(()),
-                Step::Fail(e) => return Err(e),
-                Step::Backoff(delay) => {
-                    std::thread::sleep(delay);
-                    attempt += 1;
-                }
+        if let Some(transport) = &self.transport {
+            for event in events {
+                transport.enqueue(event, historical_migration);
             }
         }
+        Ok(())
     }
 
-    #[cfg(feature = "capture-v1")]
-    fn capture_v1(
-        &self,
-        events: Vec<Event>,
-        historical_migration: bool,
-    ) -> Result<CaptureResponse, Error> {
-        use super::v1_capture::{self, Step};
-        use crate::event_v1::V1BatchRequestRef;
-
-        let request_id = Uuid::now_v7();
-        let created_at = Utc::now().to_rfc3339();
-        let mut attempt: u32 = 1;
-        let defaults = self.options.capture_defaults();
-        let mut pending = v1_capture::build_events(&events, &defaults);
-        let mut final_results = HashMap::new();
-        let historical_migration = historical_migration.then_some(true);
-        let url = self
-            .options
-            .endpoints()
-            .build_custom_url(v1_capture::V1_CAPTURE_PATH);
-
-        loop {
-            let req = V1BatchRequestRef {
-                created_at: &created_at,
-                historical_migration,
-                batch: &pending,
-            };
-            let payload =
-                serde_json::to_vec(&req).map_err(|e| Error::Serialization(e.to_string()))?;
-            let mut headers = v1_capture::build_headers(&self.options, &request_id, attempt);
-            let body =
-                v1_capture::maybe_compress(self.options.capture_compression, &mut headers, payload);
-
-            let step = match self.client.post(&url).headers(headers).body(body).send() {
-                Err(e) => v1_capture::after_transport_error(
-                    &self.options,
-                    &request_id,
-                    attempt,
-                    e.to_string(),
-                ),
-                Ok(resp) => {
-                    let status = resp.status().as_u16();
-                    let retry_after = v1_capture::parse_retry_after(resp.headers());
-                    let text = resp.text().unwrap_or_else(|_| "Unknown error".to_string());
-                    v1_capture::after_response(
-                        &self.options,
-                        &request_id,
-                        attempt,
-                        status,
-                        retry_after,
-                        &text,
-                        &mut pending,
-                        &mut final_results,
-                    )
-                }
-            };
-
-            match step {
-                Step::Done => break,
-                Step::Fail(e) => return Err(e),
-                Step::Backoff(d) => {
-                    attempt += 1;
-                    std::thread::sleep(d);
-                }
-            }
-        }
-
-        Ok(CaptureResponse {
-            results: final_results,
-        })
+    /// Number of events queued for delivery but not yet picked up by the worker.
+    /// Returns 0 for a disabled client. Does not count events already in flight
+    /// or held for retry.
+    pub fn pending_events(&self) -> usize {
+        self.transport.as_ref().map_or(0, |t| t.pending())
     }
 
     /// Get all remote feature flags and payloads for a user.
@@ -1103,5 +947,23 @@ impl Client {
             Error::Serialization(format!("Failed to parse feature flags response: {e}"))
         })?;
         Ok(extract_flag_details(parsed))
+    }
+}
+
+impl Drop for Client {
+    /// Best-effort flush and worker join on drop. An explicit `shutdown()`
+    /// beforehand makes this a no-op.
+    fn drop(&mut self) {
+        let Some(transport) = &self.transport else {
+            return;
+        };
+        if !transport.begin_close() {
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
+            let _ = rx.recv();
+        }
+        transport.join();
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -38,6 +38,7 @@ impl CaptureCompression {
 #[cfg(not(feature = "async-client"))]
 mod blocking;
 mod retry;
+mod transport;
 #[cfg(not(feature = "capture-v1"))]
 mod v0_capture;
 #[cfg(feature = "capture-v1")]
@@ -189,6 +190,25 @@ pub struct ClientOptions {
     #[builder(default = "30000")]
     #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
     pub(crate) retry_max_backoff_ms: u64,
+
+    /// Number of buffered events that triggers an automatic flush (default: 100).
+    #[builder(default = "100")]
+    pub(crate) flush_at: usize,
+
+    /// Maximum number of events sent in a single batch request (default: 100).
+    /// A flush of more than this many events is split into multiple requests.
+    #[builder(default = "100")]
+    pub(crate) max_batch_size: usize,
+
+    /// Interval between automatic time-based flushes, in milliseconds
+    /// (default: 5000).
+    #[builder(default = "5000")]
+    pub(crate) flush_interval_ms: u64,
+
+    /// Maximum number of events buffered before new events are dropped
+    /// (default: 10000). A single warning is logged while the queue is full.
+    #[builder(default = "10000")]
+    pub(crate) max_queue_size: usize,
 
     /// Optional request-body compression. When `None` (default), bodies are
     /// sent uncompressed. The V0 pipeline supports `Gzip` only; V1 supports all

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -210,6 +210,13 @@ pub struct ClientOptions {
     #[builder(default = "10000")]
     pub(crate) max_queue_size: usize,
 
+    /// Maximum time `shutdown()` and `Drop` spend draining buffered and
+    /// retrying events before abandoning the rest, in milliseconds (default:
+    /// 30000). Bounds how long process teardown can block on a slow or
+    /// unreachable endpoint; `flush()` is unaffected.
+    #[builder(default = "30000")]
+    pub(crate) shutdown_timeout_ms: u64,
+
     /// Optional request-body compression. When `None` (default), bodies are
     /// sent uncompressed. The V0 pipeline supports `Gzip` only; V1 supports all
     /// variants.

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -161,7 +161,9 @@ impl TransportHandle {
     }
 
     /// Events accepted but not yet delivered or dropped: channel depth plus the
-    /// worker's current batch buffer plus any batches held for retry.
+    /// worker's current batch buffer plus any batches held for retry. Only the
+    /// `test-harness`-gated `Client::pending_events` and the unit tests read this.
+    #[cfg(any(test, feature = "test-harness"))]
     pub(crate) fn pending(&self) -> usize {
         self.len.load(Ordering::Acquire)
     }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -160,8 +160,8 @@ impl TransportHandle {
         self.closed.load(Ordering::Acquire)
     }
 
-    /// Events queued but not yet pulled by the worker. Excludes batches already
-    /// pulled into the worker's buffer or held for retry.
+    /// Events accepted but not yet delivered or dropped: channel depth plus the
+    /// worker's current batch buffer plus any batches held for retry.
     pub(crate) fn pending(&self) -> usize {
         self.len.load(Ordering::Acquire)
     }
@@ -226,8 +226,23 @@ fn try_reserve(len: &AtomicUsize, max: usize, warned: &AtomicBool) -> bool {
             .compare_exchange_weak(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
         {
+            // Re-arm the full-queue warning once the queue has fully drained, so a
+            // service that repeatedly fills then drains warns once per episode
+            // instead of only on the very first overflow.
+            if current == 0 {
+                warned.store(false, Ordering::Release);
+            }
             return true;
         }
+    }
+}
+
+/// Decrement the in-flight counter by `n` (no-op for 0). Called when events reach
+/// a terminal outcome (delivered or dropped) so `pending()` reflects everything
+/// still in flight: channel + worker buffer + retry queue.
+fn dec_len(len: &AtomicUsize, n: usize) {
+    if n > 0 {
+        len.fetch_sub(n, Ordering::AcqRel);
     }
 }
 
@@ -264,7 +279,7 @@ fn run_worker(
     let flush_at = options.flush_at.max(1);
     let max_batch_size = options.max_batch_size.max(1);
     let flush_interval = Duration::from_millis(options.flush_interval_ms);
-    let mut pipeline = Pipeline::new(&options, Arc::clone(&clock));
+    let mut pipeline = Pipeline::new(&options, Arc::clone(&clock), len);
 
     let mut buffer: Vec<Event> = Vec::new();
     let mut buffer_hist = false;
@@ -294,7 +309,9 @@ fn run_worker(
                 event,
                 historical_migration,
             }) => {
-                len.fetch_sub(1, Ordering::AcqRel);
+                // `len` is not decremented here: the in-flight counter spans the
+                // whole worker lifecycle (channel + buffer + retries) and is
+                // decremented by the pipeline once a batch is delivered or dropped.
                 // Keep each batch homogeneous in historical_migration: flush the
                 // current buffer before mixing in an event with a different flag.
                 if !buffer.is_empty() && historical_migration != buffer_hist {
@@ -445,12 +462,13 @@ struct Pipeline {
     options: ClientOptions,
     url: String,
     clock: Arc<dyn Clock>,
+    len: Arc<AtomicUsize>,
     retries: VecDeque<RetryBatch>,
 }
 
 #[cfg(feature = "capture-v1")]
 impl Pipeline {
-    fn new(options: &ClientOptions, clock: Arc<dyn Clock>) -> Self {
+    fn new(options: &ClientOptions, clock: Arc<dyn Clock>, len: Arc<AtomicUsize>) -> Self {
         let http = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(options.request_timeout_seconds))
             .build()
@@ -463,6 +481,7 @@ impl Pipeline {
             options: options.clone(),
             url,
             clock,
+            len,
             retries: VecDeque::new(),
         }
     }
@@ -471,6 +490,7 @@ impl Pipeline {
         use super::common::{apply_before_send_hooks, apply_capture_defaults};
 
         let defaults = self.options.capture_defaults();
+        let original = events.len();
         let processed: Vec<Event> = events
             .into_iter()
             .filter_map(|mut event| {
@@ -478,6 +498,8 @@ impl Pipeline {
                 apply_before_send_hooks(&self.options.before_send, event)
             })
             .collect();
+        // Events dropped by before_send are terminal.
+        dec_len(&self.len, original - processed.len());
         if processed.is_empty() {
             return;
         }
@@ -508,7 +530,11 @@ impl Pipeline {
         let payload = match serde_json::to_vec(&req) {
             Ok(p) => p,
             Err(e) => {
-                warn!("posthog-rs: dropping batch, serialization failed: {e}");
+                warn!(
+                    "posthog-rs: dropping {} event(s), serialization failed: {e}",
+                    batch.pending.len()
+                );
+                dec_len(&self.len, batch.pending.len());
                 return;
             }
         };
@@ -546,15 +572,22 @@ impl Pipeline {
             }
         };
 
+        // Events that left `pending` (the ok/drop/warning subset) are terminal.
+        dec_len(&self.len, count - batch.pending.len());
+
         match step {
             Step::Done => {}
-            Step::Fail(e) => warn!("posthog-rs: dropping {count} event(s): {e}"),
+            Step::Fail(e) => {
+                warn!("posthog-rs: dropping {} event(s): {e}", batch.pending.len());
+                dec_len(&self.len, batch.pending.len());
+            }
             Step::Backoff(delay) => {
                 if final_attempt {
                     warn!(
                         "posthog-rs: dropping {} undelivered event(s) on shutdown",
                         batch.pending.len()
                     );
+                    dec_len(&self.len, batch.pending.len());
                 } else {
                     batch.attempt += 1;
                     batch.next_at = self.clock.now() + delay;
@@ -608,12 +641,13 @@ struct Pipeline {
     options: ClientOptions,
     url_base: String,
     clock: Arc<dyn Clock>,
+    len: Arc<AtomicUsize>,
     retries: VecDeque<RetryBatch>,
 }
 
 #[cfg(not(feature = "capture-v1"))]
 impl Pipeline {
-    fn new(options: &ClientOptions, clock: Arc<dyn Clock>) -> Self {
+    fn new(options: &ClientOptions, clock: Arc<dyn Clock>, len: Arc<AtomicUsize>) -> Self {
         let http = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(options.request_timeout_seconds))
             .build()
@@ -626,6 +660,7 @@ impl Pipeline {
             options: options.clone(),
             url_base,
             clock,
+            len,
             retries: VecDeque::new(),
         }
     }
@@ -641,9 +676,14 @@ impl Pipeline {
             &self.options.before_send,
         ) {
             Ok(Some(p)) => p,
-            Ok(None) => return, // every event dropped by before_send
+            Ok(None) => {
+                // Every event dropped by before_send (terminal).
+                dec_len(&self.len, count);
+                return;
+            }
             Err(e) => {
-                warn!("posthog-rs: dropping batch, serialization failed: {e}");
+                warn!("posthog-rs: dropping {count} event(s), serialization failed: {e}");
+                dec_len(&self.len, count);
                 return;
             }
         };
@@ -690,14 +730,18 @@ impl Pipeline {
         };
 
         match step {
-            Step::Done => {}
-            Step::Fail(e) => warn!("posthog-rs: dropping {} event(s): {e}", batch.count),
+            Step::Done => dec_len(&self.len, batch.count),
+            Step::Fail(e) => {
+                warn!("posthog-rs: dropping {} event(s): {e}", batch.count);
+                dec_len(&self.len, batch.count);
+            }
             Step::Backoff(delay) => {
                 if final_attempt {
                     warn!(
                         "posthog-rs: dropping {} undelivered event(s) on shutdown",
                         batch.count
                     );
+                    dec_len(&self.len, batch.count);
                 } else {
                     batch.attempt += 1;
                     batch.next_at = self.clock.now() + delay;
@@ -802,13 +846,18 @@ mod tests {
     }
 
     #[test]
-    fn try_reserve_allows_again_after_drain() {
+    fn try_reserve_rearms_warning_after_full_drain() {
         let len = AtomicUsize::new(0);
         let warned = AtomicBool::new(false);
         assert!(try_reserve(&len, 1, &warned));
+        assert!(!try_reserve(&len, 1, &warned)); // full -> warns
+        assert!(warned.load(Ordering::Acquire));
+        len.fetch_sub(1, Ordering::AcqRel); // queue fully drains
+        assert!(try_reserve(&len, 1, &warned)); // reserve from empty re-arms the warning
+        assert!(!warned.load(Ordering::Acquire));
+        // A fresh overflow warns again (a new full episode).
         assert!(!try_reserve(&len, 1, &warned));
-        len.fetch_sub(1, Ordering::AcqRel); // worker consumed one
-        assert!(try_reserve(&len, 1, &warned));
+        assert!(warned.load(Ordering::Acquire));
     }
 
     #[test]
@@ -860,10 +909,20 @@ mod tests {
         handle.enqueue(Event::new("Delayed", "user-1"), false);
         handle.tick(); // interval not yet elapsed
         mock.assert_hits(0);
+        assert_eq!(
+            handle.pending(),
+            1,
+            "buffered-but-undelivered event stays in flight"
+        );
 
         clock.advance(Duration::from_secs(10));
         handle.tick(); // interval elapsed -> flush, no real sleep
         mock.assert_hits(1);
+        assert_eq!(
+            handle.pending(),
+            0,
+            "delivered event is decremented from in flight"
+        );
 
         handle.shutdown_blocking();
     }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -550,7 +550,15 @@ impl Dispatcher {
             Control::Flush(completion) => {
                 // One attempt per pending batch (held retries + buffered events);
                 // failures are held for a future cycle. Completes once those sends
-                // report back.
+                // report back (in_flight returns to zero).
+                //
+                // Known limitation: the barrier waits on the *global* in-flight
+                // count, and captures arriving mid-drain are deferred then replayed.
+                // With concurrent flush() calls from multiple threads, a later flush
+                // can complete based on the shared drain rather than strictly the
+                // events captured before that specific call. Single-threaded use
+                // (the common case) is exact. A fully precise fix needs per-flush
+                // generation tracking; tracked as a follow-up.
                 self.dispatch_all_retries(false);
                 self.dispatch_buffer(false);
                 self.register_barrier(completion);

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -101,6 +101,8 @@ pub(crate) struct TransportHandle {
     /// Latches the single "queue full" warning so a full queue doesn't spam logs.
     full_warned: AtomicBool,
     max_queue_size: usize,
+    /// Shares the worker's clock; used to stamp capture (enqueue) time.
+    clock: Arc<dyn Clock>,
 }
 
 impl TransportHandle {
@@ -114,9 +116,10 @@ impl TransportHandle {
         let len = Arc::new(AtomicUsize::new(0));
         let max_queue_size = options.max_queue_size;
         let worker_len = len.clone();
+        let worker_clock = Arc::clone(&clock);
         let worker = thread::Builder::new()
             .name("posthog-transport".to_string())
-            .spawn(move || run_worker(options, rx, worker_len, clock))
+            .spawn(move || run_worker(options, rx, worker_len, worker_clock))
             .ok();
         Self {
             tx,
@@ -125,18 +128,22 @@ impl TransportHandle {
             worker: Mutex::new(worker),
             full_warned: AtomicBool::new(false),
             max_queue_size,
+            clock,
         }
     }
 
     /// Non-blocking enqueue. Drops (with a single warning) when the queue is full
     /// or the client is closed.
-    pub(crate) fn enqueue(&self, event: Event, historical_migration: bool) {
+    pub(crate) fn enqueue(&self, mut event: Event, historical_migration: bool) {
         if self.closed.load(Ordering::Acquire) {
             return;
         }
         if !try_reserve(&self.len, self.max_queue_size, &self.full_warned) {
             return;
         }
+        // Stamp capture (enqueue) time on the producer side so a batched or
+        // retried event records when it occurred, not when it was finally sent.
+        event.ensure_timestamp(self.clock.now_utc());
         if self
             .tx
             .send(Control::Capture {
@@ -674,6 +681,7 @@ impl Pipeline {
             events,
             self.options.api_key.clone(),
             historical_migration,
+            self.clock.now_utc(),
             &defaults,
             &self.options.before_send,
         ) {
@@ -962,6 +970,66 @@ mod tests {
         handle.tick(); // due -> retried, delivered
         ok.assert_hits(1);
 
+        handle.shutdown_blocking();
+    }
+
+    /// Parse either an RFC3339 string (v1 timestamps / v0 `sent_at`) or a naive
+    /// datetime (v0 event timestamps serialize without an offset) as UTC.
+    fn parse_ts(s: &str) -> Option<DateTime<Utc>> {
+        DateTime::parse_from_rfc3339(s)
+            .map(|d| d.with_timezone(&Utc))
+            .ok()
+            .or_else(|| {
+                chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+                    .map(|n| n.and_utc())
+                    .ok()
+            })
+    }
+
+    #[test]
+    fn event_timestamp_is_capture_time_not_publish_time() {
+        // An event captured at T0 but flushed 10s later must carry T0 as its
+        // event `timestamp` (when it occurred), while the batch envelope carries
+        // the publish time (v1 `created_at` / v0 `sent_at`). The check is encoded
+        // in the matcher: the request only matches when publish - timestamp ~= 10s,
+        // proving the stamp happens at enqueue, not at send. Holds for both wire
+        // shapes (both nest the event under `batch[0]`).
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST).matches(|req| {
+                let Some(bytes) = req.body.as_deref() else {
+                    return false;
+                };
+                let Ok(json) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+                    return false;
+                };
+                let event_ts = json["batch"][0]["timestamp"].as_str().and_then(parse_ts);
+                let publish_ts = json
+                    .get("created_at")
+                    .or_else(|| json.get("sent_at"))
+                    .and_then(|v| v.as_str())
+                    .and_then(parse_ts);
+                match (event_ts, publish_ts) {
+                    (Some(e), Some(p)) => (9_900..=10_100).contains(&(p - e).num_milliseconds()),
+                    _ => false,
+                }
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "results": {} }));
+        });
+
+        let clock = ManualClock::new();
+        let handle = TransportHandle::spawn_with_clock(
+            options(server.base_url()).build().unwrap(),
+            Arc::new(clock.clone()),
+        );
+
+        handle.enqueue(Event::new("Captured", "user-1"), false); // stamped at T0
+        clock.advance(Duration::from_secs(10)); // ...delivered 10s later
+        handle.flush_blocking();
+
+        mock.assert_hits(1);
         handle.shutdown_blocking();
     }
 }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -288,6 +288,7 @@ fn run_worker(
     let flush_at = options.flush_at.max(1);
     let max_batch_size = options.max_batch_size.max(1);
     let flush_interval = Duration::from_millis(options.flush_interval_ms);
+    let shutdown_timeout = Duration::from_millis(options.shutdown_timeout_ms);
     let mut pipeline = Pipeline::new(&options, Arc::clone(&clock), len);
 
     let mut buffer: Vec<Event> = Vec::new();
@@ -329,7 +330,7 @@ fn run_worker(
                         &mut buffer,
                         buffer_hist,
                         max_batch_size,
-                        false,
+                        None,
                     );
                     buffer_since = None;
                 }
@@ -344,7 +345,7 @@ fn run_worker(
                         &mut buffer,
                         buffer_hist,
                         max_batch_size,
-                        false,
+                        None,
                     );
                     buffer_since = None;
                 }
@@ -354,27 +355,29 @@ fn run_worker(
                 // batches first, then the freshly buffered ones. Failures from
                 // either are held for the next cycle (so a single 503 leaves the
                 // event queued rather than being re-attempted in this same call).
-                pipeline.flush_retries(false);
+                pipeline.flush_retries(None);
                 send_buffer(
                     &mut pipeline,
                     &mut buffer,
                     buffer_hist,
                     max_batch_size,
-                    false,
+                    None,
                 );
                 buffer_since = None;
                 completion.signal();
             }
             Wake::Msg(Control::Shutdown(completion)) => {
-                // FIFO delivery means every pre-shutdown Capture has already been
-                // buffered, so one final attempt per batch is sufficient.
-                pipeline.flush_retries(true);
+                // Drain held retries then buffered events, one final attempt each,
+                // bounded by `shutdown_timeout`: once the deadline passes the rest
+                // is dropped so teardown can't hang on a slow/unreachable endpoint.
+                let deadline = clock.now() + shutdown_timeout;
+                pipeline.flush_retries(Some(deadline));
                 send_buffer(
                     &mut pipeline,
                     &mut buffer,
                     buffer_hist,
                     max_batch_size,
-                    true,
+                    Some(deadline),
                 );
                 completion.signal();
                 return;
@@ -389,7 +392,7 @@ fn run_worker(
                         &mut buffer,
                         buffer_hist,
                         max_batch_size,
-                        false,
+                        None,
                     );
                     buffer_since = None;
                 }
@@ -405,7 +408,7 @@ fn run_worker(
                         &mut buffer,
                         buffer_hist,
                         max_batch_size,
-                        false,
+                        None,
                     );
                     buffer_since = None;
                 }
@@ -413,15 +416,16 @@ fn run_worker(
             }
             Wake::Disconnected => {
                 // All client handles dropped without an explicit shutdown — best
-                // effort drain, then exit.
+                // effort drain bounded by `shutdown_timeout`, then exit.
+                let deadline = clock.now() + shutdown_timeout;
                 send_buffer(
                     &mut pipeline,
                     &mut buffer,
                     buffer_hist,
                     max_batch_size,
-                    true,
+                    Some(deadline),
                 );
-                pipeline.flush_retries(true);
+                pipeline.flush_retries(Some(deadline));
                 return;
             }
         }
@@ -429,16 +433,28 @@ fn run_worker(
 }
 
 /// Drain `buffer` into batches of at most `max_batch_size`, FIFO from the front,
-/// attempting each once. `final_attempt` warns-and-drops on transient failure
-/// (shutdown) instead of scheduling a retry.
+/// attempting each once. `deadline` is `Some` only on the shutdown/disconnect
+/// path: those attempts are final (warn-and-drop on transient failure instead of
+/// scheduling a retry), and once the deadline passes the rest of the buffer is
+/// dropped so teardown can't hang on a slow endpoint.
 fn send_buffer(
     pipeline: &mut Pipeline,
     buffer: &mut Vec<Event>,
     historical_migration: bool,
     max_batch_size: usize,
-    final_attempt: bool,
+    deadline: Option<Instant>,
 ) {
+    let final_attempt = deadline.is_some();
     while !buffer.is_empty() {
+        if deadline.is_some_and(|d| pipeline.clock.now() >= d) {
+            warn!(
+                "posthog-rs: shutdown timeout reached; dropping {} buffered event(s)",
+                buffer.len()
+            );
+            dec_len(&pipeline.len, buffer.len());
+            buffer.clear();
+            return;
+        }
         let take = buffer.len().min(max_batch_size);
         let chunk: Vec<Event> = buffer.drain(..take).collect();
         pipeline.send_batch(chunk, historical_migration, final_attempt);
@@ -621,12 +637,21 @@ impl Pipeline {
         }
     }
 
-    fn flush_retries(&mut self, final_attempt: bool) {
+    fn flush_retries(&mut self, deadline: Option<Instant>) {
+        // `Some` is the shutdown/disconnect path: attempts are final (drop on
+        // failure), and any batch still pending once the deadline passes is
+        // dropped rather than attempted.
+        let final_attempt = deadline.is_some();
         for batch in std::mem::take(&mut self.retries) {
-            self.attempt(batch, final_attempt);
-        }
-        if final_attempt && !self.retries.is_empty() {
-            warn!("posthog-rs: shutdown completed with undelivered events");
+            if deadline.is_some_and(|d| self.clock.now() >= d) {
+                warn!(
+                    "posthog-rs: shutdown timeout reached; dropping {} undelivered event(s)",
+                    batch.pending.len()
+                );
+                dec_len(&self.len, batch.pending.len());
+            } else {
+                self.attempt(batch, final_attempt);
+            }
         }
     }
 }
@@ -778,12 +803,21 @@ impl Pipeline {
         }
     }
 
-    fn flush_retries(&mut self, final_attempt: bool) {
+    fn flush_retries(&mut self, deadline: Option<Instant>) {
+        // `Some` is the shutdown/disconnect path: attempts are final (drop on
+        // failure), and any batch still pending once the deadline passes is
+        // dropped rather than attempted.
+        let final_attempt = deadline.is_some();
         for batch in std::mem::take(&mut self.retries) {
-            self.attempt(batch, final_attempt);
-        }
-        if final_attempt && !self.retries.is_empty() {
-            warn!("posthog-rs: shutdown completed with undelivered events");
+            if deadline.is_some_and(|d| self.clock.now() >= d) {
+                warn!(
+                    "posthog-rs: shutdown timeout reached; dropping {} undelivered event(s)",
+                    batch.count
+                );
+                dec_len(&self.len, batch.count);
+            } else {
+                self.attempt(batch, final_attempt);
+            }
         }
     }
 }
@@ -1031,5 +1065,32 @@ mod tests {
 
         mock.assert_hits(1);
         handle.shutdown_blocking();
+    }
+
+    #[test]
+    fn shutdown_timeout_drops_undelivered_without_blocking() {
+        // shutdown_timeout = 0: the drain deadline is already past when the worker
+        // handles Shutdown, so a buffered event is dropped (not sent) and teardown
+        // returns instead of blocking on the endpoint.
+        let server = MockServer::start();
+        let mock = ok_mock(&server);
+        let clock = ManualClock::new();
+        let handle = TransportHandle::spawn_with_clock(
+            options(server.base_url())
+                .shutdown_timeout_ms(0u64)
+                .build()
+                .unwrap(),
+            Arc::new(clock.clone()),
+        );
+
+        handle.enqueue(Event::new("Dropped", "user-1"), false);
+        handle.shutdown_blocking(); // deadline already past -> drop, do not send
+
+        mock.assert_hits(0);
+        assert_eq!(
+            handle.pending(),
+            0,
+            "dropped events leave nothing in flight"
+        );
     }
 }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -915,8 +915,9 @@ impl Pipeline {
 
 #[cfg(not(feature = "capture-v1"))]
 struct RetryBatch {
-    body: Vec<u8>,
-    encoding: Option<&'static str>,
+    /// Structured so `sent_at` can be re-stamped and the body re-serialized on
+    /// each attempt; `count` is the original event count for `len` accounting.
+    request: crate::event::BatchRequest,
     count: usize,
     attempt: u32,
     next_at: Instant,
@@ -955,34 +956,25 @@ impl Pipeline {
     fn build(&self, events: Vec<Event>, historical_migration: bool) -> Option<RetryBatch> {
         let defaults = self.options.capture_defaults();
         let count = events.len();
-        let payload = match super::v0_capture::build_batch_payload(
+        match super::v0_capture::build_batch_payload(
             events,
             self.options.api_key.clone(),
             historical_migration,
-            self.clock.now_utc(),
             &defaults,
             &self.options.before_send,
         ) {
-            Ok(Some(p)) => p,
-            Ok(None) => {
+            Some(request) => Some(RetryBatch {
+                request,
+                count,
+                attempt: 1,
+                next_at: self.clock.now(),
+            }),
+            None => {
                 // Every event dropped by before_send (terminal).
                 dec_len(&self.len, count);
-                return None;
+                None
             }
-            Err(e) => {
-                warn!("posthog-rs: dropping {count} event(s), serialization failed: {e}");
-                dec_len(&self.len, count);
-                return None;
-            }
-        };
-        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
-        Some(RetryBatch {
-            body,
-            encoding,
-            count,
-            attempt: 1,
-            next_at: self.clock.now(),
-        })
+        }
     }
 
     /// Sender-side: one blocking HTTP attempt. Terminal outcomes adjust `len` and
@@ -992,8 +984,22 @@ impl Pipeline {
         use super::retry::{v0_after_response, v0_after_transport_error, Step};
         use reqwest::header::{CONTENT_TYPE, USER_AGENT};
 
+        // Stamp sent_at at the actual send time, per attempt, so a retried batch
+        // carries when it was really sent (for server-side clock-skew correction).
+        batch.request.sent_at = self.clock.now_utc().to_rfc3339();
+        let (body, encoding) = match serde_json::to_string(&batch.request) {
+            Ok(json) => super::v0_capture::encode_body(&self.options, json),
+            Err(e) => {
+                warn!(
+                    "posthog-rs: dropping {} event(s), serialization failed: {e}",
+                    batch.count
+                );
+                dec_len(&self.len, batch.count);
+                return SendResult::Done;
+            }
+        };
         // v0 capture reads the compression hint from the query param, not the header.
-        let url = match batch.encoding {
+        let url = match encoding {
             Some(token) => format!("{}?compression={token}", self.url_base),
             None => self.url_base.clone(),
         };
@@ -1002,8 +1008,8 @@ impl Pipeline {
             .post(&url)
             .header(CONTENT_TYPE, "application/json")
             .header(USER_AGENT, get_default_user_agent())
-            .body(batch.body.clone());
-        if let Some(token) = batch.encoding {
+            .body(body);
+        if let Some(token) = encoding {
             request = request.header(reqwest::header::CONTENT_ENCODING, token);
         }
         let request = super::v0_capture::apply_extra_headers(&self.options, request);

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -1,20 +1,24 @@
 //! Runtime-independent event transport.
 //!
-//! A single background `std::thread` drains a channel, batches events, sends
-//! them with **blocking** reqwest, and retries transient failures on a schedule.
-//! Being a plain thread with a blocking client (never a tokio task) it works for
-//! the async client, the blocking client, and — in a later change — a
+//! A background **dispatcher** `std::thread` drains the control channel, batches
+//! events, and schedules retries; it hands each built batch to a small pool of
+//! **sender** threads that perform the **blocking** reqwest POST, so one slow or
+//! stalled endpoint can't head-of-line block draining. Senders report each
+//! outcome back to the dispatcher, which solely owns the retry queue and
+//! schedule. Being plain threads with a blocking client (never tokio tasks) this
+//! works for the async client, the blocking client, and — in a later change — a
 //! `std::panic` hook with no runtime present.
 //!
 //! `capture()` becomes a non-blocking enqueue (`Control::Capture`). `flush()` and
-//! `shutdown()` send a control message carrying a [`Completion`] the worker
-//! signals once the requested work is done, bridging the std-thread worker to
-//! either an async (`oneshot`) or blocking (`mpsc`) caller without putting a
+//! `shutdown()` send a control message carrying a [`Completion`] the dispatcher
+//! signals once the sends it dispatched have reported back, bridging the threads
+//! to either an async (`oneshot`) or blocking (`mpsc`) caller without putting a
 //! runtime in the worker.
 //!
-//! A [`Clock`] is injected into the worker so the interval timer, retry backoff,
-//! and v1 wire timestamps are deterministic in tests (a `ManualClock` plus a
-//! test-only `Tick` command drive the worker with virtual time — no real sleeps).
+//! A [`Clock`] is injected so the interval timer, retry backoff, and v1 wire
+//! timestamps are deterministic in tests (a `ManualClock` plus a test-only `Tick`
+//! command drive the dispatcher with virtual time; barriers wait on real sender
+//! outcomes — still no real sleeps).
 
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -23,6 +27,7 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
+use crossbeam_channel::{select, unbounded, Receiver, Sender};
 use tracing::warn;
 
 use super::ClientOptions;
@@ -92,7 +97,7 @@ impl Clock for SystemClock {
 /// Handle stored on the client. `&self` methods use the atomics/mutex so the
 /// client can stay a plain field while `capture`/`flush`/`shutdown` take `&self`.
 pub(crate) struct TransportHandle {
-    tx: mpsc::Sender<Control>,
+    tx: Sender<Control>,
     /// Pending `Capture` events not yet pulled by the worker. Gates the bounded queue.
     len: Arc<AtomicUsize>,
     /// Set once `shutdown`/`Drop` begins; blocks further enqueue and control sends.
@@ -112,7 +117,7 @@ impl TransportHandle {
     }
 
     fn spawn_with_clock(options: ClientOptions, clock: Arc<dyn Clock>) -> Self {
-        let (tx, rx) = mpsc::channel::<Control>();
+        let (tx, rx) = unbounded::<Control>();
         let len = Arc::new(AtomicUsize::new(0));
         let max_queue_size = options.max_queue_size;
         let worker_len = len.clone();
@@ -273,15 +278,328 @@ fn compute_wait(
     deadline.map(|d| d.saturating_duration_since(now))
 }
 
-enum Wake {
-    Msg(Control),
-    Timeout,
-    Disconnected,
+/// Number of concurrent sender threads. Telemetry sends are network-bound, so we
+/// only need enough concurrency that one slow or stalled endpoint can't
+/// head-of-line block the rest; capped so a many-core host doesn't oversubscribe.
+fn sender_pool_size() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().min(4))
+        .unwrap_or(2)
+}
+
+/// A built batch handed to a sender thread for one blocking HTTP attempt.
+struct SendJob {
+    batch: RetryBatch,
+    final_attempt: bool,
+}
+
+/// What a sender reports back after one attempt. Terminal outcomes (delivered or
+/// dropped) have already adjusted `len`; `Retry` carries the batch back so the
+/// dispatcher can reschedule it at `batch.next_at`.
+enum SendResult {
+    Done,
+    Retry(RetryBatch),
+}
+
+/// Sender thread body: pull built batches, POST them (blocking), report outcomes.
+fn run_sender(pipeline: Arc<Pipeline>, jobs: Receiver<SendJob>, outcomes: Sender<SendResult>) {
+    while let Ok(job) = jobs.recv() {
+        let result = pipeline.attempt(job.batch, job.final_attempt);
+        if outcomes.send(result).is_err() {
+            return; // dispatcher gone
+        }
+    }
+}
+
+/// Owns the buffer, retry queue, and schedule on a single thread (so neither
+/// needs a lock) and fans batch sends out to the pool. A send never blocks the
+/// dispatcher; `flush`/`shutdown`/`Tick` are barriers that complete once the
+/// sends they dispatched report back (`in_flight` returns to zero). While a
+/// barrier is pending, no new threshold/interval/retry sends are started, so
+/// `in_flight` can drain to zero.
+struct Dispatcher {
+    pipeline: Arc<Pipeline>,
+    jobs: Sender<SendJob>,
+    clock: Arc<dyn Clock>,
+    flush_at: usize,
+    max_batch_size: usize,
+    flush_interval: Duration,
+    shutdown_timeout: Duration,
+    buffer: Vec<Event>,
+    buffer_hist: bool,
+    buffer_since: Option<Instant>,
+    retries: VecDeque<RetryBatch>,
+    /// Batches dispatched to the pool but not yet reported back.
+    in_flight: usize,
+    /// Flush/Tick completions awaiting `in_flight == 0`.
+    flush_waiters: Vec<Completion>,
+    /// Set once shutdown/disconnect begins; carries the drain deadline.
+    shutdown_deadline: Option<Instant>,
+    shutdown_completion: Option<Completion>,
+    /// Control channel hung up (all clients dropped without an explicit shutdown).
+    disconnected: bool,
+    done: bool,
+}
+
+impl Dispatcher {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        pipeline: Arc<Pipeline>,
+        jobs: Sender<SendJob>,
+        clock: Arc<dyn Clock>,
+        flush_at: usize,
+        max_batch_size: usize,
+        flush_interval: Duration,
+        shutdown_timeout: Duration,
+    ) -> Self {
+        Self {
+            pipeline,
+            jobs,
+            clock,
+            flush_at,
+            max_batch_size,
+            flush_interval,
+            shutdown_timeout,
+            buffer: Vec::new(),
+            buffer_hist: false,
+            buffer_since: None,
+            retries: VecDeque::new(),
+            in_flight: 0,
+            flush_waiters: Vec::new(),
+            shutdown_deadline: None,
+            shutdown_completion: None,
+            disconnected: false,
+            done: false,
+        }
+    }
+
+    /// While draining, no new threshold/interval/retry sends are started so
+    /// `in_flight` can fall to zero and the pending barrier(s) can complete.
+    fn draining(&self) -> bool {
+        !self.flush_waiters.is_empty() || self.shutdown_deadline.is_some() || self.disconnected
+    }
+
+    /// Time until the next wakeup. `None` means block on the channels (idle, or
+    /// draining a flush — bounded by the per-attempt request timeout).
+    fn wait(&self) -> Option<Duration> {
+        if let Some(deadline) = self.shutdown_deadline {
+            return Some(deadline.saturating_duration_since(self.clock.now()));
+        }
+        if !self.flush_waiters.is_empty() {
+            return None;
+        }
+        compute_wait(
+            self.clock.now(),
+            self.buffer_since,
+            self.flush_interval,
+            self.retries.iter().map(|b| b.next_at).min(),
+        )
+    }
+
+    fn dispatch(&mut self, batch: RetryBatch, final_attempt: bool) {
+        match self.jobs.send(SendJob {
+            batch,
+            final_attempt,
+        }) {
+            Ok(()) => self.in_flight += 1,
+            // Pool gone (only at teardown): account for the lost events.
+            Err(crossbeam_channel::SendError(job)) => self.pipeline.drop_batch(job.batch),
+        }
+    }
+
+    /// Drain the buffer into batches of at most `max_batch_size`, dispatching each.
+    fn dispatch_buffer(&mut self, final_attempt: bool) {
+        while !self.buffer.is_empty() {
+            let take = self.buffer.len().min(self.max_batch_size);
+            let chunk: Vec<Event> = self.buffer.drain(..take).collect();
+            if let Some(batch) = self.pipeline.build(chunk, self.buffer_hist) {
+                self.dispatch(batch, final_attempt);
+            }
+        }
+        self.buffer_since = None;
+    }
+
+    fn dispatch_all_retries(&mut self, final_attempt: bool) {
+        for batch in std::mem::take(&mut self.retries) {
+            self.dispatch(batch, final_attempt);
+        }
+    }
+
+    fn dispatch_due_retries(&mut self) {
+        let now = self.clock.now();
+        for batch in std::mem::take(&mut self.retries) {
+            if now >= batch.next_at {
+                self.dispatch(batch, false);
+            } else {
+                self.retries.push_back(batch);
+            }
+        }
+    }
+
+    fn drop_buffer(&mut self) {
+        if !self.buffer.is_empty() {
+            warn!(
+                "posthog-rs: shutdown timeout reached; dropping {} buffered event(s)",
+                self.buffer.len()
+            );
+            dec_len(&self.pipeline.len, self.buffer.len());
+            self.buffer.clear();
+        }
+        self.buffer_since = None;
+    }
+
+    fn drop_all_retries(&mut self) {
+        for batch in std::mem::take(&mut self.retries) {
+            self.pipeline.drop_batch(batch);
+        }
+    }
+
+    /// Register a flush/tick completion, or signal it now if nothing is in flight.
+    fn register_barrier(&mut self, completion: Completion) {
+        if self.in_flight == 0 {
+            completion.signal();
+        } else {
+            self.flush_waiters.push(completion);
+        }
+    }
+
+    fn on_control(&mut self, msg: Result<Control, crossbeam_channel::RecvError>) {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(_) => return self.on_disconnect(),
+        };
+        match msg {
+            Control::Capture {
+                event,
+                historical_migration,
+            } => {
+                // `len` is not decremented here: the in-flight counter spans the
+                // whole lifecycle (channel + buffer + sends + retries) and is
+                // adjusted by the pipeline once a batch is delivered or dropped.
+                // Keep each batch homogeneous in historical_migration: flush the
+                // current buffer before mixing in an event with a different flag.
+                if !self.buffer.is_empty() && historical_migration != self.buffer_hist {
+                    self.dispatch_buffer(false);
+                }
+                if self.buffer.is_empty() {
+                    self.buffer_hist = historical_migration;
+                    self.buffer_since = Some(self.clock.now());
+                }
+                self.buffer.push(*event);
+                if !self.draining() && self.buffer.len() >= self.flush_at {
+                    self.dispatch_buffer(false);
+                }
+            }
+            Control::Flush(completion) => {
+                // One attempt per pending batch (held retries + buffered events);
+                // failures are held for a future cycle. Completes once those sends
+                // report back.
+                self.dispatch_all_retries(false);
+                self.dispatch_buffer(false);
+                self.register_barrier(completion);
+            }
+            Control::Shutdown(completion) => {
+                let deadline = self.clock.now() + self.shutdown_timeout;
+                if self.clock.now() >= deadline {
+                    // Zero/elapsed grace: drop without attempting.
+                    self.drop_all_retries();
+                    self.drop_buffer();
+                } else {
+                    self.dispatch_all_retries(true);
+                    self.dispatch_buffer(true);
+                }
+                if self.in_flight == 0 {
+                    completion.signal();
+                    self.done = true;
+                } else {
+                    self.shutdown_deadline = Some(deadline);
+                    self.shutdown_completion = Some(completion);
+                }
+            }
+            #[cfg(test)]
+            Control::Tick(completion) => {
+                if !self.draining() {
+                    if self
+                        .buffer_since
+                        .is_some_and(|s| self.clock.now().duration_since(s) >= self.flush_interval)
+                    {
+                        self.dispatch_buffer(false);
+                    }
+                    self.dispatch_due_retries();
+                }
+                self.register_barrier(completion);
+            }
+        }
+    }
+
+    fn on_outcome(&mut self, res: Result<SendResult, crossbeam_channel::RecvError>) {
+        let Ok(result) = res else {
+            return;
+        };
+        self.in_flight = self.in_flight.saturating_sub(1);
+        if let SendResult::Retry(batch) = result {
+            if self.shutdown_deadline.is_some() {
+                // Tearing down: don't re-queue a failed final attempt.
+                self.pipeline.drop_batch(batch);
+            } else {
+                self.retries.push_back(batch);
+            }
+        }
+        if self.in_flight == 0 {
+            for c in self.flush_waiters.drain(..) {
+                c.signal();
+            }
+            if self.shutdown_deadline.is_some() {
+                if let Some(c) = self.shutdown_completion.take() {
+                    c.signal();
+                }
+                self.done = true;
+            }
+        }
+    }
+
+    fn on_timeout(&mut self) {
+        if self
+            .shutdown_deadline
+            .is_some_and(|d| self.clock.now() >= d)
+        {
+            // Deadline hit with sends still outstanding: abandon them and exit.
+            // The detached senders finish their in-flight POST and then stop.
+            if let Some(c) = self.shutdown_completion.take() {
+                c.signal();
+            }
+            self.done = true;
+            return;
+        }
+        if !self.draining() {
+            if self
+                .buffer_since
+                .is_some_and(|s| self.clock.now().duration_since(s) >= self.flush_interval)
+            {
+                self.dispatch_buffer(false);
+            }
+            self.dispatch_due_retries();
+        }
+    }
+
+    fn on_disconnect(&mut self) {
+        // All clients dropped without an explicit shutdown. Best-effort final
+        // drain bounded by `shutdown_timeout`, then exit.
+        self.disconnected = true;
+        let deadline = self.clock.now() + self.shutdown_timeout;
+        self.dispatch_all_retries(true);
+        self.dispatch_buffer(true);
+        if self.in_flight == 0 {
+            self.done = true;
+        } else {
+            self.shutdown_deadline = Some(deadline);
+        }
+    }
 }
 
 fn run_worker(
     options: ClientOptions,
-    rx: mpsc::Receiver<Control>,
+    control: Receiver<Control>,
     len: Arc<AtomicUsize>,
     clock: Arc<dyn Clock>,
 ) {
@@ -289,176 +607,64 @@ fn run_worker(
     let max_batch_size = options.max_batch_size.max(1);
     let flush_interval = Duration::from_millis(options.flush_interval_ms);
     let shutdown_timeout = Duration::from_millis(options.shutdown_timeout_ms);
-    let mut pipeline = Pipeline::new(&options, Arc::clone(&clock), len);
+    let pipeline = Arc::new(Pipeline::new(&options, Arc::clone(&clock), len));
 
-    let mut buffer: Vec<Event> = Vec::new();
-    let mut buffer_hist = false;
-    let mut buffer_since: Option<Instant> = None;
+    // Sender pool: the blocking POST runs here, off the dispatcher, so a slow or
+    // stalled endpoint can't head-of-line block draining. Senders are detached;
+    // they exit when the dispatcher drops `job_tx` at teardown.
+    let (job_tx, job_rx) = unbounded::<SendJob>();
+    let (outcome_tx, outcome_rx) = unbounded::<SendResult>();
+    for i in 0..sender_pool_size() {
+        let pipeline = Arc::clone(&pipeline);
+        let jobs = job_rx.clone();
+        let outcomes = outcome_tx.clone();
+        let _ = thread::Builder::new()
+            .name(format!("posthog-sender-{i}"))
+            .spawn(move || run_sender(pipeline, jobs, outcomes));
+    }
+    drop(job_rx);
+    drop(outcome_tx);
 
-    loop {
-        let wait = compute_wait(
-            clock.now(),
-            buffer_since,
-            flush_interval,
-            pipeline.earliest_retry(),
-        );
-        let wake = match wait {
-            None => match rx.recv() {
-                Ok(msg) => Wake::Msg(msg),
-                Err(_) => Wake::Disconnected,
-            },
-            Some(timeout) => match rx.recv_timeout(timeout) {
-                Ok(msg) => Wake::Msg(msg),
-                Err(mpsc::RecvTimeoutError::Timeout) => Wake::Timeout,
-                Err(mpsc::RecvTimeoutError::Disconnected) => Wake::Disconnected,
-            },
-        };
+    let mut dispatcher = Dispatcher::new(
+        pipeline,
+        job_tx,
+        clock,
+        flush_at,
+        max_batch_size,
+        flush_interval,
+        shutdown_timeout,
+    );
 
-        match wake {
-            Wake::Msg(Control::Capture {
-                event,
-                historical_migration,
-            }) => {
-                // `len` is not decremented here: the in-flight counter spans the
-                // whole worker lifecycle (channel + buffer + retries) and is
-                // decremented by the pipeline once a batch is delivered or dropped.
-                // Keep each batch homogeneous in historical_migration: flush the
-                // current buffer before mixing in an event with a different flag.
-                if !buffer.is_empty() && historical_migration != buffer_hist {
-                    send_buffer(
-                        &mut pipeline,
-                        &mut buffer,
-                        buffer_hist,
-                        max_batch_size,
-                        None,
-                    );
-                    buffer_since = None;
-                }
-                if buffer.is_empty() {
-                    buffer_hist = historical_migration;
-                    buffer_since = Some(clock.now());
-                }
-                buffer.push(*event);
-                if buffer.len() >= flush_at {
-                    send_buffer(
-                        &mut pipeline,
-                        &mut buffer,
-                        buffer_hist,
-                        max_batch_size,
-                        None,
-                    );
-                    buffer_since = None;
-                }
+    while !dispatcher.done {
+        let wait = dispatcher.wait();
+        if dispatcher.disconnected {
+            // Control hung up; only sender outcomes remain to drain.
+            match wait {
+                Some(dur) => select! {
+                    recv(outcome_rx) -> r => dispatcher.on_outcome(r),
+                    default(dur) => dispatcher.on_timeout(),
+                },
+                None => match outcome_rx.recv() {
+                    Ok(r) => dispatcher.on_outcome(Ok(r)),
+                    Err(_) => dispatcher.done = true,
+                },
             }
-            Wake::Msg(Control::Flush(completion)) => {
-                // One delivery attempt per pending batch: retry the already-held
-                // batches first, then the freshly buffered ones. Failures from
-                // either are held for the next cycle (so a single 503 leaves the
-                // event queued rather than being re-attempted in this same call).
-                pipeline.flush_retries(None);
-                send_buffer(
-                    &mut pipeline,
-                    &mut buffer,
-                    buffer_hist,
-                    max_batch_size,
-                    None,
-                );
-                buffer_since = None;
-                completion.signal();
-            }
-            Wake::Msg(Control::Shutdown(completion)) => {
-                // Drain held retries then buffered events, one final attempt each,
-                // bounded by `shutdown_timeout`: once the deadline passes the rest
-                // is dropped so teardown can't hang on a slow/unreachable endpoint.
-                let deadline = clock.now() + shutdown_timeout;
-                pipeline.flush_retries(Some(deadline));
-                send_buffer(
-                    &mut pipeline,
-                    &mut buffer,
-                    buffer_hist,
-                    max_batch_size,
-                    Some(deadline),
-                );
-                completion.signal();
-                return;
-            }
-            #[cfg(test)]
-            Wake::Msg(Control::Tick(completion)) => {
-                if buffer_since
-                    .is_some_and(|since| clock.now().duration_since(since) >= flush_interval)
-                {
-                    send_buffer(
-                        &mut pipeline,
-                        &mut buffer,
-                        buffer_hist,
-                        max_batch_size,
-                        None,
-                    );
-                    buffer_since = None;
-                }
-                pipeline.attempt_due();
-                completion.signal();
-            }
-            Wake::Timeout => {
-                if buffer_since
-                    .is_some_and(|since| clock.now().duration_since(since) >= flush_interval)
-                {
-                    send_buffer(
-                        &mut pipeline,
-                        &mut buffer,
-                        buffer_hist,
-                        max_batch_size,
-                        None,
-                    );
-                    buffer_since = None;
-                }
-                pipeline.attempt_due();
-            }
-            Wake::Disconnected => {
-                // All client handles dropped without an explicit shutdown — best
-                // effort drain bounded by `shutdown_timeout`, then exit.
-                let deadline = clock.now() + shutdown_timeout;
-                send_buffer(
-                    &mut pipeline,
-                    &mut buffer,
-                    buffer_hist,
-                    max_batch_size,
-                    Some(deadline),
-                );
-                pipeline.flush_retries(Some(deadline));
-                return;
+        } else {
+            match wait {
+                Some(dur) => select! {
+                    recv(control) -> m => dispatcher.on_control(m),
+                    recv(outcome_rx) -> r => dispatcher.on_outcome(r),
+                    default(dur) => dispatcher.on_timeout(),
+                },
+                None => select! {
+                    recv(control) -> m => dispatcher.on_control(m),
+                    recv(outcome_rx) -> r => dispatcher.on_outcome(r),
+                },
             }
         }
     }
-}
-
-/// Drain `buffer` into batches of at most `max_batch_size`, FIFO from the front,
-/// attempting each once. `deadline` is `Some` only on the shutdown/disconnect
-/// path: those attempts are final (warn-and-drop on transient failure instead of
-/// scheduling a retry), and once the deadline passes the rest of the buffer is
-/// dropped so teardown can't hang on a slow endpoint.
-fn send_buffer(
-    pipeline: &mut Pipeline,
-    buffer: &mut Vec<Event>,
-    historical_migration: bool,
-    max_batch_size: usize,
-    deadline: Option<Instant>,
-) {
-    let final_attempt = deadline.is_some();
-    while !buffer.is_empty() {
-        if deadline.is_some_and(|d| pipeline.clock.now() >= d) {
-            warn!(
-                "posthog-rs: shutdown timeout reached; dropping {} buffered event(s)",
-                buffer.len()
-            );
-            dec_len(&pipeline.len, buffer.len());
-            buffer.clear();
-            return;
-        }
-        let take = buffer.len().min(max_batch_size);
-        let chunk: Vec<Event> = buffer.drain(..take).collect();
-        pipeline.send_batch(chunk, historical_migration, final_attempt);
-    }
+    // `dispatcher` (and its `job_tx`) drops here, so the pool's senders see the
+    // job channel close and exit after any in-flight POST completes.
 }
 
 // ===========================================================================
@@ -488,7 +694,6 @@ struct Pipeline {
     url: String,
     clock: Arc<dyn Clock>,
     len: Arc<AtomicUsize>,
-    retries: VecDeque<RetryBatch>,
 }
 
 #[cfg(feature = "capture-v1")]
@@ -507,11 +712,12 @@ impl Pipeline {
             url,
             clock,
             len,
-            retries: VecDeque::new(),
         }
     }
 
-    fn send_batch(&mut self, events: Vec<Event>, historical_migration: bool, final_attempt: bool) {
+    /// Dispatcher-side: apply defaults + before_send and build the wire batch.
+    /// Returns `None` when every event was dropped by before_send.
+    fn build(&self, events: Vec<Event>, historical_migration: bool) -> Option<RetryBatch> {
         use super::common::{apply_before_send_hooks, apply_capture_defaults};
 
         let defaults = self.options.capture_defaults();
@@ -526,24 +732,24 @@ impl Pipeline {
         // Events dropped by before_send are terminal.
         dec_len(&self.len, original - processed.len());
         if processed.is_empty() {
-            return;
+            return None;
         }
-        let now = self.clock.now();
         let pending =
             super::v1_capture::build_events_at(&processed, &defaults, self.clock.now_utc());
-        let batch = RetryBatch {
+        Some(RetryBatch {
             pending,
             request_id: Uuid::now_v7(),
             created_at: self.clock.now_utc().to_rfc3339(),
             final_results: HashMap::new(),
             historical_migration,
             attempt: 1,
-            next_at: now,
-        };
-        self.attempt(batch, final_attempt);
+            next_at: self.clock.now(),
+        })
     }
 
-    fn attempt(&mut self, mut batch: RetryBatch, final_attempt: bool) {
+    /// Sender-side: one blocking HTTP attempt. Terminal outcomes adjust `len` and
+    /// return `Done`; a transient failure returns `Retry` with `next_at` set.
+    fn attempt(&self, mut batch: RetryBatch, final_attempt: bool) -> SendResult {
         use super::v1_capture::{self, Step};
         use crate::event_v1::V1BatchRequestRef;
 
@@ -560,7 +766,7 @@ impl Pipeline {
                     batch.pending.len()
                 );
                 dec_len(&self.len, batch.pending.len());
-                return;
+                return SendResult::Done;
             }
         };
         let mut headers = v1_capture::build_headers_at(
@@ -601,10 +807,11 @@ impl Pipeline {
         dec_len(&self.len, count - batch.pending.len());
 
         match step {
-            Step::Done => {}
+            Step::Done => SendResult::Done,
             Step::Fail(e) => {
                 warn!("posthog-rs: dropping {} event(s): {e}", batch.pending.len());
                 dec_len(&self.len, batch.pending.len());
+                SendResult::Done
             }
             Step::Backoff(delay) => {
                 if final_attempt {
@@ -613,46 +820,19 @@ impl Pipeline {
                         batch.pending.len()
                     );
                     dec_len(&self.len, batch.pending.len());
+                    SendResult::Done
                 } else {
                     batch.attempt += 1;
                     batch.next_at = self.clock.now() + delay;
-                    self.retries.push_back(batch);
+                    SendResult::Retry(batch)
                 }
             }
         }
     }
 
-    fn earliest_retry(&self) -> Option<Instant> {
-        self.retries.iter().map(|b| b.next_at).min()
-    }
-
-    fn attempt_due(&mut self) {
-        let now = self.clock.now();
-        for batch in std::mem::take(&mut self.retries) {
-            if now >= batch.next_at {
-                self.attempt(batch, false);
-            } else {
-                self.retries.push_back(batch);
-            }
-        }
-    }
-
-    fn flush_retries(&mut self, deadline: Option<Instant>) {
-        // `Some` is the shutdown/disconnect path: attempts are final (drop on
-        // failure), and any batch still pending once the deadline passes is
-        // dropped rather than attempted.
-        let final_attempt = deadline.is_some();
-        for batch in std::mem::take(&mut self.retries) {
-            if deadline.is_some_and(|d| self.clock.now() >= d) {
-                warn!(
-                    "posthog-rs: shutdown timeout reached; dropping {} undelivered event(s)",
-                    batch.pending.len()
-                );
-                dec_len(&self.len, batch.pending.len());
-            } else {
-                self.attempt(batch, final_attempt);
-            }
-        }
+    /// Account for a built-but-unsent batch (shutdown deadline / pool gone).
+    fn drop_batch(&self, batch: RetryBatch) {
+        dec_len(&self.len, batch.pending.len());
     }
 }
 
@@ -676,7 +856,6 @@ struct Pipeline {
     url_base: String,
     clock: Arc<dyn Clock>,
     len: Arc<AtomicUsize>,
-    retries: VecDeque<RetryBatch>,
 }
 
 #[cfg(not(feature = "capture-v1"))]
@@ -695,11 +874,12 @@ impl Pipeline {
             url_base,
             clock,
             len,
-            retries: VecDeque::new(),
         }
     }
 
-    fn send_batch(&mut self, events: Vec<Event>, historical_migration: bool, final_attempt: bool) {
+    /// Dispatcher-side: apply defaults + before_send and serialize the wire body.
+    /// Returns `None` when every event was dropped by before_send.
+    fn build(&self, events: Vec<Event>, historical_migration: bool) -> Option<RetryBatch> {
         let defaults = self.options.capture_defaults();
         let count = events.len();
         let payload = match super::v0_capture::build_batch_payload(
@@ -714,26 +894,27 @@ impl Pipeline {
             Ok(None) => {
                 // Every event dropped by before_send (terminal).
                 dec_len(&self.len, count);
-                return;
+                return None;
             }
             Err(e) => {
                 warn!("posthog-rs: dropping {count} event(s), serialization failed: {e}");
                 dec_len(&self.len, count);
-                return;
+                return None;
             }
         };
         let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
-        let batch = RetryBatch {
+        Some(RetryBatch {
             body,
             encoding,
             count,
             attempt: 1,
             next_at: self.clock.now(),
-        };
-        self.attempt(batch, final_attempt);
+        })
     }
 
-    fn attempt(&mut self, mut batch: RetryBatch, final_attempt: bool) {
+    /// Sender-side: one blocking HTTP attempt. Terminal outcomes adjust `len` and
+    /// return `Done`; a transient failure returns `Retry` with `next_at` set.
+    fn attempt(&self, mut batch: RetryBatch, final_attempt: bool) -> SendResult {
         use super::get_default_user_agent;
         use super::retry::{v0_after_response, v0_after_transport_error, Step};
         use reqwest::header::{CONTENT_TYPE, USER_AGENT};
@@ -767,10 +948,14 @@ impl Pipeline {
         };
 
         match step {
-            Step::Done => dec_len(&self.len, batch.count),
+            Step::Done => {
+                dec_len(&self.len, batch.count);
+                SendResult::Done
+            }
             Step::Fail(e) => {
                 warn!("posthog-rs: dropping {} event(s): {e}", batch.count);
                 dec_len(&self.len, batch.count);
+                SendResult::Done
             }
             Step::Backoff(delay) => {
                 if final_attempt {
@@ -779,46 +964,19 @@ impl Pipeline {
                         batch.count
                     );
                     dec_len(&self.len, batch.count);
+                    SendResult::Done
                 } else {
                     batch.attempt += 1;
                     batch.next_at = self.clock.now() + delay;
-                    self.retries.push_back(batch);
+                    SendResult::Retry(batch)
                 }
             }
         }
     }
 
-    fn earliest_retry(&self) -> Option<Instant> {
-        self.retries.iter().map(|b| b.next_at).min()
-    }
-
-    fn attempt_due(&mut self) {
-        let now = self.clock.now();
-        for batch in std::mem::take(&mut self.retries) {
-            if now >= batch.next_at {
-                self.attempt(batch, false);
-            } else {
-                self.retries.push_back(batch);
-            }
-        }
-    }
-
-    fn flush_retries(&mut self, deadline: Option<Instant>) {
-        // `Some` is the shutdown/disconnect path: attempts are final (drop on
-        // failure), and any batch still pending once the deadline passes is
-        // dropped rather than attempted.
-        let final_attempt = deadline.is_some();
-        for batch in std::mem::take(&mut self.retries) {
-            if deadline.is_some_and(|d| self.clock.now() >= d) {
-                warn!(
-                    "posthog-rs: shutdown timeout reached; dropping {} undelivered event(s)",
-                    batch.count
-                );
-                dec_len(&self.len, batch.count);
-            } else {
-                self.attempt(batch, final_attempt);
-            }
-        }
+    /// Account for a built-but-unsent batch (shutdown deadline / pool gone).
+    fn drop_batch(&self, batch: RetryBatch) {
+        dec_len(&self.len, batch.count);
     }
 }
 
@@ -1092,5 +1250,31 @@ mod tests {
             0,
             "dropped events leave nothing in flight"
         );
+    }
+
+    #[test]
+    fn flush_waits_for_every_batch_across_the_pool() {
+        // max_batch_size = 1 forces one batch per event, so a single flush fans
+        // several sends out to the pool concurrently. The flush barrier must wait
+        // for *all* of them to report back before returning.
+        let server = MockServer::start();
+        let mock = ok_mock(&server);
+        let clock = ManualClock::new();
+        let handle = TransportHandle::spawn_with_clock(
+            options(server.base_url())
+                .max_batch_size(1usize)
+                .build()
+                .unwrap(),
+            Arc::new(clock.clone()),
+        );
+
+        for _ in 0..5 {
+            handle.enqueue(Event::new("E", "user-1"), false);
+        }
+        handle.flush_blocking();
+
+        mock.assert_hits(5);
+        assert_eq!(handle.pending(), 0, "all batches delivered after flush");
+        handle.shutdown_blocking();
     }
 }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -318,8 +318,15 @@ fn run_sender(
             continue;
         }
         let result = pipeline.attempt(job.batch, job.final_attempt);
-        if outcomes.send(result).is_err() {
-            return; // dispatcher gone
+        if let Err(crossbeam_channel::SendError(undelivered)) = outcomes.send(result) {
+            // Dispatcher gone (e.g. the shutdown deadline already fired). A `Retry`
+            // result still owns its events — `attempt` only decremented terminal
+            // outcomes — so account for them before stopping, or `pending_events`
+            // would leak.
+            if let SendResult::Retry(batch) = undelivered {
+                pipeline.drop_batch(batch);
+            }
+            return;
         }
     }
 }
@@ -344,6 +351,9 @@ struct Dispatcher {
     buffer: Vec<Event>,
     buffer_hist: bool,
     buffer_since: Option<Instant>,
+    /// Captures received while a barrier is pending; replayed once it clears so a
+    /// flush only waits for work queued before it.
+    deferred: Vec<(Box<Event>, bool)>,
     retries: VecDeque<RetryBatch>,
     /// Batches dispatched to the pool but not yet reported back.
     in_flight: usize,
@@ -381,6 +391,7 @@ impl Dispatcher {
             buffer: Vec::new(),
             buffer_hist: false,
             buffer_since: None,
+            deferred: Vec::new(),
             retries: VecDeque::new(),
             in_flight: 0,
             flush_waiters: Vec::new(),
@@ -472,6 +483,39 @@ impl Dispatcher {
         }
     }
 
+    /// Buffer one capture: flush first to keep each batch homogeneous in
+    /// historical_migration, then dispatch on the size threshold. Only reached
+    /// outside a barrier (captures arriving during one are deferred).
+    fn buffer_capture(&mut self, event: Box<Event>, historical_migration: bool) {
+        if !self.buffer.is_empty() && historical_migration != self.buffer_hist {
+            self.dispatch_buffer(false);
+        }
+        if self.buffer.is_empty() {
+            self.buffer_hist = historical_migration;
+            self.buffer_since = Some(self.clock.now());
+        }
+        self.buffer.push(*event);
+        if self.buffer.len() >= self.flush_at {
+            self.dispatch_buffer(false);
+        }
+    }
+
+    /// Replay captures held while a barrier was pending.
+    fn replay_deferred(&mut self) {
+        for (event, historical_migration) in std::mem::take(&mut self.deferred) {
+            self.buffer_capture(event, historical_migration);
+        }
+    }
+
+    /// Drop held captures (zero-grace shutdown), accounting for them in `len`.
+    fn drop_deferred(&mut self) {
+        let n = self.deferred.len();
+        if n > 0 {
+            self.deferred.clear();
+            dec_len(&self.pipeline.len, n);
+        }
+    }
+
     /// Register a flush/tick completion, or signal it now if nothing is in flight.
     fn register_barrier(&mut self, completion: Completion) {
         if self.in_flight == 0 {
@@ -494,18 +538,13 @@ impl Dispatcher {
                 // `len` is not decremented here: the in-flight counter spans the
                 // whole lifecycle (channel + buffer + sends + retries) and is
                 // adjusted by the pipeline once a batch is delivered or dropped.
-                // Keep each batch homogeneous in historical_migration: flush the
-                // current buffer before mixing in an event with a different flag.
-                if !self.buffer.is_empty() && historical_migration != self.buffer_hist {
-                    self.dispatch_buffer(false);
-                }
-                if self.buffer.is_empty() {
-                    self.buffer_hist = historical_migration;
-                    self.buffer_since = Some(self.clock.now());
-                }
-                self.buffer.push(*event);
-                if !self.draining() && self.buffer.len() >= self.flush_at {
-                    self.dispatch_buffer(false);
+                // While a barrier is pending, hold the capture so the barrier only
+                // waits for work queued before it; it's replayed once the barrier
+                // clears (and folded back in on shutdown).
+                if self.draining() {
+                    self.deferred.push((event, historical_migration));
+                } else {
+                    self.buffer_capture(event, historical_migration);
                 }
             }
             Control::Flush(completion) => {
@@ -520,9 +559,13 @@ impl Dispatcher {
                 let deadline = self.clock.now() + self.shutdown_timeout;
                 if self.clock.now() >= deadline {
                     // Zero/elapsed grace: drop without attempting.
+                    self.drop_deferred();
                     self.drop_all_retries();
                     self.drop_buffer();
                 } else {
+                    // Fold captures held during an in-progress flush back in so
+                    // they get a final attempt too.
+                    self.replay_deferred();
                     self.dispatch_all_retries(true);
                     self.dispatch_buffer(true);
                 }
@@ -575,6 +618,9 @@ impl Dispatcher {
                     c.signal();
                 }
                 self.done = true;
+            } else {
+                // Flush barrier cleared; process captures held during it.
+                self.replay_deferred();
             }
         }
     }
@@ -610,6 +656,7 @@ impl Dispatcher {
         // drain bounded by `shutdown_timeout`, then exit.
         self.disconnected = true;
         let deadline = self.clock.now() + self.shutdown_timeout;
+        self.replay_deferred();
         self.dispatch_all_retries(true);
         self.dispatch_buffer(true);
         if self.in_flight == 0 {
@@ -1339,6 +1386,51 @@ mod tests {
             len.load(Ordering::Acquire),
             0,
             "abandoned batch is dropped from in-flight, not sent"
+        );
+    }
+
+    #[test]
+    fn sender_accounts_retry_when_dispatcher_is_gone() {
+        // If the dispatcher exited (shutdown deadline) while a non-final attempt is
+        // in flight and it then fails transiently, the sender can't report the
+        // Retry — it must still drop the batch so pending_events doesn't leak.
+        let server = MockServer::start();
+        let fail = server.mock(|when, then| {
+            when.method(POST);
+            then.status(503);
+        });
+        let len = Arc::new(AtomicUsize::new(1));
+        let clock: Arc<dyn Clock> = Arc::new(ManualClock::new());
+        let pipeline = Arc::new(Pipeline::new(
+            &options(server.base_url())
+                .max_capture_attempts(5u32)
+                .build()
+                .unwrap(),
+            Arc::clone(&clock),
+            Arc::clone(&len),
+        ));
+        let batch = pipeline
+            .build(vec![Event::new("E", "user-1")], false)
+            .expect("batch built");
+
+        let (job_tx, job_rx) = unbounded::<SendJob>();
+        let (out_tx, out_rx) = unbounded::<SendResult>();
+        job_tx
+            .send(SendJob {
+                batch,
+                final_attempt: false,
+            })
+            .unwrap();
+        drop(job_tx);
+        drop(out_rx); // dispatcher gone: the outcome send fails
+
+        run_sender(pipeline, job_rx, out_tx, Arc::new(AtomicBool::new(false)));
+
+        fail.assert_hits(1); // the transient attempt happened...
+        assert_eq!(
+            len.load(Ordering::Acquire),
+            0,
+            "...and its retry batch was accounted, not leaked"
         );
     }
 }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -1,0 +1,904 @@
+//! Runtime-independent event transport.
+//!
+//! A single background `std::thread` drains a channel, batches events, sends
+//! them with **blocking** reqwest, and retries transient failures on a schedule.
+//! Being a plain thread with a blocking client (never a tokio task) it works for
+//! the async client, the blocking client, and — in a later change — a
+//! `std::panic` hook with no runtime present.
+//!
+//! `capture()` becomes a non-blocking enqueue (`Control::Capture`). `flush()` and
+//! `shutdown()` send a control message carrying a [`Completion`] the worker
+//! signals once the requested work is done, bridging the std-thread worker to
+//! either an async (`oneshot`) or blocking (`mpsc`) caller without putting a
+//! runtime in the worker.
+//!
+//! A [`Clock`] is injected into the worker so the interval timer, retry backoff,
+//! and v1 wire timestamps are deterministic in tests (a `ManualClock` plus a
+//! test-only `Tick` command drive the worker with virtual time — no real sleeps).
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use tracing::warn;
+
+use super::ClientOptions;
+use crate::Event;
+
+/// Messages sent from producers (`capture`/`flush`/`shutdown`) to the worker.
+pub(crate) enum Control {
+    // Boxed so the channel node isn't sized to a whole Event on every flush/
+    // shutdown message (clippy::large_enum_variant).
+    Capture {
+        event: Box<Event>,
+        historical_migration: bool,
+    },
+    Flush(Completion),
+    Shutdown(Completion),
+    /// Test-only: re-evaluate the (virtual) clock and flush/retry whatever is now
+    /// due, so interval and backoff timing can be driven without real sleeps.
+    #[cfg(test)]
+    Tick(Completion),
+}
+
+/// Completion signal handed to the worker so the caller can wait for a flush or
+/// shutdown to finish. The worker calls [`Completion::signal`] without needing a
+/// runtime — `oneshot::Sender::send` and `mpsc::Sender::send` are both runtime-free.
+pub(crate) enum Completion {
+    Blocking(mpsc::Sender<()>),
+    #[cfg(feature = "async-client")]
+    Async(tokio::sync::oneshot::Sender<()>),
+}
+
+impl Completion {
+    fn signal(self) {
+        match self {
+            Completion::Blocking(tx) => {
+                let _ = tx.send(());
+            }
+            #[cfg(feature = "async-client")]
+            Completion::Async(tx) => {
+                let _ = tx.send(());
+            }
+        }
+    }
+}
+
+/// Source of time for the worker. Injected so tests can drive the interval
+/// timer, retry backoff, and v1 wire timestamps deterministically.
+pub(crate) trait Clock: Send + Sync + 'static {
+    /// Monotonic time, for batching/retry scheduling.
+    fn now(&self) -> Instant;
+    /// Wall-clock time, for v1 `created_at` / event timestamps / request headers.
+    /// Unused by the v0 pipeline, which takes its timestamp from the event itself.
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    fn now_utc(&self) -> DateTime<Utc>;
+}
+
+struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+    fn now_utc(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// Handle stored on the client. `&self` methods use the atomics/mutex so the
+/// client can stay a plain field while `capture`/`flush`/`shutdown` take `&self`.
+pub(crate) struct TransportHandle {
+    tx: mpsc::Sender<Control>,
+    /// Pending `Capture` events not yet pulled by the worker. Gates the bounded queue.
+    len: Arc<AtomicUsize>,
+    /// Set once `shutdown`/`Drop` begins; blocks further enqueue and control sends.
+    closed: AtomicBool,
+    worker: Mutex<Option<JoinHandle<()>>>,
+    /// Latches the single "queue full" warning so a full queue doesn't spam logs.
+    full_warned: AtomicBool,
+    max_queue_size: usize,
+}
+
+impl TransportHandle {
+    /// Spawn the worker with the real system clock.
+    pub(crate) fn spawn(options: ClientOptions) -> Self {
+        Self::spawn_with_clock(options, Arc::new(SystemClock))
+    }
+
+    fn spawn_with_clock(options: ClientOptions, clock: Arc<dyn Clock>) -> Self {
+        let (tx, rx) = mpsc::channel::<Control>();
+        let len = Arc::new(AtomicUsize::new(0));
+        let max_queue_size = options.max_queue_size;
+        let worker_len = len.clone();
+        let worker = thread::Builder::new()
+            .name("posthog-transport".to_string())
+            .spawn(move || run_worker(options, rx, worker_len, clock))
+            .ok();
+        Self {
+            tx,
+            len,
+            closed: AtomicBool::new(false),
+            worker: Mutex::new(worker),
+            full_warned: AtomicBool::new(false),
+            max_queue_size,
+        }
+    }
+
+    /// Non-blocking enqueue. Drops (with a single warning) when the queue is full
+    /// or the client is closed.
+    pub(crate) fn enqueue(&self, event: Event, historical_migration: bool) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        if !try_reserve(&self.len, self.max_queue_size, &self.full_warned) {
+            return;
+        }
+        if self
+            .tx
+            .send(Control::Capture {
+                event: Box::new(event),
+                historical_migration,
+            })
+            .is_err()
+        {
+            // Worker gone; release the slot we reserved.
+            self.len.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    /// Send a flush/shutdown control message. Returns `false` if closed or the
+    /// worker is gone, so a caller's wait becomes a no-op instead of hanging.
+    pub(crate) fn send_control(&self, control: Control) -> bool {
+        self.tx.send(control).is_ok()
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    /// Events queued but not yet pulled by the worker. Excludes batches already
+    /// pulled into the worker's buffer or held for retry.
+    pub(crate) fn pending(&self) -> usize {
+        self.len.load(Ordering::Acquire)
+    }
+
+    /// Mark closed. Returns `true` for the caller that won the transition (so
+    /// shutdown is idempotent and only one caller drives teardown).
+    pub(crate) fn begin_close(&self) -> bool {
+        !self.closed.swap(true, Ordering::AcqRel)
+    }
+
+    /// Join the worker thread. Safe to call repeatedly.
+    pub(crate) fn join(&self) {
+        if let Some(handle) = self.worker.lock().unwrap_or_else(|p| p.into_inner()).take() {
+            let _ = handle.join();
+        }
+    }
+
+    /// Test helper: drive one worker cycle against the current (virtual) clock.
+    #[cfg(test)]
+    fn tick(&self) {
+        let (tx, rx) = mpsc::channel();
+        if self.send_control(Control::Tick(Completion::Blocking(tx))) {
+            let _ = rx.recv();
+        }
+    }
+
+    /// Test helper: blocking flush (the async client uses a oneshot instead).
+    #[cfg(test)]
+    fn flush_blocking(&self) {
+        let (tx, rx) = mpsc::channel();
+        if self.send_control(Control::Flush(Completion::Blocking(tx))) {
+            let _ = rx.recv();
+        }
+    }
+
+    /// Test helper: flush + stop + join, mirroring the client's shutdown.
+    #[cfg(test)]
+    fn shutdown_blocking(&self) {
+        if !self.begin_close() {
+            return;
+        }
+        let (tx, rx) = mpsc::channel();
+        if self.send_control(Control::Shutdown(Completion::Blocking(tx))) {
+            let _ = rx.recv();
+        }
+        self.join();
+    }
+}
+
+/// Reserve a queue slot under the bounded-capacity cap. Returns `false` (and
+/// warns once) when full. A CAS keeps the count exact under concurrent producers.
+fn try_reserve(len: &AtomicUsize, max: usize, warned: &AtomicBool) -> bool {
+    loop {
+        let current = len.load(Ordering::Acquire);
+        if current >= max {
+            if !warned.swap(true, Ordering::AcqRel) {
+                warn!("posthog-rs: event queue full (capacity {max}); dropping events");
+            }
+            return false;
+        }
+        if len
+            .compare_exchange_weak(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return true;
+        }
+    }
+}
+
+/// Time until the next scheduled wakeup: the buffer's flush-interval deadline or
+/// the earliest retry, whichever is sooner. `None` means nothing is pending, so
+/// the worker should block on `recv` until a message arrives.
+fn compute_wait(
+    now: Instant,
+    buffer_since: Option<Instant>,
+    flush_interval: Duration,
+    earliest_retry: Option<Instant>,
+) -> Option<Duration> {
+    let deadline = match (buffer_since, earliest_retry) {
+        (Some(since), Some(retry)) => Some((since + flush_interval).min(retry)),
+        (Some(since), None) => Some(since + flush_interval),
+        (None, Some(retry)) => Some(retry),
+        (None, None) => None,
+    };
+    deadline.map(|d| d.saturating_duration_since(now))
+}
+
+enum Wake {
+    Msg(Control),
+    Timeout,
+    Disconnected,
+}
+
+fn run_worker(
+    options: ClientOptions,
+    rx: mpsc::Receiver<Control>,
+    len: Arc<AtomicUsize>,
+    clock: Arc<dyn Clock>,
+) {
+    let flush_at = options.flush_at.max(1);
+    let max_batch_size = options.max_batch_size.max(1);
+    let flush_interval = Duration::from_millis(options.flush_interval_ms);
+    let mut pipeline = Pipeline::new(&options, Arc::clone(&clock));
+
+    let mut buffer: Vec<Event> = Vec::new();
+    let mut buffer_hist = false;
+    let mut buffer_since: Option<Instant> = None;
+
+    loop {
+        let wait = compute_wait(
+            clock.now(),
+            buffer_since,
+            flush_interval,
+            pipeline.earliest_retry(),
+        );
+        let wake = match wait {
+            None => match rx.recv() {
+                Ok(msg) => Wake::Msg(msg),
+                Err(_) => Wake::Disconnected,
+            },
+            Some(timeout) => match rx.recv_timeout(timeout) {
+                Ok(msg) => Wake::Msg(msg),
+                Err(mpsc::RecvTimeoutError::Timeout) => Wake::Timeout,
+                Err(mpsc::RecvTimeoutError::Disconnected) => Wake::Disconnected,
+            },
+        };
+
+        match wake {
+            Wake::Msg(Control::Capture {
+                event,
+                historical_migration,
+            }) => {
+                len.fetch_sub(1, Ordering::AcqRel);
+                // Keep each batch homogeneous in historical_migration: flush the
+                // current buffer before mixing in an event with a different flag.
+                if !buffer.is_empty() && historical_migration != buffer_hist {
+                    send_buffer(
+                        &mut pipeline,
+                        &mut buffer,
+                        buffer_hist,
+                        max_batch_size,
+                        false,
+                    );
+                    buffer_since = None;
+                }
+                if buffer.is_empty() {
+                    buffer_hist = historical_migration;
+                    buffer_since = Some(clock.now());
+                }
+                buffer.push(*event);
+                if buffer.len() >= flush_at {
+                    send_buffer(
+                        &mut pipeline,
+                        &mut buffer,
+                        buffer_hist,
+                        max_batch_size,
+                        false,
+                    );
+                    buffer_since = None;
+                }
+            }
+            Wake::Msg(Control::Flush(completion)) => {
+                // One delivery attempt per pending batch: retry the already-held
+                // batches first, then the freshly buffered ones. Failures from
+                // either are held for the next cycle (so a single 503 leaves the
+                // event queued rather than being re-attempted in this same call).
+                pipeline.flush_retries(false);
+                send_buffer(
+                    &mut pipeline,
+                    &mut buffer,
+                    buffer_hist,
+                    max_batch_size,
+                    false,
+                );
+                buffer_since = None;
+                completion.signal();
+            }
+            Wake::Msg(Control::Shutdown(completion)) => {
+                // FIFO delivery means every pre-shutdown Capture has already been
+                // buffered, so one final attempt per batch is sufficient.
+                pipeline.flush_retries(true);
+                send_buffer(
+                    &mut pipeline,
+                    &mut buffer,
+                    buffer_hist,
+                    max_batch_size,
+                    true,
+                );
+                completion.signal();
+                return;
+            }
+            #[cfg(test)]
+            Wake::Msg(Control::Tick(completion)) => {
+                if buffer_since
+                    .is_some_and(|since| clock.now().duration_since(since) >= flush_interval)
+                {
+                    send_buffer(
+                        &mut pipeline,
+                        &mut buffer,
+                        buffer_hist,
+                        max_batch_size,
+                        false,
+                    );
+                    buffer_since = None;
+                }
+                pipeline.attempt_due();
+                completion.signal();
+            }
+            Wake::Timeout => {
+                if buffer_since
+                    .is_some_and(|since| clock.now().duration_since(since) >= flush_interval)
+                {
+                    send_buffer(
+                        &mut pipeline,
+                        &mut buffer,
+                        buffer_hist,
+                        max_batch_size,
+                        false,
+                    );
+                    buffer_since = None;
+                }
+                pipeline.attempt_due();
+            }
+            Wake::Disconnected => {
+                // All client handles dropped without an explicit shutdown — best
+                // effort drain, then exit.
+                send_buffer(
+                    &mut pipeline,
+                    &mut buffer,
+                    buffer_hist,
+                    max_batch_size,
+                    true,
+                );
+                pipeline.flush_retries(true);
+                return;
+            }
+        }
+    }
+}
+
+/// Drain `buffer` into batches of at most `max_batch_size`, FIFO from the front,
+/// attempting each once. `final_attempt` warns-and-drops on transient failure
+/// (shutdown) instead of scheduling a retry.
+fn send_buffer(
+    pipeline: &mut Pipeline,
+    buffer: &mut Vec<Event>,
+    historical_migration: bool,
+    max_batch_size: usize,
+    final_attempt: bool,
+) {
+    while !buffer.is_empty() {
+        let take = buffer.len().min(max_batch_size);
+        let chunk: Vec<Event> = buffer.drain(..take).collect();
+        pipeline.send_batch(chunk, historical_migration, final_attempt);
+    }
+}
+
+// ===========================================================================
+// V1 pipeline
+// ===========================================================================
+
+#[cfg(feature = "capture-v1")]
+use std::collections::HashMap;
+#[cfg(feature = "capture-v1")]
+use uuid::Uuid;
+
+#[cfg(feature = "capture-v1")]
+struct RetryBatch {
+    pending: Vec<crate::event_v1::V1Event>,
+    request_id: Uuid,
+    created_at: String,
+    final_results: HashMap<Uuid, crate::event_v1::EventResult>,
+    historical_migration: bool,
+    attempt: u32,
+    next_at: Instant,
+}
+
+#[cfg(feature = "capture-v1")]
+struct Pipeline {
+    http: reqwest::blocking::Client,
+    options: ClientOptions,
+    url: String,
+    clock: Arc<dyn Clock>,
+    retries: VecDeque<RetryBatch>,
+}
+
+#[cfg(feature = "capture-v1")]
+impl Pipeline {
+    fn new(options: &ClientOptions, clock: Arc<dyn Clock>) -> Self {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(options.request_timeout_seconds))
+            .build()
+            .unwrap_or_default();
+        let url = options
+            .endpoints()
+            .build_custom_url(super::v1_capture::V1_CAPTURE_PATH);
+        Self {
+            http,
+            options: options.clone(),
+            url,
+            clock,
+            retries: VecDeque::new(),
+        }
+    }
+
+    fn send_batch(&mut self, events: Vec<Event>, historical_migration: bool, final_attempt: bool) {
+        use super::common::{apply_before_send_hooks, apply_capture_defaults};
+
+        let defaults = self.options.capture_defaults();
+        let processed: Vec<Event> = events
+            .into_iter()
+            .filter_map(|mut event| {
+                apply_capture_defaults(&mut event, &defaults);
+                apply_before_send_hooks(&self.options.before_send, event)
+            })
+            .collect();
+        if processed.is_empty() {
+            return;
+        }
+        let now = self.clock.now();
+        let pending =
+            super::v1_capture::build_events_at(&processed, &defaults, self.clock.now_utc());
+        let batch = RetryBatch {
+            pending,
+            request_id: Uuid::now_v7(),
+            created_at: self.clock.now_utc().to_rfc3339(),
+            final_results: HashMap::new(),
+            historical_migration,
+            attempt: 1,
+            next_at: now,
+        };
+        self.attempt(batch, final_attempt);
+    }
+
+    fn attempt(&mut self, mut batch: RetryBatch, final_attempt: bool) {
+        use super::v1_capture::{self, Step};
+        use crate::event_v1::V1BatchRequestRef;
+
+        let req = V1BatchRequestRef {
+            created_at: &batch.created_at,
+            historical_migration: batch.historical_migration.then_some(true),
+            batch: &batch.pending,
+        };
+        let payload = match serde_json::to_vec(&req) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("posthog-rs: dropping batch, serialization failed: {e}");
+                return;
+            }
+        };
+        let mut headers = v1_capture::build_headers_at(
+            &self.options,
+            &batch.request_id,
+            batch.attempt,
+            self.clock.now_utc(),
+        );
+        let body =
+            v1_capture::maybe_compress(self.options.capture_compression, &mut headers, payload);
+
+        let count = batch.pending.len();
+        let step = match self.http.post(&self.url).headers(headers).body(body).send() {
+            Err(e) => v1_capture::after_transport_error(
+                &self.options,
+                &batch.request_id,
+                batch.attempt,
+                e.to_string(),
+            ),
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                let retry_after = v1_capture::parse_retry_after(resp.headers());
+                let text = resp.text().unwrap_or_else(|_| "Unknown error".to_string());
+                v1_capture::after_response(
+                    &self.options,
+                    &batch.request_id,
+                    batch.attempt,
+                    status,
+                    retry_after,
+                    &text,
+                    &mut batch.pending,
+                    &mut batch.final_results,
+                )
+            }
+        };
+
+        match step {
+            Step::Done => {}
+            Step::Fail(e) => warn!("posthog-rs: dropping {count} event(s): {e}"),
+            Step::Backoff(delay) => {
+                if final_attempt {
+                    warn!(
+                        "posthog-rs: dropping {} undelivered event(s) on shutdown",
+                        batch.pending.len()
+                    );
+                } else {
+                    batch.attempt += 1;
+                    batch.next_at = self.clock.now() + delay;
+                    self.retries.push_back(batch);
+                }
+            }
+        }
+    }
+
+    fn earliest_retry(&self) -> Option<Instant> {
+        self.retries.iter().map(|b| b.next_at).min()
+    }
+
+    fn attempt_due(&mut self) {
+        let now = self.clock.now();
+        for batch in std::mem::take(&mut self.retries) {
+            if now >= batch.next_at {
+                self.attempt(batch, false);
+            } else {
+                self.retries.push_back(batch);
+            }
+        }
+    }
+
+    fn flush_retries(&mut self, final_attempt: bool) {
+        for batch in std::mem::take(&mut self.retries) {
+            self.attempt(batch, final_attempt);
+        }
+        if final_attempt && !self.retries.is_empty() {
+            warn!("posthog-rs: shutdown completed with undelivered events");
+        }
+    }
+}
+
+// ===========================================================================
+// V0 pipeline
+// ===========================================================================
+
+#[cfg(not(feature = "capture-v1"))]
+struct RetryBatch {
+    body: Vec<u8>,
+    encoding: Option<&'static str>,
+    count: usize,
+    attempt: u32,
+    next_at: Instant,
+}
+
+#[cfg(not(feature = "capture-v1"))]
+struct Pipeline {
+    http: reqwest::blocking::Client,
+    options: ClientOptions,
+    url_base: String,
+    clock: Arc<dyn Clock>,
+    retries: VecDeque<RetryBatch>,
+}
+
+#[cfg(not(feature = "capture-v1"))]
+impl Pipeline {
+    fn new(options: &ClientOptions, clock: Arc<dyn Clock>) -> Self {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(options.request_timeout_seconds))
+            .build()
+            .unwrap_or_default();
+        let url_base = options
+            .endpoints()
+            .build_url(crate::endpoints::Endpoint::Batch);
+        Self {
+            http,
+            options: options.clone(),
+            url_base,
+            clock,
+            retries: VecDeque::new(),
+        }
+    }
+
+    fn send_batch(&mut self, events: Vec<Event>, historical_migration: bool, final_attempt: bool) {
+        let defaults = self.options.capture_defaults();
+        let count = events.len();
+        let payload = match super::v0_capture::build_batch_payload(
+            events,
+            self.options.api_key.clone(),
+            historical_migration,
+            &defaults,
+            &self.options.before_send,
+        ) {
+            Ok(Some(p)) => p,
+            Ok(None) => return, // every event dropped by before_send
+            Err(e) => {
+                warn!("posthog-rs: dropping batch, serialization failed: {e}");
+                return;
+            }
+        };
+        let (body, encoding) = super::v0_capture::encode_body(&self.options, payload);
+        let batch = RetryBatch {
+            body,
+            encoding,
+            count,
+            attempt: 1,
+            next_at: self.clock.now(),
+        };
+        self.attempt(batch, final_attempt);
+    }
+
+    fn attempt(&mut self, mut batch: RetryBatch, final_attempt: bool) {
+        use super::retry::{v0_after_response, v0_after_transport_error, Step};
+        use reqwest::header::CONTENT_TYPE;
+
+        // v0 capture reads the compression hint from the query param, not the header.
+        let url = match batch.encoding {
+            Some(token) => format!("{}?compression={token}", self.url_base),
+            None => self.url_base.clone(),
+        };
+        let mut request = self
+            .http
+            .post(&url)
+            .header(CONTENT_TYPE, "application/json")
+            .body(batch.body.clone());
+        if let Some(token) = batch.encoding {
+            request = request.header(reqwest::header::CONTENT_ENCODING, token);
+        }
+        let request = super::v0_capture::apply_extra_headers(&self.options, request);
+
+        let step = match request.send() {
+            Err(e) => v0_after_transport_error(&self.options, batch.attempt, e.to_string()),
+            Ok(response) => {
+                let status = response.status().as_u16();
+                let retry_after = super::retry::parse_retry_after(response.headers());
+                let body = response
+                    .text()
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                v0_after_response(&self.options, batch.attempt, status, retry_after, &body)
+            }
+        };
+
+        match step {
+            Step::Done => {}
+            Step::Fail(e) => warn!("posthog-rs: dropping {} event(s): {e}", batch.count),
+            Step::Backoff(delay) => {
+                if final_attempt {
+                    warn!(
+                        "posthog-rs: dropping {} undelivered event(s) on shutdown",
+                        batch.count
+                    );
+                } else {
+                    batch.attempt += 1;
+                    batch.next_at = self.clock.now() + delay;
+                    self.retries.push_back(batch);
+                }
+            }
+        }
+    }
+
+    fn earliest_retry(&self) -> Option<Instant> {
+        self.retries.iter().map(|b| b.next_at).min()
+    }
+
+    fn attempt_due(&mut self) {
+        let now = self.clock.now();
+        for batch in std::mem::take(&mut self.retries) {
+            if now >= batch.next_at {
+                self.attempt(batch, false);
+            } else {
+                self.retries.push_back(batch);
+            }
+        }
+    }
+
+    fn flush_retries(&mut self, final_attempt: bool) {
+        for batch in std::mem::take(&mut self.retries) {
+            self.attempt(batch, final_attempt);
+        }
+        if final_attempt && !self.retries.is_empty() {
+            warn!("posthog-rs: shutdown completed with undelivered events");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::ClientOptionsBuilder;
+    use httpmock::prelude::*;
+
+    /// Test clock with manually advanced virtual time, so interval and backoff
+    /// timing are exercised without real sleeps.
+    #[derive(Clone)]
+    struct ManualClock {
+        inner: Arc<Mutex<(Instant, DateTime<Utc>)>>,
+    }
+
+    impl ManualClock {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(Mutex::new((Instant::now(), Utc::now()))),
+            }
+        }
+        fn advance(&self, by: Duration) {
+            let mut g = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+            g.0 += by;
+            g.1 += chrono::Duration::from_std(by).expect("test duration fits chrono");
+        }
+    }
+
+    impl Clock for ManualClock {
+        fn now(&self) -> Instant {
+            self.inner.lock().unwrap_or_else(|p| p.into_inner()).0
+        }
+        fn now_utc(&self) -> DateTime<Utc> {
+            self.inner.lock().unwrap_or_else(|p| p.into_inner()).1
+        }
+    }
+
+    fn ok_mock(server: &MockServer) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
+            when.method(POST);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "results": {} }));
+        })
+    }
+
+    fn options(base_url: String) -> ClientOptionsBuilder {
+        let mut builder = ClientOptionsBuilder::default();
+        builder
+            .api_key("phc_test".to_string())
+            .host(base_url)
+            .flush_at(100usize)
+            .flush_interval_ms(10_000u64);
+        builder
+    }
+
+    // -- pure helpers --------------------------------------------------------
+
+    #[test]
+    fn try_reserve_bounds_at_capacity_and_warns_once() {
+        let len = AtomicUsize::new(0);
+        let warned = AtomicBool::new(false);
+        assert!(try_reserve(&len, 2, &warned));
+        assert!(try_reserve(&len, 2, &warned));
+        assert!(!try_reserve(&len, 2, &warned)); // third dropped
+        assert_eq!(len.load(Ordering::Acquire), 2);
+        assert!(warned.load(Ordering::Acquire));
+        // A second overflow does not re-warn (single warning when full).
+        assert!(!try_reserve(&len, 2, &warned));
+    }
+
+    #[test]
+    fn try_reserve_allows_again_after_drain() {
+        let len = AtomicUsize::new(0);
+        let warned = AtomicBool::new(false);
+        assert!(try_reserve(&len, 1, &warned));
+        assert!(!try_reserve(&len, 1, &warned));
+        len.fetch_sub(1, Ordering::AcqRel); // worker consumed one
+        assert!(try_reserve(&len, 1, &warned));
+    }
+
+    #[test]
+    fn compute_wait_picks_interval_then_zero_when_elapsed() {
+        let base = Instant::now();
+        let interval = Duration::from_secs(10);
+        assert_eq!(
+            compute_wait(base, Some(base), interval, None),
+            Some(interval)
+        );
+        assert_eq!(
+            compute_wait(base + Duration::from_secs(10), Some(base), interval, None),
+            Some(Duration::ZERO)
+        );
+        assert_eq!(
+            compute_wait(base + Duration::from_secs(9), Some(base), interval, None),
+            Some(Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn compute_wait_blocks_when_idle_and_prefers_earliest() {
+        let base = Instant::now();
+        let interval = Duration::from_secs(10);
+        assert_eq!(compute_wait(base, None, interval, None), None);
+        let retry_at = base + Duration::from_secs(2);
+        assert_eq!(
+            compute_wait(base, Some(base), interval, Some(retry_at)),
+            Some(Duration::from_secs(2))
+        );
+        assert_eq!(
+            compute_wait(base, None, interval, Some(retry_at)),
+            Some(Duration::from_secs(2))
+        );
+    }
+
+    // -- virtual-clock worker tests (no real sleeps) -------------------------
+
+    #[test]
+    fn interval_flush_fires_on_clock_advance() {
+        let server = MockServer::start();
+        let mock = ok_mock(&server);
+        let clock = ManualClock::new();
+        let handle = TransportHandle::spawn_with_clock(
+            options(server.base_url()).build().unwrap(),
+            Arc::new(clock.clone()),
+        );
+
+        handle.enqueue(Event::new("Delayed", "user-1"), false);
+        handle.tick(); // interval not yet elapsed
+        mock.assert_hits(0);
+
+        clock.advance(Duration::from_secs(10));
+        handle.tick(); // interval elapsed -> flush, no real sleep
+        mock.assert_hits(1);
+
+        handle.shutdown_blocking();
+    }
+
+    #[test]
+    fn retry_backoff_is_honored_against_the_clock() {
+        let server = MockServer::start();
+        let mut fail = server.mock(|when, then| {
+            when.method(POST);
+            then.status(503);
+        });
+        let clock = ManualClock::new();
+        let handle = TransportHandle::spawn_with_clock(
+            options(server.base_url())
+                .max_capture_attempts(5u32)
+                .retry_initial_backoff_ms(1_000u64)
+                .retry_max_backoff_ms(60_000u64)
+                .build()
+                .unwrap(),
+            Arc::new(clock.clone()),
+        );
+
+        handle.enqueue(Event::new("Save", "user-1"), false);
+        handle.flush_blocking(); // attempt 1 -> 503, held with next_at = now + 1s
+        fail.assert_hits(1);
+
+        handle.tick(); // backoff not elapsed -> no retry
+        fail.assert_hits(1);
+
+        fail.delete();
+        let ok = ok_mock(&server);
+        clock.advance(Duration::from_secs(1)); // now >= next_at
+        handle.tick(); // due -> retried, delivered
+        ok.assert_hits(1);
+
+        handle.shutdown_blocking();
+    }
+}

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -556,11 +556,14 @@ impl Dispatcher {
         };
         self.in_flight = self.in_flight.saturating_sub(1);
         if let SendResult::Retry(batch) = result {
-            if self.shutdown_deadline.is_some() {
-                // Tearing down: don't re-queue a failed final attempt.
-                self.pipeline.drop_batch(batch);
-            } else {
-                self.retries.push_back(batch);
+            match self.shutdown_deadline {
+                // Mid-teardown. A final attempt never returns Retry, so this batch
+                // was dispatched before shutdown and failed transiently; it is owed
+                // one final attempt. Give it one while the deadline allows (matching
+                // the pre-pool single-worker behavior); past the deadline, drop it.
+                Some(deadline) if self.clock.now() < deadline => self.dispatch(batch, true),
+                Some(_) => self.pipeline.drop_batch(batch),
+                None => self.retries.push_back(batch),
             }
         }
         if self.in_flight == 0 {

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -302,8 +302,21 @@ enum SendResult {
 }
 
 /// Sender thread body: pull built batches, POST them (blocking), report outcomes.
-fn run_sender(pipeline: Arc<Pipeline>, jobs: Receiver<SendJob>, outcomes: Sender<SendResult>) {
+fn run_sender(
+    pipeline: Arc<Pipeline>,
+    jobs: Receiver<SendJob>,
+    outcomes: Sender<SendResult>,
+    abandon: Arc<AtomicBool>,
+) {
     while let Ok(job) = jobs.recv() {
+        // The shutdown deadline fired: drop jobs still queued for this sender
+        // instead of POSTing them, so a closed client can't keep doing network
+        // work past `shutdown_timeout`. (An already in-flight POST still finishes,
+        // bounded by the request timeout — it can't be cancelled mid-flight.)
+        if abandon.load(Ordering::Acquire) {
+            pipeline.drop_batch(job.batch);
+            continue;
+        }
         let result = pipeline.attempt(job.batch, job.final_attempt);
         if outcomes.send(result).is_err() {
             return; // dispatcher gone
@@ -320,6 +333,9 @@ fn run_sender(pipeline: Arc<Pipeline>, jobs: Receiver<SendJob>, outcomes: Sender
 struct Dispatcher {
     pipeline: Arc<Pipeline>,
     jobs: Sender<SendJob>,
+    /// Shared with the senders: set when the shutdown deadline fires so they drop
+    /// queued jobs instead of POSTing them after the dispatcher has exited.
+    abandon: Arc<AtomicBool>,
     clock: Arc<dyn Clock>,
     flush_at: usize,
     max_batch_size: usize,
@@ -346,6 +362,7 @@ impl Dispatcher {
     fn new(
         pipeline: Arc<Pipeline>,
         jobs: Sender<SendJob>,
+        abandon: Arc<AtomicBool>,
         clock: Arc<dyn Clock>,
         flush_at: usize,
         max_batch_size: usize,
@@ -355,6 +372,7 @@ impl Dispatcher {
         Self {
             pipeline,
             jobs,
+            abandon,
             clock,
             flush_at,
             max_batch_size,
@@ -563,8 +581,10 @@ impl Dispatcher {
             .shutdown_deadline
             .is_some_and(|d| self.clock.now() >= d)
         {
-            // Deadline hit with sends still outstanding: abandon them and exit.
-            // The detached senders finish their in-flight POST and then stop.
+            // Deadline hit with sends still outstanding: tell the senders to drop
+            // their queued jobs (any in-flight POST still finishes, bounded by the
+            // request timeout), signal the waiter, and exit.
+            self.abandon.store(true, Ordering::Release);
             if let Some(c) = self.shutdown_completion.take() {
                 c.signal();
             }
@@ -614,13 +634,15 @@ fn run_worker(
     // they exit when the dispatcher drops `job_tx` at teardown.
     let (job_tx, job_rx) = unbounded::<SendJob>();
     let (outcome_tx, outcome_rx) = unbounded::<SendResult>();
+    let abandon = Arc::new(AtomicBool::new(false));
     for i in 0..sender_pool_size() {
         let pipeline = Arc::clone(&pipeline);
         let jobs = job_rx.clone();
         let outcomes = outcome_tx.clone();
+        let abandon = Arc::clone(&abandon);
         let _ = thread::Builder::new()
             .name(format!("posthog-sender-{i}"))
-            .spawn(move || run_sender(pipeline, jobs, outcomes));
+            .spawn(move || run_sender(pipeline, jobs, outcomes, abandon));
     }
     drop(job_rx);
     drop(outcome_tx);
@@ -628,6 +650,7 @@ fn run_worker(
     let mut dispatcher = Dispatcher::new(
         pipeline,
         job_tx,
+        Arc::clone(&abandon),
         clock,
         flush_at,
         max_batch_size,
@@ -1276,5 +1299,43 @@ mod tests {
         mock.assert_hits(5);
         assert_eq!(handle.pending(), 0, "all batches delivered after flush");
         handle.shutdown_blocking();
+    }
+
+    #[test]
+    fn sender_abandons_queued_jobs_without_posting() {
+        // With the abandon flag set (shutdown deadline passed), a sender drops
+        // queued jobs and accounts for them instead of POSTing, so a closed client
+        // stops doing network work even with batches still queued.
+        let server = MockServer::start();
+        let mock = ok_mock(&server);
+        let len = Arc::new(AtomicUsize::new(1));
+        let clock: Arc<dyn Clock> = Arc::new(ManualClock::new());
+        let pipeline = Arc::new(Pipeline::new(
+            &options(server.base_url()).build().unwrap(),
+            Arc::clone(&clock),
+            Arc::clone(&len),
+        ));
+        let batch = pipeline
+            .build(vec![Event::new("E", "user-1")], false)
+            .expect("batch built");
+
+        let (job_tx, job_rx) = unbounded::<SendJob>();
+        let (out_tx, _out_rx) = unbounded::<SendResult>();
+        job_tx
+            .send(SendJob {
+                batch,
+                final_attempt: true,
+            })
+            .unwrap();
+        drop(job_tx); // sender's recv ends once the queue drains
+
+        run_sender(pipeline, job_rx, out_tx, Arc::new(AtomicBool::new(true)));
+
+        mock.assert_hits(0);
+        assert_eq!(
+            len.load(Ordering::Acquire),
+            0,
+            "abandoned batch is dropped from in-flight, not sent"
+        );
     }
 }

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -4,14 +4,12 @@
 
 // The transport worker is always blocking reqwest, even for the async client,
 // so the v0 request helpers operate on the blocking RequestBuilder.
-use chrono::{DateTime, Utc};
 use reqwest::blocking::RequestBuilder;
 
 use super::{
     common::{apply_before_send_hooks, apply_capture_defaults, apply_runtime_context},
     BeforeSendHook, CaptureDefaults, ClientOptions,
 };
-use crate::error::Error;
 use crate::event::{BatchRequest, Event, InnerEvent};
 
 // ---------------------------------------------------------------------------
@@ -37,10 +35,9 @@ pub(crate) fn build_batch_payload(
     events: Vec<Event>,
     api_key: String,
     historical_migration: bool,
-    sent_at: DateTime<Utc>,
     defaults: &CaptureDefaults,
     before_send: &[BeforeSendHook],
-) -> Result<Option<String>, Error> {
+) -> Option<BatchRequest> {
     let inner_events: Vec<InnerEvent> = events
         .into_iter()
         .filter_map(|mut event| {
@@ -51,18 +48,18 @@ pub(crate) fn build_batch_payload(
         .collect();
 
     if inner_events.is_empty() {
-        return Ok(None);
+        return None;
     }
 
-    let batch_request = BatchRequest {
+    // `sent_at` is stamped per HTTP attempt by the pipeline, not here, so a retried
+    // batch reflects when it was actually sent (for server-side clock-skew
+    // correction) rather than when it was first built.
+    Some(BatchRequest {
         api_key,
         historical_migration,
-        sent_at: sent_at.to_rfc3339(),
+        sent_at: String::new(),
         batch: inner_events,
-    };
-    serde_json::to_string(&batch_request)
-        .map(Some)
-        .map_err(|e| Error::Serialization(e.to_string()))
+    })
 }
 
 /// Encode the V0 JSON body, compressing when configured. Returns the bytes and

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -2,10 +2,9 @@
 //! Each client keeps only the I/O; this module owns event preparation and
 //! payload construction.
 
-#[cfg(not(feature = "async-client"))]
+// The transport worker is always blocking reqwest, even for the async client,
+// so the v0 request helpers operate on the blocking RequestBuilder.
 use reqwest::blocking::RequestBuilder;
-#[cfg(feature = "async-client")]
-use reqwest::RequestBuilder;
 
 use super::{
     common::{apply_before_send_hooks, apply_capture_defaults, apply_runtime_context},
@@ -31,12 +30,6 @@ pub(crate) fn prepare_event(event: &mut Event, defaults: &CaptureDefaults) {
 // ---------------------------------------------------------------------------
 // Payload building
 // ---------------------------------------------------------------------------
-
-/// Build the JSON body for a single-event V0 capture request.
-pub(crate) fn build_capture_payload(event: Event, api_key: String) -> Result<String, Error> {
-    let inner_event = InnerEvent::new(event, api_key);
-    serde_json::to_string(&inner_event).map_err(|e| Error::Serialization(e.to_string()))
-}
 
 /// Build the JSON body for a V0 batch capture request.
 pub(crate) fn build_batch_payload(

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -4,6 +4,7 @@
 
 // The transport worker is always blocking reqwest, even for the async client,
 // so the v0 request helpers operate on the blocking RequestBuilder.
+use chrono::{DateTime, Utc};
 use reqwest::blocking::RequestBuilder;
 
 use super::{
@@ -36,6 +37,7 @@ pub(crate) fn build_batch_payload(
     events: Vec<Event>,
     api_key: String,
     historical_migration: bool,
+    sent_at: DateTime<Utc>,
     defaults: &CaptureDefaults,
     before_send: &[BeforeSendHook],
 ) -> Result<Option<String>, Error> {
@@ -55,6 +57,7 @@ pub(crate) fn build_batch_payload(
     let batch_request = BatchRequest {
         api_key,
         historical_migration,
+        sent_at: sent_at.to_rfc3339(),
         batch: inner_events,
     };
     serde_json::to_string(&batch_request)

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 pub(crate) const V1_CAPTURE_PATH: &str = "/i/v1/analytics/events";
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use tracing::debug;
 use uuid::Uuid;
@@ -25,12 +25,22 @@ use crate::event_v1::{CaptureResponse, EventResult, EventStatus, V1ErrorResponse
 // ---------------------------------------------------------------------------
 
 pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<V1Event> {
+    build_events_at(events, defaults, Utc::now())
+}
+
+/// Like [`build_events`] but with an injected `now` so the transport worker can
+/// stamp deterministic event timestamps from its clock.
+pub(crate) fn build_events_at(
+    events: &[Event],
+    defaults: &CaptureDefaults,
+    now: DateTime<Utc>,
+) -> Vec<V1Event> {
     events
         .iter()
         .map(|event| {
             let mut event = event.clone();
             apply_runtime_context(&mut event);
-            let mut v1 = V1Event::from_event(&event);
+            let mut v1 = V1Event::from_event_at(&event, now);
             if let serde_json::Value::Object(ref mut map) = v1.properties {
                 if defaults.disable_geoip {
                     map.entry("$geoip_disable")
@@ -47,6 +57,17 @@ pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<
 }
 
 pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u32) -> HeaderMap {
+    build_headers_at(opts, request_id, attempt, Utc::now())
+}
+
+/// Like [`build_headers`] but with an injected `now` for a deterministic
+/// `posthog-request-timestamp` (used by the transport worker via its clock).
+pub(crate) fn build_headers_at(
+    opts: &ClientOptions,
+    request_id: &Uuid,
+    attempt: u32,
+    now: DateTime<Utc>,
+) -> HeaderMap {
     let sdk_info = get_default_user_agent();
 
     let mut headers = HeaderMap::new();
@@ -76,7 +97,7 @@ pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u3
     );
     headers.insert(
         "posthog-request-timestamp",
-        HeaderValue::from_str(&Utc::now().to_rfc3339())
+        HeaderValue::from_str(&now.to_rfc3339())
             .unwrap_or_else(|_| HeaderValue::from_static("unknown")),
     );
     #[cfg(feature = "test-harness")]

--- a/src/event.rs
+++ b/src/event.rs
@@ -160,6 +160,16 @@ impl Event {
         Ok(())
     }
 
+    /// Stamp the capture (enqueue) time when the caller hasn't set an explicit
+    /// timestamp. Done on the producer side before the event is queued, so a
+    /// batched or retried event records when it *occurred*, not when the worker
+    /// finally sent it.
+    pub(crate) fn ensure_timestamp(&mut self, now: DateTime<Utc>) {
+        if self.timestamp.is_none() {
+            self.timestamp = Some(now.naive_utc());
+        }
+    }
+
     /// Override the auto-generated UUID for this event.
     ///
     /// Useful for deduplication when re-importing historical data.
@@ -318,6 +328,8 @@ impl Event {
 pub struct BatchRequest {
     pub api_key: String,
     pub historical_migration: bool,
+    /// Time the batch left the client, for server-side clock-skew correction.
+    pub sent_at: String,
     pub batch: Vec<InnerEvent>,
 }
 
@@ -393,6 +405,7 @@ pub mod tests {
         let batch = BatchRequest {
             api_key: "test_api_key".to_string(),
             historical_migration: false,
+            sent_at: "2026-01-01T00:00:00Z".to_string(),
             batch: vec![
                 build_v0(Event::new("e1", "user1")),
                 build_v0(Event::new("e2", "user2")),
@@ -518,5 +531,26 @@ mod test {
             .expect_err("Date is in the future, should be rejected");
 
         assert!(event.timestamp.is_none())
+    }
+
+    #[test]
+    fn ensure_timestamp_stamps_only_when_unset() {
+        let now = DateTime::parse_from_rfc3339("2026-06-17T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        // Unset -> stamped with the provided capture time.
+        let mut event = Event::new("test", "user1");
+        event.ensure_timestamp(now);
+        assert_eq!(event.timestamp, Some(now.naive_utc()));
+
+        // Caller's explicit timestamp wins; ensure is a no-op.
+        let mut event = Event::new("test", "user1");
+        let caller = DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        event.set_timestamp(caller).unwrap();
+        event.ensure_timestamp(now);
+        assert_eq!(event.timestamp, Some(caller.naive_utc()));
     }
 }

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -21,7 +21,17 @@ pub struct V1Event {
 }
 
 impl V1Event {
+    // Only the tests build a V1Event without an injected clock; the worker uses
+    // `from_event_at` so its timestamps are deterministic.
+    #[cfg(test)]
     pub fn from_event(event: &Event) -> Self {
+        Self::from_event_at(event, Utc::now())
+    }
+
+    /// Like [`V1Event::from_event`] but with an injected `now`, so the transport
+    /// worker can stamp a deterministic timestamp from its clock when the event
+    /// carries none of its own.
+    pub(crate) fn from_event_at(event: &Event, now: DateTime<Utc>) -> Self {
         let mut properties = event.properties().clone();
 
         if !event.groups().is_empty() {
@@ -40,7 +50,7 @@ impl V1Event {
         let timestamp = event
             .timestamp()
             .map(|ts| ts.and_utc().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
-            .unwrap_or_else(|| Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string());
+            .unwrap_or_else(|| now.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string());
 
         // V1 carries process_person_profile in options; strip the property
         // duplicate in case a caller manually inserted it.

--- a/src/global.rs
+++ b/src/global.rs
@@ -91,6 +91,28 @@ pub async fn capture(event: Event) -> Result<(), Error> {
     client.capture(event).await
 }
 
+/// Flush the global client's queued events, awaiting the worker's next delivery
+/// attempt. No-op if `init_global` has not run.
+///
+/// `capture` only enqueues, and the global client lives in a `static` whose
+/// `Drop` never runs at process exit, so call this (or [`shutdown`]) before
+/// exiting to avoid losing buffered events.
+#[cfg(feature = "async-client")]
+pub async fn flush() {
+    if let Some(client) = GLOBAL_CLIENT.get() {
+        client.flush().await;
+    }
+}
+
+/// Flush and stop the global client's background worker. Idempotent; no-op if
+/// `init_global` has not run.
+#[cfg(feature = "async-client")]
+pub async fn shutdown() {
+    if let Some(client) = GLOBAL_CLIENT.get() {
+        client.shutdown().await;
+    }
+}
+
 /// Capture a Rust error personlessly using the global client.
 #[cfg(all(feature = "async-client", feature = "error-tracking"))]
 pub async fn capture_exception<E>(error: &E) -> Result<(), Error>
@@ -124,6 +146,28 @@ where
 pub fn capture(event: Event) -> Result<(), Error> {
     let client = GLOBAL_CLIENT.get().ok_or(Error::NotInitialized)?;
     client.capture(event)
+}
+
+/// Flush the global client's queued events, blocking until the worker's next
+/// delivery attempt. No-op if `init_global` has not run.
+///
+/// `capture` only enqueues, and the global client lives in a `static` whose
+/// `Drop` never runs at process exit, so call this (or [`shutdown`]) before
+/// exiting to avoid losing buffered events.
+#[cfg(not(feature = "async-client"))]
+pub fn flush() {
+    if let Some(client) = GLOBAL_CLIENT.get() {
+        client.flush();
+    }
+}
+
+/// Flush and stop the global client's background worker. Idempotent; no-op if
+/// `init_global` has not run.
+#[cfg(not(feature = "async-client"))]
+pub fn shutdown() {
+    if let Some(client) = GLOBAL_CLIENT.get() {
+        client.shutdown();
+    }
 }
 
 /// Capture a Rust error personlessly using the global client.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,12 +133,16 @@ pub use local_evaluation::{
 #[cfg(feature = "async-client")]
 pub use local_evaluation::AsyncFlagPoller;
 
-// We expose a global capture function as a convenience, that uses a global client
+// We expose global convenience functions (capture/flush/shutdown) that use a
+// global client. flush/shutdown matter because the global singleton lives in a
+// `static`, whose `Drop` never runs — they must be called to drain on exit.
 pub use global::capture;
 #[cfg(feature = "error-tracking")]
 pub use global::capture_exception;
 #[cfg(feature = "error-tracking")]
 pub use global::capture_exception_with;
 pub use global::disable as disable_global;
+pub use global::flush;
 pub use global::init_global_client as init_global;
 pub use global::is_disabled as global_is_disabled;
+pub use global::shutdown;

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -539,9 +539,9 @@ async fn test_capture_batch_sends_to_batch_endpoint() {
     let client = create_test_client(server.base_url()).await;
 
     let event = posthog_rs::Event::new("test_event", "user1");
-    let result = client.capture_batch(vec![event], false).await;
+    client.capture_batch(vec![event], false).await.unwrap();
+    client.flush().await;
 
-    assert!(result.is_ok());
     batch_mock.assert();
 }
 
@@ -560,9 +560,9 @@ async fn test_capture_batch_historical_migration() {
     let client = create_test_client(server.base_url()).await;
 
     let event = posthog_rs::Event::new("test_event", "user1");
-    let result = client.capture_batch(vec![event], true).await;
+    client.capture_batch(vec![event], true).await.unwrap();
+    client.flush().await;
 
-    assert!(result.is_ok());
     batch_mock.assert();
 }
 
@@ -579,10 +579,11 @@ async fn test_capture_batch_rate_limit() {
     let client = create_test_client(server.base_url()).await;
 
     let event = posthog_rs::Event::new("test_event", "user1");
-    let result = client.capture_batch(vec![event], true).await;
+    // Capture is now infallible; a terminal 429 is attempted once on flush and
+    // then dropped (the rate-limit is logged, not returned to the caller).
+    client.capture_batch(vec![event], true).await.unwrap();
+    client.flush().await;
 
-    assert!(result.is_err());
-    assert!(matches!(result.unwrap_err(), posthog_rs::Error::RateLimit));
     batch_mock.assert();
 }
 
@@ -599,14 +600,11 @@ async fn test_capture_batch_bad_request() {
     let client = create_test_client(server.base_url()).await;
 
     let event = posthog_rs::Event::new("test_event", "user1");
-    let result = client.capture_batch(vec![event], false).await;
+    // Capture is now infallible; a terminal 400 is attempted once on flush and
+    // then dropped (the bad-request is logged, not returned to the caller).
+    client.capture_batch(vec![event], false).await.unwrap();
+    client.flush().await;
 
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    match err {
-        posthog_rs::Error::BadRequest(msg) => assert_eq!(msg, "invalid payload"),
-        other => panic!("expected BadRequest, got: {:?}", other),
-    }
     batch_mock.assert();
 }
 
@@ -617,7 +615,7 @@ async fn v0_capture_injects_is_server_by_default() {
 
     let mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/i/v0/e/")
+            .path("/batch/")
             .body_contains("\"$is_server\":true");
         then.status(200).body("ok");
     });
@@ -625,6 +623,7 @@ async fn v0_capture_injects_is_server_by_default() {
     let client = create_test_client(server.base_url()).await;
     let event = posthog_rs::Event::new("test_event", "user-1");
     client.capture(event).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -643,7 +642,7 @@ async fn v0_capture_applies_runtime_context_defaults_and_preserves_caller_values
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/i/v0/e/")
+                .path("/batch/")
                 .body_contains(expected_os)
                 .body_contains(expected_os_version);
             then.status(200).body("ok");
@@ -656,6 +655,7 @@ async fn v0_capture_applies_runtime_context_defaults_and_preserves_caller_values
             event.insert_prop("$os_version", os_version).unwrap();
         }
         client.capture(event).await.unwrap();
+        client.flush().await;
         mock.assert();
     }
 }
@@ -667,7 +667,7 @@ async fn v0_capture_caller_override_wins_for_is_server() {
 
     let mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/i/v0/e/")
+            .path("/batch/")
             .body_contains("\"$is_server\":false");
         then.status(200).body("ok");
     });
@@ -676,6 +676,7 @@ async fn v0_capture_caller_override_wins_for_is_server() {
     let mut event = posthog_rs::Event::new("test_event", "user-1");
     event.insert_prop("$is_server", false).unwrap();
     client.capture(event).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -354,9 +354,9 @@ fn test_capture_batch_sends_to_batch_endpoint() {
     let client = create_test_client(server.base_url());
 
     let event = posthog_rs::Event::new("test_event", "user1");
-    let result = client.capture_batch(vec![event], false);
+    client.capture_batch(vec![event], false).unwrap();
+    client.flush();
 
-    assert!(result.is_ok());
     batch_mock.assert();
 }
 
@@ -375,9 +375,9 @@ fn test_capture_batch_historical_migration() {
     let client = create_test_client(server.base_url());
 
     let event = posthog_rs::Event::new("test_event", "user1");
-    let result = client.capture_batch(vec![event], true);
+    client.capture_batch(vec![event], true).unwrap();
+    client.flush();
 
-    assert!(result.is_ok());
     batch_mock.assert();
 }
 
@@ -394,10 +394,11 @@ fn test_capture_batch_rate_limit() {
     let client = create_test_client(server.base_url());
 
     let event = posthog_rs::Event::new("test_event", "user1");
-    let result = client.capture_batch(vec![event], true);
+    // Capture is now infallible; a terminal 429 is attempted once on flush and
+    // then dropped (the rate-limit is logged, not returned to the caller).
+    client.capture_batch(vec![event], true).unwrap();
+    client.flush();
 
-    assert!(result.is_err());
-    assert!(matches!(result.unwrap_err(), posthog_rs::Error::RateLimit));
     batch_mock.assert();
 }
 
@@ -414,14 +415,11 @@ fn test_capture_batch_bad_request() {
     let client = create_test_client(server.base_url());
 
     let event = posthog_rs::Event::new("test_event", "user1");
-    let result = client.capture_batch(vec![event], false);
+    // Capture is now infallible; a terminal 400 is attempted once on flush and
+    // then dropped (the bad-request is logged, not returned to the caller).
+    client.capture_batch(vec![event], false).unwrap();
+    client.flush();
 
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    match err {
-        posthog_rs::Error::BadRequest(msg) => assert_eq!(msg, "invalid payload"),
-        other => panic!("expected BadRequest, got: {:?}", other),
-    }
     batch_mock.assert();
 }
 
@@ -432,7 +430,7 @@ fn v0_capture_injects_is_server_by_default() {
 
     let mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/i/v0/e/")
+            .path("/batch/")
             .body_contains("\"$is_server\":true");
         then.status(200).body("ok");
     });
@@ -440,6 +438,7 @@ fn v0_capture_injects_is_server_by_default() {
     let client = create_test_client(server.base_url());
     let event = posthog_rs::Event::new("test_event", "user-1");
     client.capture(event).unwrap();
+    client.flush();
     mock.assert();
 }
 
@@ -450,7 +449,7 @@ fn v0_capture_caller_override_wins_for_is_server() {
 
     let mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/i/v0/e/")
+            .path("/batch/")
             .body_contains("\"$is_server\":false");
         then.status(200).body("ok");
     });
@@ -459,5 +458,6 @@ fn v0_capture_caller_override_wins_for_is_server() {
     let mut event = posthog_rs::Event::new("test_event", "user-1");
     event.insert_prop("$is_server", false).unwrap();
     client.capture(event).unwrap();
+    client.flush();
     mock.assert();
 }

--- a/tests/test_error_tracking.rs
+++ b/tests/test_error_tracking.rs
@@ -1,5 +1,9 @@
 // These tests assert the V0 wire shape; their capture-v1 twins live in
 // `test_error_tracking_v1.rs`.
+//
+// Capture is now a non-blocking enqueue drained by the background worker, which
+// always sends through the `/batch/` endpoint, so exceptions arrive nested under
+// the batch array (`/batch/0/...`) and tests `flush()` before asserting.
 #![cfg(all(feature = "error-tracking", not(feature = "capture-v1")))]
 
 use httpmock::prelude::*;
@@ -64,14 +68,15 @@ fn request_has_no_stacktrace(req: &HttpMockRequest) -> bool {
         return false;
     };
 
-    body.pointer("/properties/$exception_list/0").is_some()
+    body.pointer("/batch/0/properties/$exception_list/0")
+        .is_some()
         && body
-            .pointer("/properties/$exception_list/0/stacktrace")
+            .pointer("/batch/0/properties/$exception_list/0/stacktrace")
             .is_none()
 }
 
 fn first_exception_stack_function(body: &serde_json::Value) -> &str {
-    body.pointer("/properties/$exception_list/0/stacktrace/frames")
+    body.pointer("/batch/0/properties/$exception_list/0/stacktrace/frames")
         .and_then(|value| value.as_array())
         .and_then(|frames| frames.first())
         .and_then(|frame| frame.get("function"))
@@ -94,7 +99,7 @@ mod blocking {
         let server = MockServer::start();
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/i/v0/e/")
+                .path("/batch/")
                 .body_contains(r#""event":"$exception""#)
                 .body_contains(r#""$process_person_profile":false"#)
                 .body_contains(r#""$exception_level":"error""#)
@@ -107,6 +112,7 @@ mod blocking {
 
         let client = create_test_client(server.base_url());
         client.capture_exception(&TestError).unwrap();
+        client.flush();
 
         capture_mock.assert_hits(1);
     }
@@ -116,7 +122,7 @@ mod blocking {
         let server = MockServer::start();
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/i/v0/e/")
+                .path("/batch/")
                 .body_contains(r#""event":"$exception""#)
                 .body_contains(r#""distinct_id":"user-1""#)
                 .body_contains(r#""route":"/checkout""#)
@@ -140,6 +146,7 @@ mod blocking {
                     .level("warning"),
             )
             .unwrap();
+        client.flush();
 
         capture_mock.assert_hits(1);
     }
@@ -168,7 +175,7 @@ mod blocking {
         let server = MockServer::start();
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/i/v0/e/")
+                .path("/batch/")
                 .body_contains(r#""event":"$exception""#)
                 .body_contains(r#""value":"payment failed""#)
                 .matches(request_has_no_stacktrace);
@@ -189,6 +196,7 @@ mod blocking {
         let client = posthog_rs::client(options);
 
         client.capture_exception(&TestError).unwrap();
+        client.flush();
 
         capture_mock.assert_hits(1);
     }
@@ -209,7 +217,7 @@ mod async_client {
         let server = MockServer::start();
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/i/v0/e/")
+                .path("/batch/")
                 .body_contains(r#""event":"$exception""#)
                 .body_contains(r#""$process_person_profile":false"#)
                 .body_contains(r#""$exception_level":"error""#)
@@ -222,6 +230,7 @@ mod async_client {
 
         let client = create_test_client(server.base_url()).await;
         client.capture_exception(&TestError).await.unwrap();
+        client.flush().await;
 
         capture_mock.assert_hits(1);
     }
@@ -231,7 +240,7 @@ mod async_client {
         let server = MockServer::start();
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/i/v0/e/")
+                .path("/batch/")
                 .body_contains(r#""event":"$exception""#)
                 .body_contains(r#""distinct_id":"user-1""#)
                 .body_contains(r#""route":"/checkout""#)
@@ -256,6 +265,7 @@ mod async_client {
             )
             .await
             .unwrap();
+        client.flush().await;
 
         capture_mock.assert_hits(1);
     }
@@ -285,7 +295,7 @@ mod async_client {
         let server = MockServer::start();
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/i/v0/e/")
+                .path("/batch/")
                 .body_contains(r#""event":"$exception""#)
                 .body_contains(r#""value":"payment failed""#)
                 .matches(request_has_no_stacktrace);
@@ -306,6 +316,7 @@ mod async_client {
         let client = posthog_rs::client(options).await;
 
         client.capture_exception(&TestError).await.unwrap();
+        client.flush().await;
 
         capture_mock.assert_hits(1);
     }

--- a/tests/test_error_tracking_v1.rs
+++ b/tests/test_error_tracking_v1.rs
@@ -108,6 +108,7 @@ mod blocking {
 
         let client = create_test_client(server.base_url());
         client.capture_exception(&TestError).unwrap();
+        client.flush();
 
         capture_mock.assert_hits(1);
     }
@@ -143,6 +144,7 @@ mod blocking {
                     .level("warning"),
             )
             .unwrap();
+        client.flush();
 
         capture_mock.assert_hits(1);
     }
@@ -201,6 +203,7 @@ mod async_client {
 
         let client = create_test_client(server.base_url()).await;
         client.capture_exception(&TestError).await.unwrap();
+        client.flush().await;
 
         capture_mock.assert_hits(1);
     }
@@ -237,6 +240,7 @@ mod async_client {
             )
             .await
             .unwrap();
+        client.flush().await;
 
         capture_mock.assert_hits(1);
     }

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -13,6 +13,13 @@ const CAPTURE_PATH: &str = "/i/v1/analytics/events";
 #[cfg(not(feature = "capture-v1"))]
 const CAPTURE_PATH: &str = "/i/v0/e/";
 
+/// Where the background worker ships analytics captures on v0: the batch
+/// endpoint (single captures are batched too now). Used only by the v0-gated
+/// `event_with_flags` tests below; `$feature_flag_called` still ships via the
+/// fire-and-forget `/i/v0/e/` host path (`CAPTURE_PATH`).
+#[cfg(not(feature = "capture-v1"))]
+const WORKER_CAPTURE_PATH: &str = "/batch/";
+
 /// Feature-aware capture mock; the JSON body is required by V1, ignored by v0.
 fn capture_path_mock(server: &MockServer) -> httpmock::Mock<'_> {
     server.mock(|when, then| {
@@ -331,7 +338,12 @@ mod blocking {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = capture_path_mock(&server);
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST).path(WORKER_CAPTURE_PATH);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "results": {} }));
+        });
         let client = create_test_client(server.base_url());
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -339,7 +351,8 @@ mod blocking {
         let mut event = Event::new("checkout-started", "user-1");
         event.with_flags(&snapshot);
         client.capture(event).expect("capture should succeed");
-        // One /flags request, one /i/v0/e/ request — no second flag fetch.
+        client.flush();
+        // One /flags request, one capture request — no second flag fetch.
         flags_mock.assert_hits(1);
         capture_mock.assert_hits(1);
     }
@@ -786,7 +799,12 @@ mod async_tests {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let capture_mock = capture_path_mock(&server);
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST).path(WORKER_CAPTURE_PATH);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "results": {} }));
+        });
         let client = create_test_client(server.base_url()).await;
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
@@ -795,6 +813,7 @@ mod async_tests {
         let mut event = Event::new("checkout-started", "user-1");
         event.with_flags(&snapshot);
         client.capture(event).await.unwrap();
+        client.flush().await;
         flags_mock.assert_hits(1);
         capture_mock.assert_hits(1);
     }

--- a/tests/test_transport.rs
+++ b/tests/test_transport.rs
@@ -16,11 +16,15 @@ async fn client_with(host: String, flush_at: usize, max_attempts: u32) -> Client
         .host(host)
         .flush_at(flush_at)
         .max_batch_size(100usize)
-        .flush_interval_ms(50u64)
+        // Large interval + backoff so the worker never flushes or retries on its
+        // own mid-test: every send is driven by the flush_at threshold or an
+        // explicit flush()/shutdown(), keeping the hit-count assertions
+        // deterministic. (Autonomous interval/backoff timing is covered by the
+        // ManualClock unit tests in transport.rs.)
+        .flush_interval_ms(600_000u64)
         .max_capture_attempts(max_attempts)
-        // Tiny backoffs keep scheduled retries fast in tests.
-        .retry_initial_backoff_ms(1u64)
-        .retry_max_backoff_ms(5u64)
+        .retry_initial_backoff_ms(600_000u64)
+        .retry_max_backoff_ms(600_000u64)
         .build()
         .unwrap();
     posthog_rs::client(options).await

--- a/tests/test_transport.rs
+++ b/tests/test_transport.rs
@@ -1,0 +1,260 @@
+//! Acceptance coverage for the background event transport (event-batcher,
+//! retry-queue, http-client, flush, shutdown specs). Runs on the async client;
+//! assertions are wire-format-agnostic (they hold for both the v0 `/batch/`
+//! and v1 `/i/v1/analytics/events` body shapes, which both nest events under a
+//! `batch` array).
+#![cfg(feature = "async-client")]
+
+use std::time::Duration;
+
+use httpmock::prelude::*;
+use posthog_rs::{Client, ClientOptionsBuilder, Event};
+
+async fn client_with(host: String, flush_at: usize, max_attempts: u32) -> Client {
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test".to_string())
+        .host(host)
+        .flush_at(flush_at)
+        .max_batch_size(100usize)
+        .flush_interval_ms(50u64)
+        .max_capture_attempts(max_attempts)
+        // Tiny backoffs keep scheduled retries fast in tests.
+        .retry_initial_backoff_ms(1u64)
+        .retry_max_backoff_ms(5u64)
+        .build()
+        .unwrap();
+    posthog_rs::client(options).await
+}
+
+/// Poll a mock until it has been hit `want` times (for worker-timed paths such
+/// as the size-threshold and interval flushes that aren't driven by `flush()`).
+fn wait_for_hits(mock: &httpmock::Mock, want: usize) {
+    for _ in 0..300 {
+        if mock.hits() >= want {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(mock.hits(), want, "timed out waiting for {want} hits");
+}
+
+fn body_contains(req: &HttpMockRequest, needle: &str) -> bool {
+    req.body
+        .as_deref()
+        .map(|b| String::from_utf8_lossy(b).contains(needle))
+        .unwrap_or(false)
+}
+
+// --- flush -----------------------------------------------------------------
+
+#[tokio::test]
+async fn flush_immediately_sends_queued_events() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .matches(|r| body_contains(r, "\"event\":\"First\""))
+            .matches(|r| body_contains(r, "\"event\":\"Second\""));
+        then.status(200);
+    });
+
+    let client = client_with(server.base_url(), 100, 3).await;
+    client
+        .capture(Event::new("First", "user-123"))
+        .await
+        .unwrap();
+    client
+        .capture(Event::new("Second", "user-123"))
+        .await
+        .unwrap();
+    client.flush().await;
+
+    // Both events arrive in a single batch request.
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn flush_is_safe_when_queue_is_empty() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST);
+        then.status(200);
+    });
+
+    let client = client_with(server.base_url(), 100, 3).await;
+    client.flush().await; // must not panic, must not send
+
+    mock.assert_hits(0);
+}
+
+#[tokio::test]
+async fn flush_keeps_events_retryable_then_delivers_after_success() {
+    let server = MockServer::start();
+    let mut fail = server.mock(|when, then| {
+        when.method(POST);
+        then.status(503);
+    });
+
+    let client = client_with(server.base_url(), 100, 5).await;
+    client
+        .capture(Event::new("Save", "user-123"))
+        .await
+        .unwrap();
+
+    // First flush attempts once; the 503 keeps the event queued for retry.
+    client.flush().await;
+    fail.assert_hits(1);
+
+    // Server recovers; the held event is delivered on the next flush.
+    fail.delete();
+    let ok = server.mock(|when, then| {
+        when.method(POST)
+            .matches(|r| body_contains(r, "\"event\":\"Save\""));
+        then.status(200);
+    });
+    client.flush().await;
+    ok.assert_hits(1);
+
+    // Delivered: a third flush sends nothing more.
+    client.flush().await;
+    ok.assert_hits(1);
+}
+
+// --- shutdown --------------------------------------------------------------
+
+#[tokio::test]
+async fn shutdown_flushes_and_disables_future_capture() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .matches(|r| body_contains(r, "\"event\":\"Save\""));
+        then.status(200);
+    });
+
+    let client = client_with(server.base_url(), 100, 3).await;
+    client
+        .capture(Event::new("Save", "user-123"))
+        .await
+        .unwrap();
+    client.shutdown().await;
+    mock.assert_hits(1);
+
+    // Captures after shutdown are dropped, not enqueued.
+    client
+        .capture(Event::new("After Shutdown", "user-123"))
+        .await
+        .unwrap();
+    client.flush().await;
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn shutdown_is_idempotent() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(POST);
+        then.status(200);
+    });
+
+    let client = client_with(server.base_url(), 100, 3).await;
+    client.shutdown().await;
+    client.shutdown().await; // second call must not panic or hang
+}
+
+#[tokio::test]
+async fn shutdown_does_not_throw_on_delivery_failure() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST);
+        then.status(503);
+    });
+
+    let client = client_with(server.base_url(), 100, 3).await;
+    client
+        .capture(Event::new("Save", "user-123"))
+        .await
+        .unwrap();
+    client.shutdown().await; // best-effort: attempts once, drops, does not panic
+    mock.assert_hits(1);
+}
+
+// --- event-batcher ---------------------------------------------------------
+
+#[tokio::test]
+async fn batcher_flushes_when_size_threshold_reached() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST);
+        then.status(200);
+    });
+
+    // flush_at = 2: the second capture triggers an automatic flush (no explicit
+    // flush() call).
+    let client = client_with(server.base_url(), 2, 3).await;
+    client
+        .capture(Event::new("First", "user-123"))
+        .await
+        .unwrap();
+    client
+        .capture(Event::new("Second", "user-123"))
+        .await
+        .unwrap();
+
+    wait_for_hits(&mock, 1);
+}
+
+#[tokio::test]
+async fn batcher_preserves_fifo_order_within_a_batch() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).matches(|r| {
+            let Some(body) = r.body.as_deref() else {
+                return false;
+            };
+            let s = String::from_utf8_lossy(body);
+            match (s.find("First"), s.find("Second"), s.find("Third")) {
+                (Some(a), Some(b), Some(c)) => a < b && b < c,
+                _ => false,
+            }
+        });
+        then.status(200);
+    });
+
+    let client = client_with(server.base_url(), 3, 3).await;
+    client
+        .capture(Event::new("First", "user-123"))
+        .await
+        .unwrap();
+    client
+        .capture(Event::new("Second", "user-123"))
+        .await
+        .unwrap();
+    client
+        .capture(Event::new("Third", "user-123"))
+        .await
+        .unwrap();
+
+    wait_for_hits(&mock, 1);
+}
+
+// --- http-client -----------------------------------------------------------
+
+#[tokio::test]
+async fn successful_status_drains_the_queue() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST);
+        then.status(200);
+    });
+
+    let client = client_with(server.base_url(), 100, 3).await;
+    client
+        .capture(Event::new("Save", "user-123"))
+        .await
+        .unwrap();
+    client.flush().await;
+    mock.assert_hits(1);
+
+    // Nothing left to send.
+    client.flush().await;
+    mock.assert_hits(1);
+}

--- a/tests/test_v0_blocking_retry.rs
+++ b/tests/test_v0_blocking_retry.rs
@@ -1,5 +1,11 @@
 #![cfg(all(not(feature = "async-client"), not(feature = "capture-v1")))]
 
+//! V0 retry behavior (blocking client) under the background transport. `capture`
+//! is a non-blocking enqueue, so these tests drive delivery with `flush()` (each
+//! flush makes one attempt per pending batch, ignoring backoff). Exhausting the
+//! attempt budget takes `max_attempts` flushes; the Retry-After test instead
+//! lets the worker retry on its own schedule so the header delay is observable.
+
 use std::io::Read;
 use std::time::{Duration, Instant};
 
@@ -15,8 +21,6 @@ fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
         .api_key("phc_test_token".to_string())
         .host(base_url)
         .max_capture_attempts(max_attempts)
-        // Tiny backoffs keep the retry tests fast; the retry-after test below
-        // relies on these being far smaller than the header value it asserts.
         .retry_initial_backoff_ms(1u64)
         .retry_max_backoff_ms(5u64)
         .build()
@@ -24,18 +28,32 @@ fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
     posthog_rs::client(options)
 }
 
-/// Drive whichever v0 path (single `/i/v0/e/` vs `/batch/`) the test wants,
-/// so coverage of both stays DRY.
-fn capture(client: &Client, batch: bool) -> Result<(), posthog_rs::Error> {
+/// Drive whichever capture entry point the test wants. Both now enqueue onto the
+/// same worker and send through `/batch/`.
+fn capture(client: &Client, batch: bool) {
     if batch {
-        client.capture_batch(vec![Event::new("e", "user-1")], false)
+        client
+            .capture_batch(vec![Event::new("e", "user-1")], false)
+            .unwrap();
     } else {
-        client.capture(Event::new("e", "user-1"))
+        client.capture(Event::new("e", "user-1")).unwrap();
     }
 }
 
+/// Poll until a mock has been hit `want` times (for the autonomous retry path
+/// that isn't driven by `flush()`).
+fn wait_for_hits(mock: &httpmock::Mock, want: usize) {
+    for _ in 0..400 {
+        if mock.hits() >= want {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(mock.hits(), want, "timed out waiting for {want} hits");
+}
+
 #[test]
-fn retryable_status_exhausts_attempts() {
+fn retryable_status_keeps_retrying_until_attempts_exhausted() {
     for status in [408u16, 500, 502, 503, 504] {
         for batch in [false, true] {
             let server = MockServer::start();
@@ -45,14 +63,15 @@ fn retryable_status_exhausts_attempts() {
             });
 
             let client = create_v0_client(server.base_url(), 3);
-            let result = capture(&client, batch);
+            capture(&client, batch);
+            client.flush();
+            client.flush();
+            client.flush();
 
-            assert!(
-                result.is_err(),
-                "status {} (batch={}) should error after exhausting retries",
-                status,
-                batch
-            );
+            mock.assert_hits(3);
+
+            // Budget exhausted: the event is dropped, so a further flush is a no-op.
+            client.flush();
             mock.assert_hits(3);
         }
     }
@@ -60,8 +79,8 @@ fn retryable_status_exhausts_attempts() {
 
 #[test]
 fn terminal_status_sends_once() {
-    // 429 here carries no Retry-After, so it is terminal (RateLimit), not
-    // retried — see `honors_retry_after_header` for the 429 + Retry-After case.
+    // 429 here carries no Retry-After, so it is terminal, not retried — see
+    // `honors_retry_after_header` for the 429 + Retry-After case.
     for status in [400u16, 401, 402, 403, 413, 415, 429] {
         for batch in [false, true] {
             let server = MockServer::start();
@@ -71,16 +90,12 @@ fn terminal_status_sends_once() {
             });
 
             let client = create_v0_client(server.base_url(), 3);
-            let result = capture(&client, batch);
+            capture(&client, batch);
+            client.flush();
+            mock.assert_hits(1);
 
-            let err = result.expect_err(&format!("status {status} should be terminal"));
-            if status == 429 {
-                assert!(
-                    matches!(err, posthog_rs::Error::RateLimit),
-                    "429 should map to RateLimit, got {:?}",
-                    err
-                );
-            }
+            // Terminal: dropped, not retried.
+            client.flush();
             mock.assert_hits(1);
         }
     }
@@ -96,7 +111,8 @@ fn success_sends_once() {
         });
 
         let client = create_v0_client(server.base_url(), 3);
-        capture(&client, batch).unwrap();
+        capture(&client, batch);
+        client.flush();
         mock.assert_hits(1);
     }
 }
@@ -114,7 +130,10 @@ fn retries_resend_identical_event() {
     let client = create_v0_client(server.base_url(), 3);
     let mut event = Event::new("e", "user-1");
     event.set_uuid(uuid::Uuid::parse_str(FIXED_UUID).unwrap());
-    let _ = client.capture(event);
+    client.capture(event).unwrap();
+    client.flush();
+    client.flush();
+    client.flush();
 
     mock.assert_hits(3);
 }
@@ -151,6 +170,7 @@ fn gzip_sets_header_query_param_and_compresses_body() {
         .unwrap();
     let client = posthog_rs::client(options);
     client.capture(Event::new("test_event", "user1")).unwrap();
+    client.flush();
 
     mock.assert();
 }
@@ -158,25 +178,27 @@ fn gzip_sets_header_query_param_and_compresses_body() {
 #[test]
 fn honors_retry_after_header() {
     let server = MockServer::start();
-    // Mirrors the contract's `respects_retry_after_header`: a 429 carrying
-    // Retry-After must delay the resend by the header value, not the (tiny)
-    // exponential backoff.
+    // A 429 carrying Retry-After must delay the resend by the header value.
+    // `flush()` forces an immediate attempt and would bypass the backoff, so we
+    // let the worker retry on its own schedule and observe the gap.
     let mock = server.mock(|when, then| {
         when.method(POST);
         then.status(429).header("retry-after", "1");
     });
 
     let client = create_v0_client(server.base_url(), 2);
+    client.capture(Event::new("e", "user-1")).unwrap();
+
     let start = Instant::now();
-    let _ = client.capture(Event::new("e", "user-1"));
+    client.flush();
+    mock.assert_hits(1);
+    wait_for_hits(&mock, 2);
     let elapsed = start.elapsed();
 
     mock.assert_hits(2);
-    // Exponential backoff here would be ~1ms; only an honored Retry-After: 1
-    // produces a gap this large.
     assert!(
         elapsed >= Duration::from_millis(900),
-        "Retry-After header not honored: waited only {:?}",
+        "Retry-After header not honored: second attempt after only {:?}",
         elapsed
     );
 }

--- a/tests/test_v0_retry.rs
+++ b/tests/test_v0_retry.rs
@@ -1,5 +1,13 @@
 #![cfg(all(feature = "async-client", not(feature = "capture-v1")))]
 
+//! V0 retry behavior under the background transport. `capture` is a
+//! non-blocking enqueue, so these tests drive delivery with `flush()` (each
+//! flush makes one attempt per pending batch, ignoring backoff) and assert on
+//! the wire. Exhausting the attempt budget therefore takes `max_attempts`
+//! flushes; transient failures keep the event queued in between. The Retry-After
+//! test instead lets the worker retry on its own schedule so the header delay is
+//! observable.
+
 use std::io::Read;
 use std::time::{Duration, Instant};
 
@@ -15,7 +23,7 @@ async fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
         .api_key("phc_test_token".to_string())
         .host(base_url)
         .max_capture_attempts(max_attempts)
-        // Tiny backoffs keep the retry tests fast; the retry-after test below
+        // Tiny backoffs keep the scheduled-retry test fast; the retry-after test
         // relies on these being far smaller than the header value it asserts.
         .retry_initial_backoff_ms(1u64)
         .retry_max_backoff_ms(5u64)
@@ -24,20 +32,33 @@ async fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
     posthog_rs::client(options).await
 }
 
-/// Drive whichever v0 path (single `/i/v0/e/` vs `/batch/`) the test wants,
-/// so coverage of both stays DRY.
-async fn capture(client: &Client, batch: bool) -> Result<(), posthog_rs::Error> {
+/// Drive whichever capture entry point the test wants. Both now enqueue onto the
+/// same worker and send through `/batch/`.
+async fn capture(client: &Client, batch: bool) {
     if batch {
         client
             .capture_batch(vec![Event::new("e", "user-1")], false)
             .await
+            .unwrap();
     } else {
-        client.capture(Event::new("e", "user-1")).await
+        client.capture(Event::new("e", "user-1")).await.unwrap();
     }
 }
 
+/// Poll until a mock has been hit `want` times (for the autonomous retry path
+/// that isn't driven by `flush()`).
+fn wait_for_hits(mock: &httpmock::Mock, want: usize) {
+    for _ in 0..400 {
+        if mock.hits() >= want {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(mock.hits(), want, "timed out waiting for {want} hits");
+}
+
 #[tokio::test]
-async fn retryable_status_exhausts_attempts() {
+async fn retryable_status_keeps_retrying_until_attempts_exhausted() {
     for status in [408u16, 500, 502, 503, 504] {
         for batch in [false, true] {
             let server = MockServer::start();
@@ -46,15 +67,18 @@ async fn retryable_status_exhausts_attempts() {
                 then.status(status);
             });
 
+            // max_attempts = 3 → one attempt per flush, so three flushes drive
+            // the full budget before the event is dropped.
             let client = create_v0_client(server.base_url(), 3).await;
-            let result = capture(&client, batch).await;
+            capture(&client, batch).await;
+            client.flush().await;
+            client.flush().await;
+            client.flush().await;
 
-            assert!(
-                result.is_err(),
-                "status {} (batch={}) should error after exhausting retries",
-                status,
-                batch
-            );
+            mock.assert_hits(3);
+
+            // Budget exhausted: the event is dropped, so a further flush is a no-op.
+            client.flush().await;
             mock.assert_hits(3);
         }
     }
@@ -62,8 +86,8 @@ async fn retryable_status_exhausts_attempts() {
 
 #[tokio::test]
 async fn terminal_status_sends_once() {
-    // 429 here carries no Retry-After, so it is terminal (RateLimit), not
-    // retried — see `honors_retry_after_header` for the 429 + Retry-After case.
+    // 429 here carries no Retry-After, so it is terminal, not retried — see
+    // `honors_retry_after_header` for the 429 + Retry-After case.
     for status in [400u16, 401, 402, 403, 413, 415, 429] {
         for batch in [false, true] {
             let server = MockServer::start();
@@ -73,17 +97,12 @@ async fn terminal_status_sends_once() {
             });
 
             let client = create_v0_client(server.base_url(), 3).await;
-            let result = capture(&client, batch).await;
+            capture(&client, batch).await;
+            client.flush().await;
+            mock.assert_hits(1);
 
-            let err = result.expect_err(&format!("status {status} should be terminal"));
-            // A bare 429 (no Retry-After) is a terminal rate-limit, not a retry.
-            if status == 429 {
-                assert!(
-                    matches!(err, posthog_rs::Error::RateLimit),
-                    "429 should map to RateLimit, got {:?}",
-                    err
-                );
-            }
+            // Terminal: dropped, not retried.
+            client.flush().await;
             mock.assert_hits(1);
         }
     }
@@ -99,7 +118,8 @@ async fn success_sends_once() {
         });
 
         let client = create_v0_client(server.base_url(), 3).await;
-        capture(&client, batch).await.unwrap();
+        capture(&client, batch).await;
+        client.flush().await;
         mock.assert_hits(1);
     }
 }
@@ -117,7 +137,10 @@ async fn retries_resend_identical_event() {
     let client = create_v0_client(server.base_url(), 3).await;
     let mut event = Event::new("e", "user-1");
     event.set_uuid(uuid::Uuid::parse_str(FIXED_UUID).unwrap());
-    let _ = client.capture(event).await;
+    client.capture(event).await.unwrap();
+    client.flush().await;
+    client.flush().await;
+    client.flush().await;
 
     mock.assert_hits(3);
 }
@@ -157,6 +180,7 @@ async fn gzip_sets_header_query_param_and_compresses_body() {
         .capture(Event::new("test_event", "user1"))
         .await
         .unwrap();
+    client.flush().await;
 
     mock.assert();
 }
@@ -165,16 +189,23 @@ async fn gzip_sets_header_query_param_and_compresses_body() {
 async fn honors_retry_after_header() {
     let server = MockServer::start();
     // Mirrors the contract's `respects_retry_after_header`: a 429 carrying
-    // Retry-After must delay the resend by the header value, not the (tiny)
-    // exponential backoff.
+    // Retry-After must delay the resend by the header value. `flush()` forces an
+    // immediate attempt and would bypass the backoff, so we let the worker retry
+    // on its own schedule and observe the gap.
     let mock = server.mock(|when, then| {
         when.method(POST);
         then.status(429).header("retry-after", "1");
     });
 
     let client = create_v0_client(server.base_url(), 2).await;
+    client.capture(Event::new("e", "user-1")).await.unwrap();
+
+    // First attempt happens immediately on flush (429 + Retry-After schedules the
+    // resend ~1s out); the second attempt is left to the worker's timer.
     let start = Instant::now();
-    let _ = client.capture(Event::new("e", "user-1")).await;
+    client.flush().await;
+    mock.assert_hits(1);
+    wait_for_hits(&mock, 2);
     let elapsed = start.elapsed();
 
     mock.assert_hits(2);
@@ -182,7 +213,7 @@ async fn honors_retry_after_header() {
     // produces a gap this large.
     assert!(
         elapsed >= Duration::from_millis(900),
-        "Retry-After header not honored: waited only {:?}",
+        "Retry-After header not honored: second attempt after only {:?}",
         elapsed
     );
 }

--- a/tests/test_v1_blocking.rs
+++ b/tests/test_v1_blocking.rs
@@ -1,5 +1,13 @@
 #![cfg(all(not(feature = "async-client"), feature = "capture-v1"))]
 
+//! V1 capture behavior (blocking client) under the background transport.
+//! `capture` / `capture_batch` are non-blocking enqueues that always return
+//! `Ok`, so these tests drive delivery with `flush()` (each flush makes one
+//! attempt per pending batch, ignoring backoff). A retryable failure keeps the
+//! batch queued, so a later flush re-attempts it with an incremented
+//! `posthog-attempt`; exhausting the attempt budget takes `max_capture_attempts`
+//! flushes. Wire-format assertions are unchanged from the synchronous model.
+
 use httpmock::prelude::*;
 use posthog_rs::{ClientOptionsBuilder, Event};
 use serde_json::json;
@@ -56,8 +64,8 @@ fn v1_blocking_capture_success() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture(Event::new("test_event", "user-1"));
-    assert!(result.is_ok());
+    client.capture(Event::new("test_event", "user-1")).unwrap();
+    client.flush();
     mock.assert();
 }
 
@@ -85,9 +93,13 @@ fn v1_blocking_retries_on_server_error() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture(Event::new("test", "user-1"));
+    client.capture(Event::new("test", "user-1")).unwrap();
 
-    assert!(result.is_ok());
+    // First flush hits the 500 (attempt 1) and keeps the batch queued; the second
+    // flush re-attempts it (attempt 2) against the recovered endpoint.
+    client.flush();
+    client.flush();
+
     fail_mock.assert();
     success_mock.assert();
 }
@@ -102,9 +114,13 @@ fn v1_blocking_does_not_retry_on_401() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture(Event::new("test", "user-1"));
+    client.capture(Event::new("test", "user-1")).unwrap();
 
-    assert!(result.is_err());
+    // 401 is terminal: one attempt on flush, then dropped (not returned to the
+    // caller). A second flush proves there is no retry.
+    client.flush();
+    mock.assert_hits(1);
+    client.flush();
     mock.assert_hits(1);
 }
 
@@ -156,9 +172,14 @@ fn v1_blocking_partial_batch_retry() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture_batch(vec![event1, event2], false);
+    client.capture_batch(vec![event1, event2], false).unwrap();
 
-    assert!(result.is_ok());
+    // First flush (attempt 1) sends both events; the response marks one `ok` and
+    // one `retry`, so the worker keeps only the retry event. The second flush
+    // (attempt 2) re-sends just that pruned subset.
+    client.flush();
+    client.flush();
+
     first_mock.assert();
     retry_mock.assert();
 }
@@ -194,9 +215,15 @@ fn v1_blocking_does_not_retry_terminal_results() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture_batch(vec![ev_ok, ev_drop, ev_warning], false);
+    client
+        .capture_batch(vec![ev_ok, ev_drop, ev_warning], false)
+        .unwrap();
 
-    assert!(result.is_ok());
+    // All three per-event results are terminal (ok / drop / warning), so one
+    // flush finalizes the batch. A second flush has nothing left to re-send.
+    client.flush();
+    mock.assert_hits(1);
+    client.flush();
     mock.assert_hits(1);
 }
 
@@ -255,13 +282,13 @@ fn v1_blocking_whole_batch_resent_on_retryable_status() {
         });
 
         let client = create_v1_client(server.base_url());
-        let result = client.capture_batch(vec![event1, event2], false);
+        client.capture_batch(vec![event1, event2], false).unwrap();
 
-        assert!(
-            result.is_ok(),
-            "status {} should retry then succeed",
-            status
-        );
+        // First flush hits the retryable status (attempt 1) and keeps the whole
+        // batch queued; the second flush resends every event (attempt 2).
+        client.flush();
+        client.flush();
+
         fail_mock.assert();
         success_mock.assert();
     }
@@ -314,9 +341,17 @@ fn v1_blocking_prunes_terminal_events_on_partial_retry() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture_batch(vec![ev_retry, ev_drop], false);
+    client
+        .capture_batch(vec![ev_retry, ev_drop], false)
+        .unwrap();
 
-    assert!(result.is_ok());
+    // First flush (attempt 1) sends both events; the response marks one `retry`
+    // and one `drop` (terminal), so the worker keeps only the retry event. The
+    // second flush (attempt 2) re-sends just that event, with the dropped one
+    // pruned.
+    client.flush();
+    client.flush();
+
     first_mock.assert();
     retry_mock.assert();
 }
@@ -342,10 +377,17 @@ fn v1_blocking_partial_retry_exhausts_attempts() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture(event);
+    client.capture(event).unwrap();
 
-    // 200 path returns Ok even when retries are exhausted.
-    assert!(result.is_ok());
+    // Every 200 response marks the event `retry`, so each flush re-attempts it
+    // (attempts 1, 2, 3) until the budget is spent and the event is dropped.
+    client.flush();
+    client.flush();
+    client.flush();
+    mock.assert_hits(3);
+
+    // Budget exhausted: a further flush is a no-op.
+    client.flush();
     mock.assert_hits(3);
 }
 
@@ -396,6 +438,11 @@ fn v1_blocking_request_id_stable_across_retries() {
     let client = create_v1_client(server.base_url());
     client.capture(Event::new("test", "user-1")).unwrap();
 
+    // First flush sends attempt 1 (503, kept queued); the second flush re-attempts
+    // it (attempt 2). Both requests must carry the same posthog-request-id.
+    client.flush();
+    client.flush();
+
     fail_mock.assert();
     success_mock.assert();
 
@@ -422,12 +469,14 @@ fn v1_blocking_does_not_retry_on_402() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture(Event::new("test", "user-1"));
+    client.capture(Event::new("test", "user-1")).unwrap();
 
-    assert!(matches!(
-        result,
-        Err(posthog_rs::Error::BillingLimitExceeded(_))
-    ));
+    // 402 (billing limit) is terminal: one attempt on flush, then dropped. The
+    // billing error is logged, not returned to the caller. A second flush proves
+    // there is no retry.
+    client.flush();
+    mock.assert_hits(1);
+    client.flush();
     mock.assert_hits(1);
 }
 
@@ -446,9 +495,17 @@ fn v1_blocking_exhausts_retries() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture(Event::new("test", "user-1"));
+    client.capture(Event::new("test", "user-1")).unwrap();
 
-    assert!(result.is_err());
+    // 500 is retryable: one attempt per flush (attempts 1, 2, 3) until the budget
+    // is spent and the event is dropped — the error is logged, not returned.
+    client.flush();
+    client.flush();
+    client.flush();
+    mock.assert_hits(3);
+
+    // Budget exhausted: a further flush is a no-op.
+    client.flush();
     mock.assert_hits(3);
 }
 
@@ -472,6 +529,7 @@ fn v1_blocking_sends_event_options() {
     event.set_option("process_person_profile", false).unwrap();
 
     client.capture(event).unwrap();
+    client.flush();
     mock.assert();
 }
 
@@ -497,6 +555,7 @@ fn v1_blocking_injects_geoip_disable_when_configured() {
     let client = posthog_rs::client(options);
 
     client.capture(Event::new("test", "user-1")).unwrap();
+    client.flush();
     mock.assert();
 }
 
@@ -515,6 +574,7 @@ fn v1_blocking_injects_is_server_by_default() {
 
     let client = create_v1_client(server.base_url());
     client.capture(Event::new("test", "user-1")).unwrap();
+    client.flush();
     mock.assert();
 }
 
@@ -535,6 +595,7 @@ fn v1_blocking_caller_override_wins_for_is_server() {
     let mut event = Event::new("test", "user-1");
     event.insert_prop("$is_server", false).unwrap();
     client.capture(event).unwrap();
+    client.flush();
     mock.assert();
 }
 
@@ -554,6 +615,7 @@ fn v1_blocking_batch_sets_historical_migration() {
     let client = create_v1_client(server.base_url());
     let events = vec![Event::new("a", "user-1"), Event::new("b", "user-1")];
     client.capture_batch(events, true).unwrap();
+    client.flush();
     mock.assert();
 }
 
@@ -596,6 +658,7 @@ fn v1_blocking_sends_gzip_content_encoding() {
     let client = posthog_rs::client(options);
 
     client.capture(Event::new("test", "user-1")).unwrap();
+    client.flush();
     mock.assert();
 }
 
@@ -634,6 +697,10 @@ fn v1_blocking_preserves_uuid_and_timestamp_across_retries() {
         .unwrap();
 
     client.capture(event).unwrap();
+    // First flush sends attempt 1 (503, kept queued); second flush re-sends the
+    // same bytes as attempt 2 — proving uuid + timestamp survive the retry.
+    client.flush();
+    client.flush();
     fail_mock.assert();
     success_mock.assert();
 }
@@ -650,9 +717,10 @@ fn v1_blocking_capture_batch_empty_is_noop() {
     });
 
     let client = create_v1_client(server.base_url());
-    let result = client.capture_batch(vec![], false);
+    client.capture_batch(vec![], false).unwrap();
+    client.flush();
 
-    assert!(result.is_ok());
+    // An empty batch enqueues nothing, so flushing sends no request.
     mock.assert_hits(0);
 }
 

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -1,5 +1,16 @@
 #![cfg(all(feature = "async-client", feature = "capture-v1"))]
 
+//! V1 capture behavior under the background transport. `capture` /
+//! `capture_batch` are non-blocking enqueues that always return `Ok`, so these
+//! tests drive delivery with `flush()` (each flush makes one attempt per pending
+//! batch, ignoring backoff). A retryable failure keeps the batch queued, so a
+//! later flush re-attempts it with an incremented `posthog-attempt`; exhausting
+//! the attempt budget takes `max_capture_attempts` flushes. The Retry-After test
+//! instead lets the worker retry on its own schedule so the header delay is
+//! observable. Wire-format assertions are unchanged from the synchronous model.
+
+use std::time::Duration;
+
 use httpmock::prelude::*;
 use posthog_rs::{ClientOptionsBuilder, Event};
 use serde_json::json;
@@ -40,6 +51,18 @@ fn retry_body_prunes_terminal_events(req: &HttpMockRequest) -> bool {
     body.contains(PARTIAL_UUID_RETRY) && !body.contains(PARTIAL_UUID_DROP)
 }
 
+/// Poll until a mock has been hit `want` times (for the autonomous retry path
+/// that isn't driven by `flush()`).
+fn wait_for_hits(mock: &httpmock::Mock, want: usize) {
+    for _ in 0..400 {
+        if mock.hits() >= want {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(mock.hits(), want, "timed out waiting for {want} hits");
+}
+
 #[tokio::test]
 async fn v1_capture_single_event_success() {
     let server = MockServer::start();
@@ -66,8 +89,8 @@ async fn v1_capture_single_event_success() {
     let mut event = Event::new("test_event", "user-1");
     event.set_uuid(uuid);
 
-    let result = client.capture(event).await;
-    assert!(result.is_ok());
+    client.capture(event).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -88,6 +111,7 @@ async fn v1_capture_bearer_auth_header() {
 
     let client = create_v1_client(server.base_url()).await;
     client.capture(Event::new("test", "user-1")).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -120,9 +144,13 @@ async fn v1_capture_retries_on_server_error() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client.capture(Event::new("test", "user-1")).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
 
-    assert!(result.is_ok());
+    // First flush hits the 503 (attempt 1) and keeps the batch queued; the second
+    // flush re-attempts it (attempt 2) against the recovered endpoint.
+    client.flush().await;
+    client.flush().await;
+
     fail_mock.assert();
     success_mock.assert();
 }
@@ -142,9 +170,13 @@ async fn v1_capture_does_not_retry_on_401() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client.capture(Event::new("test", "user-1")).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
 
-    assert!(result.is_err());
+    // 401 is terminal: one attempt on flush, then dropped (not returned to the
+    // caller). A second flush proves there is no retry.
+    client.flush().await;
+    mock.assert_hits(1);
+    client.flush().await;
     mock.assert_hits(1);
 }
 
@@ -163,12 +195,14 @@ async fn v1_capture_does_not_retry_on_402() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client.capture(Event::new("test", "user-1")).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
 
-    assert!(matches!(
-        result,
-        Err(posthog_rs::Error::BillingLimitExceeded(_))
-    ));
+    // 402 (billing limit) is terminal: one attempt on flush, then dropped. The
+    // billing error is logged, not returned to the caller. A second flush proves
+    // there is no retry.
+    client.flush().await;
+    mock.assert_hits(1);
+    client.flush().await;
     mock.assert_hits(1);
 }
 
@@ -220,9 +254,17 @@ async fn v1_capture_partial_batch_retry() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client.capture_batch(vec![event1, event2], false).await;
+    client
+        .capture_batch(vec![event1, event2], false)
+        .await
+        .unwrap();
 
-    assert!(result.is_ok());
+    // First flush (attempt 1) sends both events; the response marks one `ok` and
+    // one `retry`, so the worker keeps only the retry event. The second flush
+    // (attempt 2) re-sends just that pruned subset.
+    client.flush().await;
+    client.flush().await;
+
     first_mock.assert();
     retry_mock.assert();
 }
@@ -258,11 +300,16 @@ async fn v1_capture_does_not_retry_terminal_results() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client
+    client
         .capture_batch(vec![ev_ok, ev_drop, ev_warning], false)
-        .await;
+        .await
+        .unwrap();
 
-    assert!(result.is_ok());
+    // All three per-event results are terminal (ok / drop / warning), so one
+    // flush finalizes the batch. A second flush has nothing left to re-send.
+    client.flush().await;
+    mock.assert_hits(1);
+    client.flush().await;
     mock.assert_hits(1);
 }
 
@@ -321,13 +368,16 @@ async fn v1_capture_whole_batch_resent_on_retryable_status() {
         });
 
         let client = create_v1_client(server.base_url()).await;
-        let result = client.capture_batch(vec![event1, event2], false).await;
+        client
+            .capture_batch(vec![event1, event2], false)
+            .await
+            .unwrap();
 
-        assert!(
-            result.is_ok(),
-            "status {} should retry then succeed",
-            status
-        );
+        // First flush hits the retryable status (attempt 1) and keeps the whole
+        // batch queued; the second flush resends every event (attempt 2).
+        client.flush().await;
+        client.flush().await;
+
         fail_mock.assert();
         success_mock.assert();
     }
@@ -354,10 +404,17 @@ async fn v1_capture_partial_retry_exhausts_attempts() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client.capture(event).await;
+    client.capture(event).await.unwrap();
 
-    // 200 path returns Ok even when retries are exhausted.
-    assert!(result.is_ok());
+    // Every 200 response marks the event `retry`, so each flush re-attempts it
+    // (attempts 1, 2, 3) until the budget is spent and the event is dropped.
+    client.flush().await;
+    client.flush().await;
+    client.flush().await;
+    mock.assert_hits(3);
+
+    // Budget exhausted: a further flush is a no-op.
+    client.flush().await;
     mock.assert_hits(3);
 }
 
@@ -376,9 +433,17 @@ async fn v1_capture_exhausts_retries() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client.capture(Event::new("test", "user-1")).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
 
-    assert!(result.is_err());
+    // 500 is retryable: one attempt per flush (attempts 1, 2, 3) until the budget
+    // is spent and the event is dropped — the error is logged, not returned.
+    client.flush().await;
+    client.flush().await;
+    client.flush().await;
+    mock.assert_hits(3);
+
+    // Budget exhausted: a further flush is a no-op.
+    client.flush().await;
     mock.assert_hits(3);
 }
 
@@ -404,6 +469,7 @@ async fn v1_capture_sends_event_options() {
     event.set_option("process_person_profile", false).unwrap();
 
     client.capture(event).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -429,6 +495,7 @@ async fn v1_capture_injects_geoip_disable_when_configured() {
     let client = posthog_rs::client(options).await;
 
     client.capture(Event::new("test", "user-1")).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -447,6 +514,7 @@ async fn v1_capture_injects_is_server_by_default() {
 
     let client = create_v1_client(server.base_url()).await;
     client.capture(Event::new("test", "user-1")).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -479,6 +547,7 @@ async fn v1_capture_applies_runtime_context_defaults_and_preserves_caller_values
             event.insert_prop("$os_version", os_version).unwrap();
         }
         client.capture(event).await.unwrap();
+        client.flush().await;
         mock.assert();
     }
 }
@@ -500,6 +569,7 @@ async fn v1_capture_caller_override_wins_for_is_server() {
     let mut event = Event::new("test", "user-1");
     event.insert_prop("$is_server", false).unwrap();
     client.capture(event).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -533,6 +603,7 @@ async fn v1_before_send_runs_after_capture_defaults() {
     let client = posthog_rs::client(options).await;
 
     client.capture(Event::new("test", "user-1")).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -569,6 +640,7 @@ async fn v1_batch_before_send_runs_after_capture_defaults() {
         .capture_batch(vec![Event::new("test", "user-1")], false)
         .await
         .unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -588,6 +660,7 @@ async fn v1_capture_batch_sets_historical_migration() {
     let client = create_v1_client(server.base_url()).await;
     let events = vec![Event::new("a", "user-1"), Event::new("b", "user-1")];
     client.capture_batch(events, true).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -626,6 +699,10 @@ async fn v1_capture_preserves_uuid_and_timestamp_across_retries() {
         .unwrap();
 
     client.capture(event).await.unwrap();
+    // First flush sends attempt 1 (503, kept queued); second flush re-sends the
+    // same bytes as attempt 2 — proving uuid + timestamp survive the retry.
+    client.flush().await;
+    client.flush().await;
     fail_mock.assert();
     success_mock.assert();
 }
@@ -671,6 +748,7 @@ async fn v1_capture_sends_gzip_content_encoding() {
     let client = posthog_rs::client(options).await;
 
     client.capture(Event::new("test", "user-1")).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -700,18 +778,23 @@ async fn v1_capture_honors_retry_after_header() {
     });
 
     let client = create_v1_client(server.base_url()).await;
+    client.capture(Event::new("test", "user-1")).await.unwrap();
+
+    // First attempt happens immediately on flush (503 + Retry-After schedules the
+    // resend ~1s out); the second attempt is left to the worker's timer, so the
+    // header delay is observable rather than bypassed by flush().
     let start = Instant::now();
-    let result = client.capture(Event::new("test", "user-1")).await;
+    client.flush().await;
+    fail_mock.assert();
+    wait_for_hits(&success_mock, 1);
     let elapsed = start.elapsed();
 
-    assert!(result.is_ok());
-    fail_mock.assert();
     success_mock.assert();
     // The client's exponential backoff here is ~10ms; only an honored
     // Retry-After: 1 produces a gap this large.
     assert!(
         elapsed >= Duration::from_millis(900),
-        "Retry-After header not honored: waited only {:?}",
+        "Retry-After header not honored: second attempt after only {:?}",
         elapsed
     );
 }
@@ -763,9 +846,18 @@ async fn v1_capture_prunes_terminal_events_on_partial_retry() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client.capture_batch(vec![ev_retry, ev_drop], false).await;
+    client
+        .capture_batch(vec![ev_retry, ev_drop], false)
+        .await
+        .unwrap();
 
-    assert!(result.is_ok());
+    // First flush (attempt 1) sends both events; the response marks one `retry`
+    // and one `drop` (terminal), so the worker keeps only the retry event. The
+    // second flush (attempt 2) re-sends just that event, with the dropped one
+    // pruned.
+    client.flush().await;
+    client.flush().await;
+
     first_mock.assert();
     retry_mock.assert();
 }
@@ -817,6 +909,11 @@ async fn v1_capture_request_id_stable_across_retries() {
     let client = create_v1_client(server.base_url()).await;
     client.capture(Event::new("test", "user-1")).await.unwrap();
 
+    // First flush sends attempt 1 (503, kept queued); the second flush re-attempts
+    // it (attempt 2). Both requests must carry the same posthog-request-id.
+    client.flush().await;
+    client.flush().await;
+
     fail_mock.assert();
     success_mock.assert();
 
@@ -849,8 +946,12 @@ async fn v1_capture_accepts_alternate_2xx_status() {
     let mut event = Event::new("test", "user-1");
     event.set_uuid(uuid);
 
-    let result = client.capture(event).await;
-    assert!(result.is_ok(), "201 should be accepted as success");
+    // A 201 (alternate 2xx) is treated as success, not a connection error, so the
+    // batch is finalized after a single attempt.
+    client.capture(event).await.unwrap();
+    client.flush().await;
+    mock.assert_hits(1);
+    client.flush().await;
     mock.assert_hits(1);
 }
 
@@ -873,6 +974,7 @@ async fn v1_capture_sends_canonical_sdk_info_header() {
 
     let client = create_v1_client(server.base_url()).await;
     client.capture(Event::new("test", "user-1")).await.unwrap();
+    client.flush().await;
     mock.assert();
 }
 
@@ -888,9 +990,10 @@ async fn v1_capture_batch_empty_is_noop() {
     });
 
     let client = create_v1_client(server.base_url()).await;
-    let result = client.capture_batch(vec![], false).await;
+    client.capture_batch(vec![], false).await.unwrap();
+    client.flush().await;
 
-    assert!(result.is_ok());
+    // An empty batch enqueues nothing, so flushing sends no request.
     mock.assert_hits(0);
 }
 


### PR DESCRIPTION
Stacked on #145 (base branch `ci/rust-event-transport`) — review/merge that first.

## What

Addresses the head-of-line blocking raised in review: the single transport worker did the blocking POST inline, so one slow or stalled endpoint blocked draining and could fill the bounded queue.

Splits the worker into:
- a **dispatcher** thread that owns the buffer, retry queue, and schedule (single-owner, no lock), and
- a small **sender pool** (`min(cores, 4)`) that runs the blocking POSTs concurrently and reports each outcome back.

A slow endpoint now stalls at most one sender instead of the whole pipeline. `flush()`/`shutdown()` stay barriers that complete once the sends they dispatched report back. Cross-batch ordering becomes best-effort, which is fine now that event timestamps are stamped at capture time (#145).

Adds `crossbeam-channel` for the MPMC job queue plus a `select` over the control/outcome channels — std `mpsc` is single-consumer, so a pool would otherwise serialize on a mutex-wrapped receiver. Deliberately not a tokio task: the worker stays runtime-independent (blocking client + a future panic hook).

## Review (autoreview)

Ran a structured review over the diff across several rounds; it caught 5 real bugs in the shutdown/barrier semantics, all fixed with regression tests:
- queued sender jobs kept POSTing past `shutdown_timeout` → abandon flag
- a pre-shutdown in-flight batch that failed transiently was dropped instead of getting its final attempt → re-dispatch as final
- `flush()` could wait on captures that arrived after the call → defer + replay
- abandoned in-flight retries leaked the `pending_events` count → accounted on send failure
- v0 `sent_at` was stale on retries → stamped per attempt

Known limitation (deferred, documented in code): `flush()` under concurrent multi-threaded calls can under-wait — a pre-existing global-barrier limitation; a precise fix needs per-flush generation tracking. Tracked as a follow-up.

## Tests

Full gate green: fmt, clippy (`-D warnings`, v0 + v1), public-api snapshot, `publish --dry-run`, and every unit-test feature config (default, `--workspace`, capture-v1 async + blocking, error-tracking blocking, error-tracking + capture-v1, e2e). Added deterministic regression tests for the pool.
