### PR TITLE
fix: saturate transport in-flight counter to prevent underflow wedge

### DIFF
--- a/.sampo/changesets/harden-in-flight-counter.md
+++ b/.sampo/changesets/harden-in-flight-counter.md
@@ -1,0 +1,5 @@
+---
+posthog-rs: patch
+---
+
+Harden the transport's in-flight event counter against underflow. The counter is decremented from several paths (before_send drops, partial v1 batch results, terminal outcomes, shutdown drops, channel drain); a decrement bug on any of them would previously underflow the `AtomicUsize` and wrap to a huge value, making the bounded queue look permanently full and silently dropping every subsequent event. Decrements now saturate at 0 (with a `debug_assert` to surface the bug in tests), so a release build degrades gracefully instead of wedging the queue.

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -155,7 +155,7 @@ impl TransportHandle {
             .is_err()
         {
             // Worker gone; release the slot we reserved.
-            self.len.fetch_sub(1, Ordering::AcqRel);
+            dec_len(&self.len, 1);
         }
     }
 
@@ -179,7 +179,7 @@ impl TransportHandle {
             return;
         }
         if self.tx.send(Control::HistoricalBatch { events }).is_err() {
-            self.len.fetch_sub(fitted, Ordering::AcqRel);
+            dec_len(&self.len, fitted);
         }
     }
 
@@ -279,10 +279,26 @@ fn try_reserve(len: &AtomicUsize, max: usize, warned: &AtomicBool) -> bool {
 /// Decrement the in-flight counter by `n` (no-op for 0). Called when events reach
 /// a terminal outcome (delivered or dropped) so `pending()` reflects everything
 /// still in flight: channel + worker buffer + retry queue.
+///
+/// Saturates at 0 instead of a plain `fetch_sub`. The accounting spans several
+/// paths (before_send drops, partial v1 results, terminal outcomes, shutdown
+/// drops, channel drain); a double-decrement bug would otherwise underflow this
+/// `AtomicUsize` and wrap to a huge value, making the bounded queue look
+/// permanently full and silently dropping every later event. A `debug_assert`
+/// still surfaces such a bug in tests; release builds clamp rather than wrap.
 fn dec_len(len: &AtomicUsize, n: usize) {
-    if n > 0 {
-        len.fetch_sub(n, Ordering::AcqRel);
+    if n == 0 {
+        return;
     }
+    let _ = len.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+        debug_assert!(
+            current >= n,
+            "posthog-rs: in-flight counter underflow ({} - {})",
+            current,
+            n
+        );
+        Some(current.saturating_sub(n))
+    });
 }
 
 /// Per-request timeout for a send. On the shutdown/disconnect path (`deadline`


### PR DESCRIPTION
The in-flight event counter is a shared `AtomicUsize` decremented from many paths, and that accounting is tricky. This hardens it against a double-decrement bug underflowing the counter.

## :bulb: Why

- An underflow wraps to a huge value.
  - `try_reserve` then sees the queue as permanently full.
  - Every later event is silently dropped for the life of the client.
- The counter is decremented from 5+ paths, so a future bug is plausible.
  - `before_send` drops, partial v1 results, terminal sends, shutdown drops, channel drain.
- Flagged in review on #145.

## :hammer: What

- Decrements now saturate at 0 instead of `fetch_sub`.
  - `fetch_update` + `saturating_sub` in `dec_len`.
- `debug_assert` catches a real underflow bug in tests.
  - Release builds clamp instead of wedging.
- Both "worker gone" enqueue paths now route through `dec_len` too.

## :green_heart: How tested

- `fmt` + `clippy -D warnings` clean (default + `capture-v1`).
- 14 `transport::` tests pass across async-v1, blocking-v1, v0.
  - Includes the two that drive `dec_len` to 0 with the assert live.
- No saturation-only test: it needs `--release` (assert panics in debug), so it would not run in CI.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
