### PR TITLE
refactor: internalize EventOptions on the capture-v1 path

### DIFF
--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -195,19 +195,11 @@ pub fn posthog_rs::Event::event_name(&self) -> &str
 pub fn posthog_rs::Event::insert_prop<K: core::convert::Into<alloc::string::String>, P: serde_core::ser::Serialize>(&mut self, K, P) -> core::result::Result<(), posthog_rs::Error>
 pub fn posthog_rs::Event::new<S: core::convert::Into<alloc::string::String>>(S, S) -> Self
 pub fn posthog_rs::Event::new_anon<S: core::convert::Into<alloc::string::String>>(S) -> Self
-pub fn posthog_rs::Event::options(&self) -> &posthog_rs::EventOptions
 pub fn posthog_rs::Event::properties(&self) -> &std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>
 pub fn posthog_rs::Event::remove_prop(&mut self, &str) -> core::option::Option<serde_json::value::Value>
-pub fn posthog_rs::Event::set_option<V: serde_core::ser::Serialize>(&mut self, &str, V) -> core::result::Result<(), posthog_rs::Error>
 pub fn posthog_rs::Event::set_timestamp<Tz>(&mut self, chrono::datetime::DateTime<Tz>) -> core::result::Result<(), posthog_rs::Error> where Tz: chrono::offset::TimeZone
 pub fn posthog_rs::Event::set_uuid(&mut self, uuid::Uuid)
 pub fn posthog_rs::Event::with_flags(&mut self, &posthog_rs::FeatureFlagEvaluations) -> &mut Self
-pub struct posthog_rs::EventOptions
-pub posthog_rs::EventOptions::cookieless_mode: core::option::Option<bool>
-pub posthog_rs::EventOptions::disable_skew_correction: core::option::Option<bool>
-pub posthog_rs::EventOptions::extra: std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>
-pub posthog_rs::EventOptions::process_person_profile: core::option::Option<bool>
-pub posthog_rs::EventOptions::product_tour_id: core::option::Option<alloc::string::String>
 pub struct posthog_rs::EventResult
 pub posthog_rs::EventResult::details: core::option::Option<alloc::string::String>
 pub posthog_rs::EventResult::result: posthog_rs::EventStatus

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -284,7 +284,18 @@ async fn capture_event(
         if let Some(opts_val) = req.options {
             if let Some(obj) = opts_val.as_object() {
                 for (k, v) in obj {
-                    let _ = event.set_option(k, v.clone());
+                    // Translate option keys to the magic property keys that the
+                    // SDK extracts into V1 wire options during capture.
+                    let prop_key = match k.as_str() {
+                        "disable_skew_correction" => "$ignore_sent_at",
+                        other => {
+                            // Most option keys map to $<key>.
+                            let owned = format!("${other}");
+                            let _ = event.insert_prop(owned, v.clone());
+                            continue;
+                        }
+                    };
+                    let _ = event.insert_prop(prop_key, v.clone());
                 }
             }
         }

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -23,6 +23,18 @@ struct AppState {
 
 const DEFAULT_TEST_ID: &str = "_global";
 
+/// Harness wire-option key -> the magic property the SDK re-lifts into V1
+/// options. Mirrors (in inverse) the SDK's internal `OPTIONS_EXTRACTION_TABLE`;
+/// agreement is enforced by the capture_v1 compliance suite (`assert_event_option`),
+/// so any drift fails CI rather than shipping silently.
+#[cfg(feature = "capture-v1")]
+const HARNESS_OPTION_TO_PROP: &[(&str, &str)] = &[
+    ("cookieless_mode", "$cookieless_mode"),
+    ("disable_skew_correction", "$ignore_sent_at"),
+    ("product_tour_id", "$product_tour_id"),
+    ("process_person_profile", "$process_person_profile"),
+];
+
 #[derive(Default)]
 struct AdapterState {
     client: Option<Arc<Client>>,
@@ -284,18 +296,21 @@ async fn capture_event(
         if let Some(opts_val) = req.options {
             if let Some(obj) = opts_val.as_object() {
                 for (k, v) in obj {
-                    // Translate option keys to the magic property keys that the
-                    // SDK extracts into V1 wire options during capture.
-                    let prop_key = match k.as_str() {
-                        "disable_skew_correction" => "$ignore_sent_at",
-                        other => {
-                            // Most option keys map to $<key>.
-                            let owned = format!("${other}");
-                            let _ = event.insert_prop(owned, v.clone());
-                            continue;
+                    // Translate the harness wire-option key to the magic property
+                    // the SDK re-lifts into V1 options. Unknown keys fall back to
+                    // $<key>. Agreement with the SDK's extraction is enforced by
+                    // the capture_v1 compliance suite, so drift fails CI.
+                    match HARNESS_OPTION_TO_PROP
+                        .iter()
+                        .find(|(opt, _)| *opt == k.as_str())
+                    {
+                        Some((_, prop_key)) => {
+                            let _ = event.insert_prop(*prop_key, v.clone());
                         }
-                    };
-                    let _ = event.insert_prop(prop_key, v.clone());
+                        None => {
+                            let _ = event.insert_prop(format!("${k}"), v.clone());
+                        }
+                    }
                 }
             }
         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,39 @@
+//! Canonical "magic" property keys and their V1 wire option-key counterparts.
+//!
+//! Single source of truth for the property-to-options mapping the SDK derives
+//! internally (mirrors the PostHog backend reverse-extraction in
+//! `capture_v1.py` / `analytics/types.rs`). Crate-internal only.
+
+/// Controls person-profile processing. Written by [`crate::Event::new_anon`]
+/// (false) and [`crate::Event::add_group`] (true), and lifted into the V1 wire
+/// options. Used on the v0 path too, so it is always compiled.
+pub(crate) const PROCESS_PERSON_PROFILE_PROP: &str = "$process_person_profile";
+
+#[cfg(feature = "capture-v1")]
+pub(crate) use v1::*;
+
+#[cfg(feature = "capture-v1")]
+mod v1 {
+    use super::PROCESS_PERSON_PROFILE_PROP;
+
+    // Property keys lifted out of `Event.properties`.
+    pub(crate) const COOKIELESS_MODE_PROP: &str = "$cookieless_mode";
+    pub(crate) const IGNORE_SENT_AT_PROP: &str = "$ignore_sent_at";
+    pub(crate) const PRODUCT_TOUR_ID_PROP: &str = "$product_tour_id";
+    pub(crate) const SESSION_ID_PROP: &str = "$session_id";
+    pub(crate) const WINDOW_ID_PROP: &str = "$window_id";
+
+    // V1 wire option-object keys.
+    pub(crate) const COOKIELESS_MODE_OPT: &str = "cookieless_mode";
+    pub(crate) const DISABLE_SKEW_CORRECTION_OPT: &str = "disable_skew_correction";
+    pub(crate) const PRODUCT_TOUR_ID_OPT: &str = "product_tour_id";
+    pub(crate) const PROCESS_PERSON_PROFILE_OPT: &str = "process_person_profile";
+
+    /// (property key, wire option key) pairs lifted into the V1 `options` map.
+    pub(crate) const OPTIONS_EXTRACTION_TABLE: &[(&str, &str)] = &[
+        (COOKIELESS_MODE_PROP, COOKIELESS_MODE_OPT),
+        (IGNORE_SENT_AT_PROP, DISABLE_SKEW_CORRECTION_OPT),
+        (PRODUCT_TOUR_ID_PROP, PRODUCT_TOUR_ID_OPT),
+        (PROCESS_PERSON_PROFILE_PROP, PROCESS_PERSON_PROFILE_OPT),
+    ];
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,30 +2,12 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 use semver::Version;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use uuid::Uuid;
 
 use crate::client::CRATE_VERSION;
 use crate::feature_flag_evaluations::FeatureFlagEvaluations;
 use crate::Error;
-
-/// Per-event V1 capture options. Known fields are typed; unknown keys go into
-/// `extra` via `#[serde(flatten)]` for forward compatibility with new backend
-/// options without requiring an SDK update.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct EventOptions {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cookieless_mode: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub disable_skew_correction: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub product_tour_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub process_person_profile: Option<bool>,
-
-    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
-    pub extra: HashMap<String, serde_json::Value>,
-}
 
 /// An [`Event`] represents an interaction a user has with your app or
 /// website. Examples include button clicks, pageviews, query completions, and signups.
@@ -39,8 +21,6 @@ pub struct Event {
     groups: HashMap<String, String>,
     timestamp: Option<NaiveDateTime>,
     uuid: Uuid,
-    #[serde(skip)]
-    options: EventOptions,
 }
 
 impl Event {
@@ -61,7 +41,6 @@ impl Event {
             groups: HashMap::new(),
             timestamp: None,
             uuid: Uuid::now_v7(),
-            options: EventOptions::default(),
         }
     }
 
@@ -78,17 +57,18 @@ impl Event {
     /// Generates a random distinct ID and sets `$process_person_profile` to
     /// `false` so PostHog does not create a person profile for the event.
     pub fn new_anon<S: Into<String>>(event: S) -> Self {
+        let mut properties = HashMap::new();
+        properties.insert(
+            "$process_person_profile".into(),
+            serde_json::Value::Bool(false),
+        );
         Self {
             event: event.into(),
             distinct_id: Uuid::now_v7().to_string(),
-            properties: HashMap::new(),
+            properties,
             groups: HashMap::new(),
             timestamp: None,
             uuid: Uuid::now_v7(),
-            options: EventOptions {
-                process_person_profile: Some(false),
-                ..EventOptions::default()
-            },
         }
     }
 
@@ -133,7 +113,10 @@ impl Event {
     /// include person profile processing if they were anonymous. This might lead
     /// to "empty" person profiles being created.
     pub fn add_group(&mut self, group_name: &str, group_id: &str) {
-        self.options.process_person_profile = Some(true);
+        self.properties.insert(
+            "$process_person_profile".into(),
+            serde_json::Value::Bool(true),
+        );
         self.groups.insert(group_name.into(), group_id.into());
     }
 
@@ -185,29 +168,6 @@ impl Event {
         self
     }
 
-    /// Set or reset a V1 capture option by key. Known keys route to typed
-    /// fields; unknown keys go into the forward-compatible overflow map.
-    #[cfg(feature = "capture-v1")]
-    pub fn set_option<V: Serialize>(&mut self, key: &str, value: V) -> Result<(), Error> {
-        let val = serde_json::to_value(value).map_err(|e| Error::Serialization(e.to_string()))?;
-        match key {
-            "cookieless_mode" => self.options.cookieless_mode = val.as_bool(),
-            "disable_skew_correction" => self.options.disable_skew_correction = val.as_bool(),
-            "process_person_profile" => self.options.process_person_profile = val.as_bool(),
-            "product_tour_id" => self.options.product_tour_id = val.as_str().map(|s| s.to_string()),
-            _ => {
-                self.options.extra.insert(key.to_owned(), val);
-            }
-        }
-        Ok(())
-    }
-
-    /// Access the event options.
-    #[cfg(feature = "capture-v1")]
-    pub fn options(&self) -> &EventOptions {
-        &self.options
-    }
-
     /// Return the event name.
     #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
     pub fn event_name(&self) -> &str {
@@ -254,9 +214,12 @@ impl Event {
         &self.groups
     }
 
-    /// Translate `options` and `groups` into V0 properties and inject SDK
-    /// metadata. Call this before constructing [`InnerEvent`] so that the
-    /// wire payload matches what the V0 `/capture` and `/batch` endpoints expect.
+    /// Inject SDK metadata and `$groups` into V0 properties.
+    /// Call before constructing [`InnerEvent`] so that the wire payload matches
+    /// what the V0 `/capture` and `/batch` endpoints expect.
+    ///
+    /// `$process_person_profile` is already in `properties` when set by
+    /// constructors (`new_anon`, `add_group`) or explicit `insert_prop`.
     #[cfg_attr(feature = "capture-v1", allow(dead_code))]
     pub(crate) fn prepare_for_v0(&mut self) {
         if !self.properties.contains_key("$lib") {
@@ -289,12 +252,6 @@ impl Event {
                     serde_json::Value::Number(version.patch.into()),
                 );
             }
-        }
-
-        if let Some(ppp) = self.options.process_person_profile {
-            self.properties
-                .entry("$process_person_profile".into())
-                .or_insert_with(|| serde_json::Value::Bool(ppp));
         }
 
         if !self.groups.is_empty() {
@@ -502,8 +459,9 @@ pub mod tests {
     }
 
     #[test]
-    fn v0_user_property_wins_over_options_injection() {
+    fn v0_user_property_wins_over_constructor_default() {
         let mut event = Event::new_anon("test");
+        // new_anon sets $process_person_profile=false; explicit insert overwrites.
         event.insert_prop("$process_person_profile", true).unwrap();
         let inner = build_v0(event);
         assert_eq!(

--- a/src/event.rs
+++ b/src/event.rs
@@ -469,6 +469,31 @@ pub mod tests {
             Some(&serde_json::Value::Bool(true)),
         );
     }
+
+    #[test]
+    fn v0_identified_event_with_explicit_personless() {
+        let mut event = Event::new("test", "user1");
+        event.insert_prop("$process_person_profile", false).unwrap();
+        let inner = build_v0(event);
+        assert_eq!(
+            inner.properties.get("$process_person_profile"),
+            Some(&serde_json::Value::Bool(false)),
+        );
+    }
+
+    #[test]
+    fn v0_add_group_overrides_anon_person_profile() {
+        let mut event = Event::new_anon("test");
+        // new_anon sets $process_person_profile=false; add_group forces true.
+        event.add_group("company", "acme");
+        let inner = build_v0(event);
+        assert_eq!(
+            inner.properties.get("$process_person_profile"),
+            Some(&serde_json::Value::Bool(true)),
+        );
+        let groups = inner.properties.get("$groups").unwrap().as_object().unwrap();
+        assert_eq!(groups.get("company").unwrap().as_str().unwrap(), "acme");
+    }
 }
 
 #[cfg(test)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -59,7 +59,7 @@ impl Event {
     pub fn new_anon<S: Into<String>>(event: S) -> Self {
         let mut properties = HashMap::new();
         properties.insert(
-            "$process_person_profile".into(),
+            crate::constants::PROCESS_PERSON_PROFILE_PROP.into(),
             serde_json::Value::Bool(false),
         );
         Self {
@@ -114,7 +114,7 @@ impl Event {
     /// to "empty" person profiles being created.
     pub fn add_group(&mut self, group_name: &str, group_id: &str) {
         self.properties.insert(
-            "$process_person_profile".into(),
+            crate::constants::PROCESS_PERSON_PROFILE_PROP.into(),
             serde_json::Value::Bool(true),
         );
         self.groups.insert(group_name.into(), group_id.into());

--- a/src/event.rs
+++ b/src/event.rs
@@ -491,7 +491,12 @@ pub mod tests {
             inner.properties.get("$process_person_profile"),
             Some(&serde_json::Value::Bool(true)),
         );
-        let groups = inner.properties.get("$groups").unwrap().as_object().unwrap();
+        let groups = inner
+            .properties
+            .get("$groups")
+            .unwrap()
+            .as_object()
+            .unwrap();
         assert_eq!(groups.get("company").unwrap().as_str().unwrap(), "acme");
     }
 }

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -4,16 +4,8 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::constants::{OPTIONS_EXTRACTION_TABLE, SESSION_ID_PROP, WINDOW_ID_PROP};
 use crate::event::Event;
-
-/// Property keys that are lifted out of `event.properties` and placed into the
-/// V1 wire `options` map. The tuple is (property_key, wire_option_key).
-const OPTIONS_EXTRACTION_TABLE: &[(&str, &str)] = &[
-    ("$cookieless_mode", "cookieless_mode"),
-    ("$ignore_sent_at", "disable_skew_correction"),
-    ("$product_tour_id", "product_tour_id"),
-    ("$process_person_profile", "process_person_profile"),
-];
 
 /// Crate-internal V1 capture options, derived from `event.properties`.
 /// Serializes as a JSON object; an empty map produces `"options":{}`.
@@ -65,10 +57,10 @@ impl V1Event {
         }
 
         let session_id = properties
-            .remove("$session_id")
+            .remove(SESSION_ID_PROP)
             .and_then(|v| v.as_str().map(String::from));
         let window_id = properties
-            .remove("$window_id")
+            .remove(WINDOW_ID_PROP)
             .and_then(|v| v.as_str().map(String::from));
 
         Self {

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -444,4 +444,39 @@ mod tests {
         let props = v1.properties.as_object().unwrap();
         assert!(!props.contains_key("$process_person_profile"));
     }
+
+    #[test]
+    fn v1_identified_event_with_explicit_personless() {
+        let mut event = Event::new("test", "user-1");
+        event
+            .insert_prop("$process_person_profile", false)
+            .unwrap();
+        let v1 = V1Event::from_event(&event);
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+        assert_eq!(
+            options.get("process_person_profile"),
+            Some(&serde_json::json!(false))
+        );
+        let props = v1.properties.as_object().unwrap();
+        assert!(!props.contains_key("$process_person_profile"));
+    }
+
+    #[test]
+    fn v1_add_group_overrides_anon_person_profile() {
+        let mut event = Event::new_anon("test");
+        // new_anon sets $process_person_profile=false; add_group forces true.
+        event.add_group("company", "acme");
+        let v1 = V1Event::from_event(&event);
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+        assert_eq!(
+            options.get("process_person_profile"),
+            Some(&serde_json::json!(true))
+        );
+        let props = v1.properties.as_object().unwrap();
+        assert!(!props.contains_key("$process_person_profile"));
+        let groups = props.get("$groups").unwrap().as_object().unwrap();
+        assert_eq!(groups.get("company").unwrap().as_str().unwrap(), "acme");
+    }
 }

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -4,7 +4,21 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::event::{Event, EventOptions};
+use crate::event::Event;
+
+/// Property keys that are lifted out of `event.properties` and placed into the
+/// V1 wire `options` map. The tuple is (property_key, wire_option_key).
+const OPTIONS_EXTRACTION_TABLE: &[(&str, &str)] = &[
+    ("$cookieless_mode", "cookieless_mode"),
+    ("$ignore_sent_at", "disable_skew_correction"),
+    ("$product_tour_id", "product_tour_id"),
+    ("$process_person_profile", "process_person_profile"),
+];
+
+/// Crate-internal V1 capture options, derived from `event.properties`.
+/// Serializes as a JSON object; an empty map produces `"options":{}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct Options(serde_json::Map<String, serde_json::Value>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct V1Event {
@@ -16,7 +30,7 @@ pub struct V1Event {
     pub session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub window_id: Option<String>,
-    pub options: EventOptions,
+    pub(crate) options: Options,
     pub properties: serde_json::Value,
 }
 
@@ -42,10 +56,12 @@ impl V1Event {
             .map(|ts| ts.and_utc().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
             .unwrap_or_else(|| Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string());
 
-        // V1 carries process_person_profile in options; strip the property
-        // duplicate in case a caller manually inserted it.
-        if event.options().process_person_profile.is_some() {
-            properties.remove("$process_person_profile");
+        // Extract magic keys from properties into the V1 options map.
+        let mut options_map = serde_json::Map::new();
+        for &(prop_key, wire_key) in OPTIONS_EXTRACTION_TABLE {
+            if let Some(val) = properties.remove(prop_key) {
+                options_map.insert(wire_key.to_string(), val);
+            }
         }
 
         let session_id = properties
@@ -62,7 +78,7 @@ impl V1Event {
             timestamp,
             session_id,
             window_id,
-            options: event.options().clone(),
+            options: Options(options_map),
             properties: serde_json::to_value(properties)
                 .unwrap_or(serde_json::Value::Object(Default::default())),
         }
@@ -130,6 +146,8 @@ mod tests {
     use super::*;
     use crate::Event;
 
+    // -- from_event basics ---------------------------------------------------
+
     #[test]
     fn v1_event_from_event_basic() {
         let event = Event::new("test_event", "user-1");
@@ -137,11 +155,12 @@ mod tests {
 
         assert_eq!(v1.event, "test_event");
         assert_eq!(v1.distinct_id, "user-1");
-        assert_eq!(v1.options.process_person_profile, None);
-        assert_eq!(v1.options.cookieless_mode, None);
-        assert_eq!(v1.options.disable_skew_correction, None);
         assert!(v1.session_id.is_none());
         assert!(v1.window_id.is_none());
+        // No magic keys -> empty options map on the wire.
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+        assert!(options.is_empty());
     }
 
     #[test]
@@ -150,17 +169,28 @@ mod tests {
         let v1 = V1Event::from_event(&event);
 
         assert_eq!(v1.event, "anon_event");
-        assert_eq!(v1.options.process_person_profile, Some(false));
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+        assert_eq!(
+            options.get("process_person_profile"),
+            Some(&serde_json::json!(false))
+        );
         let props = v1.properties.as_object().unwrap();
         assert!(!props.contains_key("$process_person_profile"));
     }
 
+    // -- property -> options extraction --------------------------------------
+
     #[test]
-    fn v1_event_options_overrides_serialize_and_unset_are_omitted() {
+    fn v1_event_extracts_magic_keys_to_options() {
         let mut event = Event::new("test_event", "user-1");
-        event.set_option("cookieless_mode", true).unwrap();
-        event.set_option("process_person_profile", false).unwrap();
-        event.set_option("product_tour_id", "tour-42").unwrap();
+        event.insert_prop("$cookieless_mode", true).unwrap();
+        event
+            .insert_prop("$process_person_profile", false)
+            .unwrap();
+        event
+            .insert_prop("$product_tour_id", "tour-42")
+            .unwrap();
 
         let v1 = V1Event::from_event(&event);
         let json = serde_json::to_value(&v1).unwrap();
@@ -178,8 +208,32 @@ mod tests {
             options.get("product_tour_id"),
             Some(&serde_json::json!("tour-42"))
         );
+        // disable_skew_correction not set -> absent.
         assert!(!options.contains_key("disable_skew_correction"));
+        // Extracted keys removed from properties.
+        let props = v1.properties.as_object().unwrap();
+        assert!(!props.contains_key("$cookieless_mode"));
+        assert!(!props.contains_key("$process_person_profile"));
+        assert!(!props.contains_key("$product_tour_id"));
     }
+
+    #[test]
+    fn v1_event_extracts_ignore_sent_at_as_disable_skew_correction() {
+        let mut event = Event::new("test", "user-1");
+        event.insert_prop("$ignore_sent_at", true).unwrap();
+
+        let v1 = V1Event::from_event(&event);
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+        assert_eq!(
+            options.get("disable_skew_correction"),
+            Some(&serde_json::json!(true))
+        );
+        let props = v1.properties.as_object().unwrap();
+        assert!(!props.contains_key("$ignore_sent_at"));
+    }
+
+    // -- session/window extraction -------------------------------------------
 
     #[test]
     fn v1_event_extracts_session_window_from_properties() {
@@ -196,6 +250,8 @@ mod tests {
         assert!(!props.contains_key("$window_id"));
     }
 
+    // -- groups --------------------------------------------------------------
+
     #[test]
     fn v1_event_groups_in_properties() {
         let mut event = Event::new("test", "user-1");
@@ -206,8 +262,16 @@ mod tests {
         let props = v1.properties.as_object().unwrap();
         let groups = props.get("$groups").unwrap().as_object().unwrap();
         assert_eq!(groups.get("company").unwrap().as_str().unwrap(), "acme");
-        assert_eq!(v1.options.process_person_profile, Some(true));
+        // add_group forces process_person_profile=true.
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+        assert_eq!(
+            options.get("process_person_profile"),
+            Some(&serde_json::json!(true))
+        );
     }
+
+    // -- batch / response serialization (unchanged) --------------------------
 
     #[test]
     fn v1_batch_request_serializes() {
@@ -306,69 +370,77 @@ mod tests {
         );
     }
 
+    // -- unknown properties are NOT lifted -----------------------------------
+
     #[test]
-    fn v1_extra_options_serialize_as_top_level_keys() {
+    fn v1_unknown_properties_stay_in_properties() {
         let mut event = Event::new("test", "user-1");
-        event.set_option("cookieless_mode", true).unwrap();
-        event.set_option("future_flag", true).unwrap();
-        event.set_option("routing_key", "us-east").unwrap();
+        event.insert_prop("$cookieless_mode", true).unwrap();
+        event.insert_prop("custom_metric", 42).unwrap();
+        event
+            .insert_prop("future_backend_flag", "hello")
+            .unwrap();
 
         let v1 = V1Event::from_event(&event);
         let json = serde_json::to_value(&v1).unwrap();
         let options = json.get("options").unwrap().as_object().unwrap();
 
+        // Known key extracted.
         assert_eq!(
             options.get("cookieless_mode"),
             Some(&serde_json::json!(true))
         );
-        assert_eq!(options.get("future_flag"), Some(&serde_json::json!(true)));
+        // Unknown keys NOT lifted — stay in properties.
+        assert!(!options.contains_key("custom_metric"));
+        assert!(!options.contains_key("future_backend_flag"));
+        let props = v1.properties.as_object().unwrap();
+        assert_eq!(props.get("custom_metric"), Some(&serde_json::json!(42)));
         assert_eq!(
-            options.get("routing_key"),
-            Some(&serde_json::json!("us-east"))
+            props.get("future_backend_flag"),
+            Some(&serde_json::json!("hello"))
         );
-        assert!(!options.contains_key("disable_skew_correction"));
     }
 
+    // -- empty options map renders as {} on the wire -------------------------
+
     #[test]
-    fn v1_extra_options_empty_map_omitted_from_wire() {
+    fn v1_empty_options_serializes_as_empty_object() {
         let event = Event::new("test", "user-1");
         let v1 = V1Event::from_event(&event);
         let json_str = serde_json::to_string(&v1).unwrap();
-        assert!(!json_str.contains("extra"));
+        assert!(json_str.contains("\"options\":{}"));
     }
 
-    #[test]
-    fn v1_set_option_routes_unknown_keys_to_extra() {
-        let mut event = Event::new("test", "user-1");
-        event.set_option("new_backend_flag", true).unwrap();
-        event.set_option("batch_priority", 5u32).unwrap();
+    // -- anon event: property extracted, not in properties -------------------
 
+    #[test]
+    fn v1_anon_event_process_person_profile_in_options_not_properties() {
+        let event = Event::new_anon("test");
         let v1 = V1Event::from_event(&event);
         let json = serde_json::to_value(&v1).unwrap();
         let options = json.get("options").unwrap().as_object().unwrap();
-
         assert_eq!(
-            options.get("new_backend_flag"),
-            Some(&serde_json::json!(true))
+            options.get("process_person_profile"),
+            Some(&serde_json::json!(false))
         );
-        assert_eq!(options.get("batch_priority"), Some(&serde_json::json!(5)));
-    }
-
-    #[test]
-    fn v1_anon_event_no_process_person_profile_in_properties() {
-        let event = Event::new_anon("test");
-        let v1 = V1Event::from_event(&event);
-        assert_eq!(v1.options.process_person_profile, Some(false));
         let props = v1.properties.as_object().unwrap();
         assert!(!props.contains_key("$process_person_profile"));
     }
 
+    // -- explicit insert_prop wins over constructor default ------------------
+
     #[test]
-    fn v1_strips_duplicate_process_person_profile_property() {
+    fn v1_explicit_insert_prop_wins_over_anon_default() {
         let mut event = Event::new_anon("test");
-        event.insert_prop("$process_person_profile", false).unwrap();
+        // new_anon sets $process_person_profile=false; explicit insert overwrites.
+        event.insert_prop("$process_person_profile", true).unwrap();
         let v1 = V1Event::from_event(&event);
-        assert_eq!(v1.options.process_person_profile, Some(false));
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap();
+        assert_eq!(
+            options.get("process_person_profile"),
+            Some(&serde_json::json!(true))
+        );
         let props = v1.properties.as_object().unwrap();
         assert!(!props.contains_key("$process_person_profile"));
     }

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -185,12 +185,8 @@ mod tests {
     fn v1_event_extracts_magic_keys_to_options() {
         let mut event = Event::new("test_event", "user-1");
         event.insert_prop("$cookieless_mode", true).unwrap();
-        event
-            .insert_prop("$process_person_profile", false)
-            .unwrap();
-        event
-            .insert_prop("$product_tour_id", "tour-42")
-            .unwrap();
+        event.insert_prop("$process_person_profile", false).unwrap();
+        event.insert_prop("$product_tour_id", "tour-42").unwrap();
 
         let v1 = V1Event::from_event(&event);
         let json = serde_json::to_value(&v1).unwrap();
@@ -377,9 +373,7 @@ mod tests {
         let mut event = Event::new("test", "user-1");
         event.insert_prop("$cookieless_mode", true).unwrap();
         event.insert_prop("custom_metric", 42).unwrap();
-        event
-            .insert_prop("future_backend_flag", "hello")
-            .unwrap();
+        event.insert_prop("future_backend_flag", "hello").unwrap();
 
         let v1 = V1Event::from_event(&event);
         let json = serde_json::to_value(&v1).unwrap();
@@ -448,9 +442,7 @@ mod tests {
     #[test]
     fn v1_identified_event_with_explicit_personless() {
         let mut event = Event::new("test", "user-1");
-        event
-            .insert_prop("$process_person_profile", false)
-            .unwrap();
+        event.insert_prop("$process_person_profile", false).unwrap();
         let v1 = V1Event::from_event(&event);
         let json = serde_json::to_value(&v1).unwrap();
         let options = json.get("options").unwrap().as_object().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,6 @@ pub use error_tracking::{
 
 // Event
 pub use event::Event;
-#[cfg(feature = "capture-v1")]
-pub use event::EventOptions;
 
 // V1 Capture types
 #[cfg(feature = "capture-v1")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@
 //! ```
 mod client;
 mod compression;
+mod constants;
 mod endpoints;
 mod error;
 #[cfg(feature = "error-tracking")]

--- a/tests/test_v1_blocking.rs
+++ b/tests/test_v1_blocking.rs
@@ -469,9 +469,7 @@ fn v1_blocking_sends_event_options() {
     let client = create_v1_client(server.base_url());
     let mut event = Event::new("test", "user-1");
     event.insert_prop("$cookieless_mode", true).unwrap();
-    event
-        .insert_prop("$process_person_profile", false)
-        .unwrap();
+    event.insert_prop("$process_person_profile", false).unwrap();
 
     client.capture(event).unwrap();
     mock.assert();

--- a/tests/test_v1_blocking.rs
+++ b/tests/test_v1_blocking.rs
@@ -468,8 +468,10 @@ fn v1_blocking_sends_event_options() {
 
     let client = create_v1_client(server.base_url());
     let mut event = Event::new("test", "user-1");
-    event.set_option("cookieless_mode", true).unwrap();
-    event.set_option("process_person_profile", false).unwrap();
+    event.insert_prop("$cookieless_mode", true).unwrap();
+    event
+        .insert_prop("$process_person_profile", false)
+        .unwrap();
 
     client.capture(event).unwrap();
     mock.assert();

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -400,8 +400,10 @@ async fn v1_capture_sends_event_options() {
 
     let client = create_v1_client(server.base_url()).await;
     let mut event = Event::new("test", "user-1");
-    event.set_option("cookieless_mode", true).unwrap();
-    event.set_option("process_person_profile", false).unwrap();
+    event.insert_prop("$cookieless_mode", true).unwrap();
+    event
+        .insert_prop("$process_person_profile", false)
+        .unwrap();
 
     client.capture(event).await.unwrap();
     mock.assert();

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -401,9 +401,7 @@ async fn v1_capture_sends_event_options() {
     let client = create_v1_client(server.base_url()).await;
     let mut event = Event::new("test", "user-1");
     event.insert_prop("$cookieless_mode", true).unwrap();
-    event
-        .insert_prop("$process_person_profile", false)
-        .unwrap();
+    event.insert_prop("$process_person_profile", false).unwrap();
 
     client.capture(event).await.unwrap();
     mock.assert();


### PR DESCRIPTION
## Goal

Misc. updates (still gated behind `capture-v1` build feature) to accommodate "hard rollout" of capture v1 at initial release. As discussed, we will hide the new `event.options` behind legacy event shape in the public contract for now in the backend SDKs, so rollout will be transparent for end users.

## Summary

- Remove `EventOptions`, `Event::set_option`, and `Event::options` from the public API
  - Enabling `capture-v1` is now a non-breaking change vs legacy v0 capture
- V1 capture options are derived internally by extracting magic property keys from `event.properties`
  - Mirrors the PostHog backend property-to-options mapping (`capture_v1.py`, `analytics/types.rs`)
- Wire output unchanged: empty options still serializes as `"options":{}`, populated options are identical

## Changes

- **`src/event.rs`**: Delete `EventOptions` struct + `options` field. Remove `set_option()` and `options()`. Constructors (`new_anon`, `add_group`) write `$process_person_profile` into properties directly. Trim redundant block from `prepare_for_v0`.
- **`src/event_v1.rs`**: Add crate-internal map-based `Options`. Rewrite `from_event` to extract `$cookieless_mode`, `$ignore_sent_at` (-> `disable_skew_correction`), `$product_tour_id`, `$process_person_profile` from properties into the options map.
- **`src/lib.rs`**: Remove `pub use EventOptions`.
- **Compliance adapter**: Translate harness `options` entries to magic property keys via `insert_prop`.
- **`api/public-api.txt`**: 8 lines removed (2 methods + struct + 5 fields). Nothing else changed.
- **Integration tests**: `set_option` calls replaced with `insert_prop` on magic keys. Same wire assertions pass.

## Extraction table

| Property key | Wire option key |
|---|---|
| `$cookieless_mode` | `cookieless_mode` |
| `$ignore_sent_at` | `disable_skew_correction` |
| `$product_tour_id` | `product_tour_id` |
| `$process_person_profile` | `process_person_profile` |
| `$session_id` / `$window_id` | top-level V1Event fields (unchanged) |

## Test plan

- [x] `cargo test --features capture-v1` -- all pass
- [x] `cargo test --no-default-features --features capture-v1` (blocking) -- all pass
- [x] `cargo test` (v0/default) -- all pass
- [x] `cargo test --no-default-features --features error-tracking,capture-v1` -- all pass
- [x] Public API snapshot regenerated and validated
- [x] Compliance adapter compiles v0 + v1
- [x] Smoke rig compiles (new property-driven SDK fixtures added)
- [ ] CI compliance suite (`--suite capture_v1`)
- [ ] Smoke rig against prod (`bin/smoke-prod.sh`)
