### PR TITLE
chore: changeset for capture-v1 internals release (0.13.3)

### DIFF
--- a/.sampo/changesets/internalize-capture-v1-options.md
+++ b/.sampo/changesets/internalize-capture-v1-options.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Internal changes to the `capture-v1` feature path. No effect on default (v0) capture behavior.


### PR DESCRIPTION
## Summary

Adds the sampo release changeset for #153, which made internal-only changes to the `capture-v1` feature path. This cuts a **patch** release (0.13.3) so downstream services can pick up those changes from crates.io.

- Internal changes scoped to the `capture-v1` feature.
- No effect on default (v0) capture behavior.

## Notes

- #153 merged without a changeset, so it is currently stranded on `main` and unpublished. This changeset unblocks the release.