### PR TITLE
feat: add on_error client hook for terminal batch delivery failures

### DIFF
--- a/.sampo/changesets/majestic-iceseeker-aurelien.md
+++ b/.sampo/changesets/majestic-iceseeker-aurelien.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Add an `on_error` client hook to observe terminal batch delivery failures (permanent rejects and exhausted retries). The background worker invokes registered hooks with a `CaptureFailure` (cause, event count, attempt); registering one also silences the default drop WARN.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -97,6 +97,13 @@ pub fn posthog_rs::CaptureExceptionOptions::group<N: core::convert::Into<alloc::
 pub fn posthog_rs::CaptureExceptionOptions::level<S: core::convert::Into<alloc::string::String>>(self, S) -> Self
 pub fn posthog_rs::CaptureExceptionOptions::new() -> Self
 pub fn posthog_rs::CaptureExceptionOptions::property<K: core::convert::Into<alloc::string::String>, V: serde_core::ser::Serialize>(self, K, V) -> core::result::Result<Self, posthog_rs::Error>
+#[non_exhaustive] pub struct posthog_rs::CaptureFailure<'a>
+impl<'a> posthog_rs::CaptureFailure<'a>
+pub fn posthog_rs::CaptureFailure<'a>::attempt(&self) -> u32
+pub fn posthog_rs::CaptureFailure<'a>::error(&self) -> core::option::Option<&posthog_rs::Error>
+pub fn posthog_rs::CaptureFailure<'a>::event_count(&self) -> usize
+pub fn posthog_rs::CaptureFailure<'a>::event_results(&self) -> &std::collections::hash::map::HashMap<uuid::Uuid, posthog_rs::EventResult>
+pub fn posthog_rs::CaptureFailure<'a>::historical_migration(&self) -> bool
 pub struct posthog_rs::CaptureResponse
 pub posthog_rs::CaptureResponse::results: std::collections::hash::map::HashMap<uuid::Uuid, posthog_rs::EventResult>
 pub struct posthog_rs::Client
@@ -150,6 +157,7 @@ pub fn posthog_rs::ClientOptionsBuilder::shutdown_timeout_ms(&mut self, u64) -> 
 impl posthog_rs::ClientOptionsBuilder
 pub fn posthog_rs::ClientOptionsBuilder::before_send<F>(&mut self, F) -> &mut Self where F: core::ops::function::FnMut(posthog_rs::Event) -> core::option::Option<posthog_rs::Event> + core::marker::Send + 'static
 pub fn posthog_rs::ClientOptionsBuilder::build(&self) -> core::result::Result<posthog_rs::ClientOptions, posthog_rs::ClientOptionsBuilderError>
+pub fn posthog_rs::ClientOptionsBuilder::on_error<F>(&mut self, F) -> &mut Self where F: core::ops::function::FnMut(&posthog_rs::CaptureFailure<'_>) + core::marker::Send + 'static
 impl core::default::Default for posthog_rs::ClientOptionsBuilder
 pub fn posthog_rs::ClientOptionsBuilder::default() -> Self
 pub struct posthog_rs::Cohort
@@ -304,6 +312,9 @@ pub posthog_rs::MultivariateFilter::variants: alloc::vec::Vec<posthog_rs::Multiv
 pub struct posthog_rs::MultivariateVariant
 pub posthog_rs::MultivariateVariant::key: alloc::string::String
 pub posthog_rs::MultivariateVariant::rollout_percentage: f64
+pub struct posthog_rs::OnErrorHook(_)
+impl posthog_rs::OnErrorHook
+pub fn posthog_rs::OnErrorHook::new<F>(F) -> Self where F: core::ops::function::FnMut(&posthog_rs::CaptureFailure<'_>) + core::marker::Send + 'static
 pub struct posthog_rs::Property
 pub posthog_rs::Property::key: alloc::string::String
 pub posthog_rs::Property::operator: alloc::string::String

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,6 +55,7 @@ Shows:
 - Self-hosted instance configuration
 - Production settings with timeouts and geoip configuration
 - High-performance local evaluation setup
+- On-error hook for observing terminal batch delivery failures
 
 ### 4. Error Tracking Example
 

--- a/examples/advanced_config.rs
+++ b/examples/advanced_config.rs
@@ -50,6 +50,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _perf = posthog_rs::client(performance_config).await;
     println!("   → Evaluates flags locally (100x faster)\n");
 
+    // 6. OBSERVABILITY: Get notified when a batch fails to deliver
+    println!("6. On-error hook:");
+    let observable_config = ClientOptionsBuilder::default()
+        .api_key("phc_project_key".to_string())
+        // Runs on the background worker for every batch the SDK gives up on (a
+        // permanent reject, or once the retry budget is exhausted). Keep it
+        // cheap and non-blocking, and never call flush()/shutdown() from it.
+        .on_error(|failure| {
+            eprintln!(
+                "   posthog: dropped {} event(s) on attempt {}: {:?}",
+                failure.event_count(),
+                failure.attempt(),
+                failure.error(),
+            );
+        })
+        .build()?;
+
+    let _observable = posthog_rs::client(observable_config).await;
+    println!("   → Surfaces terminal delivery failures for logging/metrics\n");
+
     println!("Configuration examples complete!");
     println!("\nTip: Check out 'feature_flags' example for flag usage");
     println!("     and 'local_evaluation' for performance optimization.");

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -3,6 +3,8 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::client::BeforeSendHook;
 use crate::client::CaptureDefaults;
+use crate::client::CaptureFailure;
+use crate::client::OnErrorHook;
 use crate::feature_flag_evaluations::{EvaluatedFlagRecord, FlagCalledEventParams};
 use crate::feature_flags::{FeatureFlagsResponse, FlagDetail, FlagMetadata, FlagValue};
 use crate::Event;
@@ -69,6 +71,20 @@ pub(super) fn apply_before_send_hooks(hooks: &[BeforeSendHook], event: Event) ->
     }
 
     current
+}
+
+/// Invoke each `on_error` hook with the failure, catching panics so a misbehaving
+/// hook can't wedge the transport worker thread. No-op when no hooks are
+/// registered, keeping the common (hookless) failure path free.
+pub(super) fn apply_on_error_hooks(hooks: &[OnErrorHook], failure: &CaptureFailure<'_>) {
+    if hooks.is_empty() {
+        return;
+    }
+    for hook in hooks {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| hook.apply(failure))).is_err() {
+            error!("panic in PostHog on_error hook; ignoring");
+        }
+    }
 }
 
 /// Returns `true` when the helper has already shipped this
@@ -265,6 +281,7 @@ fn normalize_payload(payload: serde_json::Value) -> serde_json::Value {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::Arc;
 
     fn groups(pairs: &[(&str, &str)]) -> HashMap<String, String> {
         pairs
@@ -416,5 +433,38 @@ mod tests {
         assert!(
             apply_before_send_hooks(&options.before_send, Event::new("test", "user-1")).is_none()
         );
+    }
+
+    #[test]
+    fn on_error_hooks_fire_in_registration_order_and_isolate_panics() {
+        let order = Arc::new(Mutex::new(Vec::<i32>::new()));
+        let (o1, o2, o3) = (Arc::clone(&order), Arc::clone(&order), Arc::clone(&order));
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("test-key".to_string())
+            .on_error(move |_f| o1.lock().unwrap().push(1))
+            .on_error(move |_f| {
+                o2.lock().unwrap().push(2);
+                panic!("boom");
+            })
+            .on_error(move |_f| o3.lock().unwrap().push(3))
+            .build()
+            .unwrap();
+
+        let err = crate::Error::BadRequest("x".to_string());
+        #[cfg(feature = "capture-v1")]
+        let results = HashMap::new();
+        let failure = CaptureFailure {
+            error: Some(&err),
+            event_count: 1,
+            attempt: 1,
+            historical_migration: false,
+            #[cfg(feature = "capture-v1")]
+            results: &results,
+        };
+        apply_on_error_hooks(&options.on_error, &failure);
+
+        // All three ran in registration order; the middle hook's panic was caught
+        // and did not stop the third from running.
+        assert_eq!(*order.lock().unwrap(), vec![1, 2, 3]);
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,11 +1,18 @@
 use std::sync::{Arc, Mutex};
 
 use crate::endpoints::{EndpointManager, DEFAULT_HOST};
+use crate::error::Error;
 #[cfg(feature = "error-tracking")]
 use crate::error_tracking::ErrorTrackingOptions;
 use crate::event::Event;
+#[cfg(feature = "capture-v1")]
+use crate::event_v1::EventResult;
 use derive_builder::Builder;
+#[cfg(feature = "capture-v1")]
+use std::collections::HashMap;
 use tracing::warn;
+#[cfg(feature = "capture-v1")]
+use uuid::Uuid;
 
 mod common;
 
@@ -84,6 +91,100 @@ impl BeforeSendHook {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         (hook)(event)
+    }
+}
+
+type OnErrorFn = dyn FnMut(&CaptureFailure<'_>) + Send + 'static;
+type SharedOnErrorHook = Arc<Mutex<Box<OnErrorFn>>>;
+
+/// Hook invoked once per terminal batch that fails delivery.
+///
+/// Registered via [`ClientOptionsBuilder::on_error`]. The hook runs on the
+/// background transport thread, so keep it cheap and non-blocking, and never
+/// call [`Client::flush`] or `shutdown` from it (the worker would deadlock on
+/// itself). It is observability-only: the events are already gone and cannot be
+/// re-queued. Hook panics are caught and ignored.
+#[derive(Clone)]
+pub struct OnErrorHook(SharedOnErrorHook);
+
+impl OnErrorHook {
+    /// Create a new on-error hook.
+    pub fn new<F>(hook: F) -> Self
+    where
+        F: FnMut(&CaptureFailure<'_>) + Send + 'static,
+    {
+        Self(Arc::new(Mutex::new(Box::new(hook))))
+    }
+
+    pub(crate) fn apply(&self, failure: &CaptureFailure<'_>) {
+        let mut hook = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        (hook)(failure)
+    }
+}
+
+/// Details of a terminal batch delivery failure, passed by reference to each
+/// registered [`OnErrorHook`].
+///
+/// A batch fails terminally when the SDK gives up delivering it: a permanent
+/// rejection (e.g. 400/402), or transient transport/HTTP failures that exhaust
+/// the retry budget. [`error`](Self::error) carries the cause and
+/// [`event_count`](Self::event_count) how many events were dropped.
+///
+/// Fields are read through accessors; the struct is `#[non_exhaustive]` so more
+/// detail can be added without breaking callers.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct CaptureFailure<'a> {
+    error: Option<&'a Error>,
+    event_count: usize,
+    attempt: u32,
+    historical_migration: bool,
+    #[cfg(feature = "capture-v1")]
+    results: &'a HashMap<Uuid, EventResult>,
+}
+
+impl<'a> CaptureFailure<'a> {
+    /// The batch-level cause of this failure (a permanent reject, or exhausted
+    /// transport/HTTP retries).
+    #[cfg_attr(
+        not(feature = "capture-v1"),
+        doc = "\nAlways present: every failure surfaced to the hook carries a cause."
+    )]
+    #[cfg_attr(
+        feature = "capture-v1",
+        doc = "\n`None` only when the request itself succeeded (2xx) but some events were not\npersisted after the retry budget — inspect [`event_results`](Self::event_results)."
+    )]
+    pub fn error(&self) -> Option<&Error> {
+        self.error
+    }
+
+    /// Number of events this failure dropped.
+    pub fn event_count(&self) -> usize {
+        self.event_count
+    }
+
+    /// The failing attempt number (equals the configured maximum on exhaustion).
+    pub fn attempt(&self) -> u32 {
+        self.attempt
+    }
+
+    /// Whether the batch was a historical-migration batch.
+    pub fn historical_migration(&self) -> bool {
+        self.historical_migration
+    }
+
+    /// Per-event server verdicts for the batch (V1 capture pipeline only).
+    ///
+    /// Maps event UUID to its [`EventResult`] (`retry`/`drop`/`warning`/… plus a
+    /// `details` reason). Complete when [`error`](Self::error) is `None` (a 2xx
+    /// where events weren't persisted after retries); possibly partial on a
+    /// batch-level failure (only verdicts collected from earlier attempts).
+    #[cfg(feature = "capture-v1")]
+    pub fn event_results(&self) -> &HashMap<Uuid, EventResult> {
+        self.results
     }
 }
 
@@ -232,6 +333,12 @@ pub struct ClientOptions {
     #[builder(default, setter(custom))]
     pub(crate) before_send: Vec<BeforeSendHook>,
 
+    /// Hooks invoked once per terminal batch delivery failure. Observability
+    /// only; registering at least one also silences the default WARN logged for
+    /// terminal batch rejects/exhaustion (the caller now owns that signal).
+    #[builder(default, setter(custom))]
+    pub(crate) on_error: Vec<OnErrorHook>,
+
     /// Extra HTTP headers injected into every outbound capture request.
     /// Used by the SDK test harness adapter to attach `X-Test-Id` for
     /// parallel test isolation.
@@ -332,6 +439,24 @@ impl ClientOptionsBuilder {
         self.before_send
             .get_or_insert_with(Vec::new)
             .push(BeforeSendHook::new(hook));
+        self
+    }
+
+    /// Add a hook invoked once per terminal batch that fails delivery.
+    ///
+    /// Fires on a permanent rejection or after the retry budget is exhausted,
+    /// with the cause in [`CaptureFailure::error`]. The hook runs on the
+    /// background transport thread: keep it cheap, do not call `flush`/`shutdown`
+    /// from it, and expect panics to be caught and ignored. Registering a hook
+    /// silences the default WARN for terminal batch rejects/exhaustion; other
+    /// drop warnings (shutdown, serialization, queue-full) are unaffected.
+    pub fn on_error<F>(&mut self, hook: F) -> &mut Self
+    where
+        F: FnMut(&CaptureFailure<'_>) + Send + 'static,
+    {
+        self.on_error
+            .get_or_insert_with(Vec::new)
+            .push(OnErrorHook::new(hook));
         self
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -162,6 +162,10 @@ impl<'a> CaptureFailure<'a> {
     }
 
     /// Number of events this failure dropped.
+    #[cfg_attr(
+        feature = "capture-v1",
+        doc = "\nCounts only undelivered events (`retry`/`drop`). This can be smaller than\n[`event_results`](Self::event_results)`.len()`, which also reports persisted\n`ok`/`warning` verdicts — filter by status before treating an entry as lost."
+    )]
     pub fn event_count(&self) -> usize {
         self.event_count
     }
@@ -178,9 +182,12 @@ impl<'a> CaptureFailure<'a> {
 
     /// Per-event server verdicts for the batch (V1 capture pipeline only).
     ///
-    /// Maps event UUID to its [`EventResult`] (`retry`/`drop`/`warning`/… plus a
-    /// `details` reason). Complete when [`error`](Self::error) is `None` (a 2xx
-    /// where events weren't persisted after retries); possibly partial on a
+    /// Maps event UUID to its [`EventResult`]. Includes **all** verdicts the
+    /// batch collected — persisted (`ok`/`warning`) as well as lost
+    /// (`retry`/`drop`) — so this map can be larger than
+    /// [`event_count`](Self::event_count); filter by [`EventStatus`](crate::EventStatus)
+    /// to isolate the failures. Complete when [`error`](Self::error) is `None` (a 2xx where
+    /// events weren't persisted after retries); possibly partial on a
     /// batch-level failure (only verdicts collected from earlier attempts).
     #[cfg(feature = "capture-v1")]
     pub fn event_results(&self) -> &HashMap<Uuid, EventResult> {

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -25,7 +25,11 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Utc};
 use tracing::warn;
 
+use super::common::apply_on_error_hooks;
+use super::CaptureFailure;
 use super::ClientOptions;
+#[cfg(feature = "capture-v1")]
+use crate::event_v1::EventStatus;
 use crate::Event;
 
 /// Messages sent from producers (`capture`/`flush`/`shutdown`) to the worker.
@@ -725,10 +729,50 @@ impl Pipeline {
         dec_len(&self.len, count - batch.pending.len());
 
         match step {
-            Step::Done => {}
+            Step::Done => {
+                // A 2xx can still leave events undelivered: on the final attempt
+                // `after_response` finalizes any still-`retry` (exhausted) verdicts
+                // into `final_results`, and `drop` verdicts land there on any
+                // attempt. Surface those terminal non-deliveries — there's no
+                // batch-level error here, so `error` is `None`.
+                if !self.options.on_error.is_empty() {
+                    let undelivered = batch
+                        .final_results
+                        .values()
+                        .filter(|r| matches!(r.result, EventStatus::Retry | EventStatus::Drop))
+                        .count();
+                    if undelivered > 0 {
+                        apply_on_error_hooks(
+                            &self.options.on_error,
+                            &CaptureFailure {
+                                error: None,
+                                event_count: undelivered,
+                                attempt: batch.attempt,
+                                historical_migration: batch.historical_migration,
+                                results: &batch.final_results,
+                            },
+                        );
+                    }
+                }
+            }
             Step::Fail(e) => {
-                warn!("posthog-rs: dropping {} event(s): {e}", batch.pending.len());
-                dec_len(&self.len, batch.pending.len());
+                let count = batch.pending.len();
+                // The hook owns this signal when registered; otherwise warn so
+                // silent data loss is still visible.
+                if self.options.on_error.is_empty() {
+                    warn!("posthog-rs: dropping {count} event(s): {e}");
+                }
+                apply_on_error_hooks(
+                    &self.options.on_error,
+                    &CaptureFailure {
+                        error: Some(&e),
+                        event_count: count,
+                        attempt: batch.attempt,
+                        historical_migration: batch.historical_migration,
+                        results: &batch.final_results,
+                    },
+                );
+                dec_len(&self.len, count);
             }
             Step::Backoff(delay) => {
                 if deadline.is_some() {
@@ -788,6 +832,7 @@ struct RetryBatch {
     body: Vec<u8>,
     encoding: Option<&'static str>,
     count: usize,
+    historical_migration: bool,
     attempt: u32,
     next_at: Instant,
 }
@@ -858,6 +903,7 @@ impl Pipeline {
             body,
             encoding,
             count: kept,
+            historical_migration,
             attempt: 1,
             next_at: self.clock.now(),
         };
@@ -906,7 +952,20 @@ impl Pipeline {
         match step {
             Step::Done => dec_len(&self.len, batch.count),
             Step::Fail(e) => {
-                warn!("posthog-rs: dropping {} event(s): {e}", batch.count);
+                // The hook owns this signal when registered; otherwise warn so
+                // silent data loss is still visible.
+                if self.options.on_error.is_empty() {
+                    warn!("posthog-rs: dropping {} event(s): {e}", batch.count);
+                }
+                apply_on_error_hooks(
+                    &self.options.on_error,
+                    &CaptureFailure {
+                        error: Some(&e),
+                        event_count: batch.count,
+                        attempt: batch.attempt,
+                        historical_migration: batch.historical_migration,
+                    },
+                );
                 dec_len(&self.len, batch.count);
             }
             Step::Backoff(delay) => {
@@ -1413,6 +1472,322 @@ mod tests {
             handle.pending(),
             0,
             "threshold-sized historical batch delivered"
+        );
+        handle.shutdown_blocking();
+    }
+
+    // -- on_error hook -------------------------------------------------------
+
+    /// Owned, assertable view of a `CaptureFailure` recorded from inside a hook
+    /// (the failure itself only borrows, so we snapshot what we assert on).
+    #[derive(Clone, PartialEq, Debug)]
+    enum ErrTag {
+        BadRequest,
+        ServerError(u16),
+        Other,
+    }
+
+    struct FailureSnapshot {
+        event_count: usize,
+        attempt: u32,
+        error: Option<ErrTag>,
+        #[cfg(feature = "capture-v1")]
+        statuses: Vec<(EventStatus, Option<String>)>,
+    }
+
+    impl FailureSnapshot {
+        fn capture(f: &CaptureFailure<'_>) -> Self {
+            let error = f.error().map(|e| match e {
+                crate::Error::BadRequest(_) => ErrTag::BadRequest,
+                crate::Error::ServerError { status, .. } => ErrTag::ServerError(*status),
+                _ => ErrTag::Other,
+            });
+            FailureSnapshot {
+                event_count: f.event_count(),
+                attempt: f.attempt(),
+                error,
+                #[cfg(feature = "capture-v1")]
+                statuses: {
+                    let mut s: Vec<(EventStatus, Option<String>)> = f
+                        .event_results()
+                        .values()
+                        .map(|r| (r.result.clone(), r.details.clone()))
+                        .collect();
+                    s.sort_by_key(|(st, _)| format!("{st:?}"));
+                    s
+                },
+            }
+        }
+    }
+
+    type Calls = Arc<Mutex<Vec<FailureSnapshot>>>;
+
+    /// Spawn a transport whose `on_error` records each failure into the returned sink.
+    fn recording_handle(
+        mut builder: ClientOptionsBuilder,
+        clock: ManualClock,
+    ) -> (TransportHandle, Calls) {
+        let calls: Calls = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&calls);
+        builder.on_error(move |f| {
+            sink.lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(FailureSnapshot::capture(f))
+        });
+        let handle = TransportHandle::spawn_with_clock(builder.build().unwrap(), Arc::new(clock));
+        (handle, calls)
+    }
+
+    fn reject_mock(server: &MockServer, status: u16) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
+            when.method(POST);
+            then.status(status)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "error": "nope" }));
+        })
+    }
+
+    fn retrying_opts(base_url: String) -> ClientOptionsBuilder {
+        let mut b = options(base_url);
+        b.max_capture_attempts(3u32)
+            .retry_initial_backoff_ms(1_000u64)
+            .retry_max_backoff_ms(60_000u64);
+        b
+    }
+
+    #[test]
+    fn on_error_fires_once_on_permanent_reject() {
+        let server = MockServer::start();
+        let reject = reject_mock(&server, 400);
+        let (handle, calls) = recording_handle(options(server.base_url()), ManualClock::new());
+
+        handle.enqueue(Event::new("e", "user-1"));
+        handle.flush_blocking();
+
+        reject.assert_hits(1);
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "a permanent reject fires on_error exactly once"
+        );
+        assert_eq!(calls[0].event_count, 1);
+        assert_eq!(calls[0].error, Some(ErrTag::BadRequest));
+        drop(calls);
+        handle.shutdown_blocking();
+    }
+
+    #[test]
+    fn on_error_fires_once_after_retry_exhaustion() {
+        let server = MockServer::start();
+        let fail = reject_mock(&server, 500);
+        let clock = ManualClock::new();
+        let (handle, calls) = recording_handle(retrying_opts(server.base_url()), clock.clone());
+
+        handle.enqueue(Event::new("e", "user-1"));
+        handle.flush_blocking(); // attempt 1 -> 500, held
+        clock.advance(Duration::from_secs(60));
+        handle.tick(); // attempt 2 -> 500, held
+        clock.advance(Duration::from_secs(60));
+        handle.tick(); // attempt 3 -> 500 -> Fail
+
+        fail.assert_hits(3);
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "exhausted retries fire on_error exactly once"
+        );
+        assert_eq!(
+            calls[0].attempt, 3,
+            "fires on the final (budget-exhausting) attempt"
+        );
+        assert_eq!(calls[0].error, Some(ErrTag::ServerError(500)));
+        assert_eq!(calls[0].event_count, 1);
+        drop(calls);
+        handle.shutdown_blocking();
+    }
+
+    #[test]
+    fn on_error_not_fired_on_success() {
+        let server = MockServer::start();
+        let ok = ok_mock(&server);
+        let (handle, calls) = recording_handle(options(server.base_url()), ManualClock::new());
+
+        handle.enqueue(Event::new("e", "user-1"));
+        handle.flush_blocking();
+
+        ok.assert_hits(1);
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "successful delivery must not fire on_error"
+        );
+        handle.shutdown_blocking();
+    }
+
+    #[test]
+    fn on_error_not_fired_when_retry_eventually_succeeds() {
+        let server = MockServer::start();
+        let mut fail = reject_mock(&server, 503);
+        let clock = ManualClock::new();
+        let (handle, calls) = recording_handle(retrying_opts(server.base_url()), clock.clone());
+
+        handle.enqueue(Event::new("e", "user-1"));
+        handle.flush_blocking(); // attempt 1 -> 503, held
+        fail.assert_hits(1);
+
+        fail.delete();
+        let ok = ok_mock(&server);
+        clock.advance(Duration::from_secs(60));
+        handle.tick(); // retry -> 200
+
+        ok.assert_hits(1);
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "a retry that ultimately succeeds must not fire on_error"
+        );
+        handle.shutdown_blocking();
+    }
+
+    #[test]
+    fn on_error_hook_panic_is_caught_and_worker_survives() {
+        let server = MockServer::start();
+        let mut reject = reject_mock(&server, 400);
+        let mut builder = options(server.base_url());
+        builder.on_error(|_f| panic!("boom"));
+        let handle = TransportHandle::spawn_with_clock(
+            builder.build().unwrap(),
+            Arc::new(ManualClock::new()),
+        );
+
+        handle.enqueue(Event::new("e1", "user-1"));
+        handle.flush_blocking(); // 400 -> Fail -> hook panics -> caught
+        reject.assert_hits(1);
+
+        reject.delete();
+        let ok = ok_mock(&server);
+        handle.enqueue(Event::new("e2", "user-1"));
+        handle.flush_blocking(); // worker still alive -> delivers
+
+        ok.assert_hits(1);
+        assert_eq!(
+            handle.pending(),
+            0,
+            "worker survived the hook panic and delivered the next batch"
+        );
+        handle.shutdown_blocking();
+    }
+
+    #[cfg(feature = "capture-v1")]
+    fn results_mock(server: &MockServer, results: serde_json::Value) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
+            when.method(POST);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "results": results }));
+        })
+    }
+
+    #[cfg(feature = "capture-v1")]
+    fn event_with_uuid(name: &str, uuid: uuid::Uuid) -> Event {
+        let mut event = Event::new(name, "user-1");
+        event.set_uuid(uuid);
+        event
+    }
+
+    #[cfg(feature = "capture-v1")]
+    #[test]
+    fn on_error_v1_fires_on_drop_within_2xx() {
+        let server = MockServer::start();
+        let u = uuid::Uuid::now_v7();
+        let mock = results_mock(
+            &server,
+            serde_json::json!({ u.to_string(): { "result": "drop", "details": "billing_limit_exceeded" } }),
+        );
+        let (handle, calls) = recording_handle(options(server.base_url()), ManualClock::new());
+
+        handle.enqueue(event_with_uuid("e", u));
+        handle.flush_blocking();
+
+        mock.assert_hits(1);
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "a per-event drop inside a 2xx fires on_error once"
+        );
+        assert_eq!(calls[0].error, None, "a 2xx has no batch-level error");
+        assert_eq!(calls[0].event_count, 1);
+        assert_eq!(
+            calls[0].statuses,
+            vec![(
+                EventStatus::Drop,
+                Some("billing_limit_exceeded".to_string())
+            )]
+        );
+        drop(calls);
+        handle.shutdown_blocking();
+    }
+
+    #[cfg(feature = "capture-v1")]
+    #[test]
+    fn on_error_v1_fires_on_exhausted_retry_within_2xx() {
+        let server = MockServer::start();
+        let u = uuid::Uuid::now_v7();
+        let mock = results_mock(
+            &server,
+            serde_json::json!({ u.to_string(): { "result": "retry", "details": "not_persisted" } }),
+        );
+        let clock = ManualClock::new();
+        let (handle, calls) = recording_handle(retrying_opts(server.base_url()), clock.clone());
+
+        handle.enqueue(event_with_uuid("e", u));
+        handle.flush_blocking(); // attempt 1 -> retry, held
+        clock.advance(Duration::from_secs(60));
+        handle.tick(); // attempt 2 -> retry, held
+        clock.advance(Duration::from_secs(60));
+        handle.tick(); // attempt 3 final -> Done with leftover retry -> fire
+
+        mock.assert_hits(3);
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "an exhausted retry inside a 2xx fires on_error exactly once"
+        );
+        assert_eq!(calls[0].error, None, "the request itself succeeded (2xx)");
+        assert_eq!(calls[0].attempt, 3);
+        assert_eq!(
+            calls[0].statuses,
+            vec![(EventStatus::Retry, Some("not_persisted".to_string()))]
+        );
+        drop(calls);
+        handle.shutdown_blocking();
+    }
+
+    #[cfg(feature = "capture-v1")]
+    #[test]
+    fn on_error_v1_not_fired_on_ok_or_warning_within_2xx() {
+        let server = MockServer::start();
+        let u_ok = uuid::Uuid::now_v7();
+        let u_warn = uuid::Uuid::now_v7();
+        let mock = results_mock(
+            &server,
+            serde_json::json!({
+                u_ok.to_string(): { "result": "ok" },
+                u_warn.to_string(): { "result": "warning", "details": "person_processing_disabled" },
+            }),
+        );
+        let (handle, calls) = recording_handle(options(server.base_url()), ManualClock::new());
+
+        handle.enqueue(event_with_uuid("ok", u_ok));
+        handle.enqueue(event_with_uuid("warn", u_warn));
+        handle.flush_blocking();
+
+        mock.assert_hits(1);
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "ok/warning verdicts are not data loss and must not fire on_error"
         );
         handle.shutdown_blocking();
     }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -1556,56 +1556,66 @@ mod tests {
     }
 
     #[test]
-    fn on_error_fires_once_on_permanent_reject() {
-        let server = MockServer::start();
-        let reject = reject_mock(&server, 400);
-        let (handle, calls) = recording_handle(options(server.base_url()), ManualClock::new());
+    fn on_error_fires_once_on_terminal_failure() {
+        struct Case {
+            name: &'static str,
+            status: u16,
+            // clock-advance + tick cycles after the initial flush before the
+            // batch goes terminal (0 = fails on the first attempt).
+            retries_after_flush: usize,
+            expected_attempt: u32,
+            expected_error: ErrTag,
+        }
+        let cases = [
+            Case {
+                name: "permanent reject (not retryable)",
+                status: 400,
+                retries_after_flush: 0,
+                expected_attempt: 1,
+                expected_error: ErrTag::BadRequest,
+            },
+            Case {
+                name: "exhausted retry budget",
+                status: 500,
+                retries_after_flush: 2,
+                expected_attempt: 3,
+                expected_error: ErrTag::ServerError(500),
+            },
+        ];
 
-        handle.enqueue(Event::new("e", "user-1"));
-        handle.flush_blocking();
+        for case in cases {
+            let server = MockServer::start();
+            // retrying_opts is harmless for the non-retryable case (it still
+            // fails on attempt 1) and required for the exhaustion case.
+            let fail = reject_mock(&server, case.status);
+            let clock = ManualClock::new();
+            let (handle, calls) = recording_handle(retrying_opts(server.base_url()), clock.clone());
 
-        reject.assert_hits(1);
-        let calls = calls.lock().unwrap();
-        assert_eq!(
-            calls.len(),
-            1,
-            "a permanent reject fires on_error exactly once"
-        );
-        assert_eq!(calls[0].event_count, 1);
-        assert_eq!(calls[0].error, Some(ErrTag::BadRequest));
-        drop(calls);
-        handle.shutdown_blocking();
-    }
+            handle.enqueue(Event::new("e", "user-1"));
+            handle.flush_blocking();
+            for _ in 0..case.retries_after_flush {
+                clock.advance(Duration::from_secs(60));
+                handle.tick();
+            }
 
-    #[test]
-    fn on_error_fires_once_after_retry_exhaustion() {
-        let server = MockServer::start();
-        let fail = reject_mock(&server, 500);
-        let clock = ManualClock::new();
-        let (handle, calls) = recording_handle(retrying_opts(server.base_url()), clock.clone());
-
-        handle.enqueue(Event::new("e", "user-1"));
-        handle.flush_blocking(); // attempt 1 -> 500, held
-        clock.advance(Duration::from_secs(60));
-        handle.tick(); // attempt 2 -> 500, held
-        clock.advance(Duration::from_secs(60));
-        handle.tick(); // attempt 3 -> 500 -> Fail
-
-        fail.assert_hits(3);
-        let calls = calls.lock().unwrap();
-        assert_eq!(
-            calls.len(),
-            1,
-            "exhausted retries fire on_error exactly once"
-        );
-        assert_eq!(
-            calls[0].attempt, 3,
-            "fires on the final (budget-exhausting) attempt"
-        );
-        assert_eq!(calls[0].error, Some(ErrTag::ServerError(500)));
-        assert_eq!(calls[0].event_count, 1);
-        drop(calls);
-        handle.shutdown_blocking();
+            fail.assert_hits(1 + case.retries_after_flush);
+            let calls = calls.lock().unwrap();
+            assert_eq!(calls.len(), 1, "{}: fires on_error exactly once", case.name);
+            assert_eq!(
+                calls[0].attempt, case.expected_attempt,
+                "{}: fires on the terminal attempt",
+                case.name
+            );
+            assert_eq!(
+                calls[0].error,
+                Some(case.expected_error.clone()),
+                "{}",
+                case.name
+            );
+            assert_eq!(calls[0].event_count, 1, "{}", case.name);
+            drop(calls);
+            handle.shutdown_blocking();
+        }
     }
 
     #[test]
@@ -1789,6 +1799,56 @@ mod tests {
             calls.lock().unwrap().is_empty(),
             "ok/warning verdicts are not data loss and must not fire on_error"
         );
+        handle.shutdown_blocking();
+    }
+
+    #[cfg(feature = "capture-v1")]
+    #[test]
+    fn on_error_v1_event_results_includes_persisted_verdicts() {
+        // A mixed batch (ok + warning + drop): the hook fires for the one lost
+        // event, but event_results() reports every verdict — so event_count is
+        // smaller than event_results().len() and callers must filter by status.
+        let server = MockServer::start();
+        let u_ok = uuid::Uuid::now_v7();
+        let u_warn = uuid::Uuid::now_v7();
+        let u_drop = uuid::Uuid::now_v7();
+        let mock = results_mock(
+            &server,
+            serde_json::json!({
+                u_ok.to_string(): { "result": "ok" },
+                u_warn.to_string(): { "result": "warning", "details": "person_processing_disabled" },
+                u_drop.to_string(): { "result": "drop", "details": "billing_limit_exceeded" },
+            }),
+        );
+        let (handle, calls) = recording_handle(options(server.base_url()), ManualClock::new());
+
+        handle.enqueue(event_with_uuid("ok", u_ok));
+        handle.enqueue(event_with_uuid("warn", u_warn));
+        handle.enqueue(event_with_uuid("drop", u_drop));
+        handle.flush_blocking();
+
+        mock.assert_hits(1);
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "the dropped event fires on_error once");
+        assert_eq!(calls[0].error, None);
+        assert_eq!(calls[0].event_count, 1, "only the drop counts as lost");
+        // event_results() carries all three verdicts (sorted Drop, Ok, Warning).
+        assert_eq!(
+            calls[0].statuses,
+            vec![
+                (
+                    EventStatus::Drop,
+                    Some("billing_limit_exceeded".to_string())
+                ),
+                (EventStatus::Ok, None),
+                (
+                    EventStatus::Warning,
+                    Some("person_processing_disabled".to_string())
+                ),
+            ],
+            "event_results reports persisted verdicts too, not just losses"
+        );
+        drop(calls);
         handle.shutdown_blocking();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,12 @@ mod local_evaluation;
 pub use client::client;
 pub use client::BeforeSendHook;
 pub use client::CaptureCompression;
+pub use client::CaptureFailure;
 pub use client::Client;
 pub use client::ClientOptions;
 pub use client::ClientOptionsBuilder;
 pub use client::ClientOptionsBuilderError;
+pub use client::OnErrorHook;
 
 // Endpoints
 pub use endpoints::{

--- a/tests/test_transport.rs
+++ b/tests/test_transport.rs
@@ -226,3 +226,45 @@ async fn successful_status_drains_the_queue() {
     client.flush().await;
     mock.assert_hits(1);
 }
+
+// --- on_error hook (public API) --------------------------------------------
+
+#[tokio::test]
+async fn on_error_hook_observes_permanent_failure() {
+    use std::sync::{Arc, Mutex};
+
+    let server = MockServer::start();
+    let reject = server.mock(|when, then| {
+        when.method(POST);
+        then.status(400)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({ "error": "bad" }));
+    });
+
+    let seen = Arc::new(Mutex::new(Vec::<usize>::new()));
+    let sink = Arc::clone(&seen);
+    let options = ClientOptionsBuilder::default()
+        .api_key("phc_test".to_string())
+        .host(server.base_url())
+        .flush_interval_ms(600_000u64)
+        .on_error(move |failure| {
+            assert!(
+                failure.error().is_some(),
+                "a rejected batch carries an error"
+            );
+            sink.lock().unwrap().push(failure.event_count());
+        })
+        .build()
+        .unwrap();
+
+    let client = posthog_rs::client(options).await;
+    client.capture(Event::new("e", "user-1"));
+    client.flush().await;
+
+    reject.assert_hits(1);
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec![1],
+        "the public on_error hook observed the dropped batch"
+    );
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

This PR adds an additive, observability-only `on_error` hook so callers can react to terminal delivery failures without reverting to a blocking `capture()`. Purely additive change. It fires only if a handler is registered by the caller, and only when a response is non-2xx or all retries are exhausted. The v1 variant will expose the rich detail that endpoint returns so the caller can debug event delivery issues quickly and at the granularity they want.

The background transport (introduced in 0.14.0) made `capture()`/`capture_batch()` fire-and-forget. That decoupled the API call from network I/O, but it also removed the only signal callers had that a batch was *permanently* lost — a permanent reject (e.g. 400/402) or a transient failure that exhausts the retry budget. Today the SDK only emits a `WARN` and drops the events; there is no programmatic hook to log, count, or alert on dropped data.


- New `ClientOptionsBuilder::on_error(...)`, plus public `OnErrorHook` and `CaptureFailure` types.
- `CaptureFailure` exposes `error()` (the batch cause), `event_count()`, `attempt()`, and `historical_migration()`.
- The hook fires **once per terminal batch** on the background worker:
  - permanent reject, or exhausted retry budget (`error()` is `Some`);
  - on the V1 capture pipeline, also when a request was `2xx` but per-event verdicts (`retry`/`drop`) leave events unpersisted after the retry budget (`error()` is `None`). In that case the feature-gated `CaptureFailure::event_results()` exposes the per-event server verdicts.
- Registering at least one hook silences **only** the default drop `WARN` it replaces; all other drop warnings (shutdown, serialization, queue-full) are unchanged.
- Hook panics are caught so a misbehaving hook cannot wedge the worker thread; multiple hooks fire in registration order.

This is purely additive — no existing signature changes. V1-specific behavior is implemented and tested but its public rustdoc is `cfg`-gated (invisible on the default docs.rs build); full v1 documentation is deferred to the v1 cutover.

## :green_heart: How did you test it?

New unit tests in `src/client/transport.rs` (driven by the existing `ManualClock`/`httpmock` harness) and `src/client/common.rs`, plus a public-API integration test in `tests/test_transport.rs`. Coverage:

- fires exactly once on a permanent reject and on retry exhaustion (correct `attempt`/`error`/`event_count`);
- does **not** fire on success or on a retry that eventually succeeds;
- V1: fires on a `drop` and on an exhausted `retry` *within* a 2xx (`error()` is `None`, `event_results()` populated), and does **not** fire for `ok`/`warning` verdicts;
- hooks run in registration order and a panicking hook is isolated; the worker survives and keeps delivering.

Ran the full CI matrix locally (default, `capture-v1`, the `--no-default-features` combos, and the `e2e-test` config) — all green — plus `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo doc`, and regenerated `api/public-api.txt` via `scripts/check-public-api.sh --update`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file