### PR TITLE
fix(capture-v1): type-coerce options before placing on v1 wire

### DIFF
--- a/.sampo/changesets/v1-options-type-coercion.md
+++ b/.sampo/changesets/v1-options-type-coercion.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Type-coerce `capture-v1` options before placing them on the wire. A caller value whose type doesn't match the backend's strict `Options` schema is now coerced when possible, or dropped (backend applies its default) rather than rejecting the whole batch. No effect on default (v0) capture behavior.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,11 +29,32 @@ mod v1 {
     pub(crate) const PRODUCT_TOUR_ID_OPT: &str = "product_tour_id";
     pub(crate) const PROCESS_PERSON_PROFILE_OPT: &str = "process_person_profile";
 
-    /// (property key, wire option key) pairs lifted into the V1 `options` map.
-    pub(crate) const OPTIONS_EXTRACTION_TABLE: &[(&str, &str)] = &[
-        (COOKIELESS_MODE_PROP, COOKIELESS_MODE_OPT),
-        (IGNORE_SENT_AT_PROP, DISABLE_SKEW_CORRECTION_OPT),
-        (PRODUCT_TOUR_ID_PROP, PRODUCT_TOUR_ID_OPT),
-        (PROCESS_PERSON_PROFILE_PROP, PROCESS_PERSON_PROFILE_OPT),
+    /// The type the backend's `Options` struct expects for a lifted key. Drives
+    /// the coercion in `V1Event::from_event_at`: a caller value that can't be
+    /// coerced to this type is dropped rather than shipped (a mistyped option
+    /// otherwise 400s the whole batch, since the backend `Options` is strict
+    /// serde — see `rust/capture/src/v1/analytics/types.rs`).
+    #[derive(Clone, Copy)]
+    pub(crate) enum OptionKind {
+        Bool,
+        Str,
+    }
+
+    /// (property key, wire option key, expected type) tuples lifted into the V1
+    /// `options` map. The type tag selects the coercion applied before the value
+    /// is placed on the wire.
+    pub(crate) const OPTIONS_EXTRACTION_TABLE: &[(&str, &str, OptionKind)] = &[
+        (COOKIELESS_MODE_PROP, COOKIELESS_MODE_OPT, OptionKind::Bool),
+        (
+            IGNORE_SENT_AT_PROP,
+            DISABLE_SKEW_CORRECTION_OPT,
+            OptionKind::Bool,
+        ),
+        (PRODUCT_TOUR_ID_PROP, PRODUCT_TOUR_ID_OPT, OptionKind::Str),
+        (
+            PROCESS_PERSON_PROFILE_PROP,
+            PROCESS_PERSON_PROFILE_OPT,
+            OptionKind::Bool,
+        ),
     ];
 }

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::debug;
 use uuid::Uuid;
 
-use crate::constants::{OPTIONS_EXTRACTION_TABLE, SESSION_ID_PROP, WINDOW_ID_PROP};
+use crate::constants::{OptionKind, OPTIONS_EXTRACTION_TABLE, SESSION_ID_PROP, WINDOW_ID_PROP};
 use crate::event::Event;
 
 /// Crate-internal V1 capture options, derived from `event.properties`.
@@ -58,11 +60,24 @@ impl V1Event {
             .map(|ts| ts.and_utc().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
             .unwrap_or_else(|| now.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string());
 
-        // Extract magic keys from properties into the V1 options map.
+        // Extract magic keys from properties into the V1 options map. The key is
+        // always removed from properties (these sentinels must never reach v1
+        // backend properties); the value is coerced to the type the backend's
+        // strict `Options` struct expects. A value that can't be coerced is
+        // dropped so the backend applies its default, rather than 400-ing the
+        // whole batch on a type mismatch.
         let mut options_map = serde_json::Map::new();
-        for &(prop_key, wire_key) in OPTIONS_EXTRACTION_TABLE {
+        for &(prop_key, wire_key, kind) in OPTIONS_EXTRACTION_TABLE {
             if let Some(val) = properties.remove(prop_key) {
-                options_map.insert(wire_key.to_string(), val);
+                match coerce_option(kind, val) {
+                    Some(coerced) => {
+                        options_map.insert(wire_key.to_string(), coerced);
+                    }
+                    None => debug!(
+                        prop = prop_key,
+                        "v1 options: dropping mistyped value; backend will apply its default"
+                    ),
+                }
             }
         }
 
@@ -84,6 +99,41 @@ impl V1Event {
             properties: serde_json::to_value(properties)
                 .unwrap_or(serde_json::Value::Object(Default::default())),
         }
+    }
+}
+
+/// Coerce a lifted property value to the type the backend `Options` field
+/// expects, returning the canonical wire value or `None` if uninterpretable.
+fn coerce_option(kind: OptionKind, val: Value) -> Option<Value> {
+    match kind {
+        OptionKind::Bool => coerce_bool(val).map(Value::Bool),
+        OptionKind::Str => coerce_string(val).map(Value::String),
+    }
+}
+
+/// Coerce a value to bool using the same truthiness rules the backend would
+/// accept: native bool passes through; common string/numeric forms are
+/// accepted (`"true"`/`"1"`/`1`/`1.0` → true, `"false"`/`"0"`/`0` → false).
+/// Returns `None` when the value is not interpretable as a boolean.
+fn coerce_bool(val: Value) -> Option<bool> {
+    match val {
+        Value::Bool(b) => Some(b),
+        Value::String(s) => match s.trim().to_lowercase().as_str() {
+            "true" | "1" => Some(true),
+            "false" | "0" => Some(false),
+            _ => None,
+        },
+        Value::Number(n) => n.as_f64().map(|f| f != 0.0),
+        _ => None,
+    }
+}
+
+/// Coerce a value to string. The backend's `product_tour_id` is
+/// `Option<String>`; non-string types are not interpretable.
+fn coerce_string(val: Value) -> Option<String> {
+    match val {
+        Value::String(s) => Some(s),
+        _ => None,
     }
 }
 
@@ -229,6 +279,116 @@ mod tests {
         );
         let props = v1.properties.as_object().unwrap();
         assert!(!props.contains_key("$ignore_sent_at"));
+    }
+
+    // -- options type coercion -----------------------------------------------
+
+    /// Lift one magic property and return the parsed (options, properties)
+    /// objects so a case can assert both the wire value and the strip.
+    fn lift_one(
+        prop_key: &str,
+        val: serde_json::Value,
+    ) -> (
+        serde_json::Map<String, serde_json::Value>,
+        serde_json::Map<String, serde_json::Value>,
+    ) {
+        let mut event = Event::new("test", "user-1");
+        event.insert_prop(prop_key, val).unwrap();
+        let v1 = V1Event::from_event(&event);
+        let json = serde_json::to_value(&v1).unwrap();
+        let options = json.get("options").unwrap().as_object().unwrap().clone();
+        let props = v1.properties.as_object().unwrap().clone();
+        (options, props)
+    }
+
+    #[test]
+    fn v1_options_bool_coercion() {
+        // (input value, expected wire bool or None when omitted). Covers native
+        // bool, the string/numeric forms the backend tolerates, and
+        // uninterpretable values that must be dropped (not shipped mistyped).
+        let cases: [(serde_json::Value, Option<bool>); 13] = [
+            (serde_json::json!(true), Some(true)),
+            (serde_json::json!(false), Some(false)),
+            (serde_json::json!("true"), Some(true)),
+            (serde_json::json!("false"), Some(false)),
+            (serde_json::json!("TRUE"), Some(true)),
+            (serde_json::json!("  True  "), Some(true)),
+            (serde_json::json!("1"), Some(true)),
+            (serde_json::json!("0"), Some(false)),
+            (serde_json::json!(1), Some(true)),
+            (serde_json::json!(0), Some(false)),
+            (serde_json::json!(2), Some(true)),
+            (serde_json::json!("yes"), None),
+            (serde_json::json!(null), None),
+        ];
+        // Assert one representative bool key end-to-end, then confirm every bool
+        // key in the table shares the path with a single non-coercible value.
+        for (input, expected) in cases {
+            let (options, props) = lift_one("$cookieless_mode", input.clone());
+            assert_eq!(
+                options.get("cookieless_mode"),
+                expected.map(serde_json::Value::Bool).as_ref(),
+                "cookieless_mode input={:?}",
+                input
+            );
+            // Always stripped from properties, even when coercion fails.
+            assert!(
+                !props.contains_key("$cookieless_mode"),
+                "magic key must be stripped, input={:?}",
+                input
+            );
+        }
+
+        // All three bool option keys behave identically: a non-coercible value
+        // is dropped, a coercible one is normalized.
+        for (prop_key, wire_key) in [
+            ("$cookieless_mode", "cookieless_mode"),
+            ("$ignore_sent_at", "disable_skew_correction"),
+            ("$process_person_profile", "process_person_profile"),
+        ] {
+            let (bad, _) = lift_one(prop_key, serde_json::json!(["nope"]));
+            assert!(
+                !bad.contains_key(wire_key),
+                "{}: array must be dropped",
+                wire_key
+            );
+            let (good, _) = lift_one(prop_key, serde_json::json!("1"));
+            assert_eq!(
+                good.get(wire_key),
+                Some(&serde_json::json!(true)),
+                "{}: \"1\" must coerce to true",
+                wire_key
+            );
+        }
+    }
+
+    #[test]
+    fn v1_options_product_tour_id_coercion() {
+        // product_tour_id is Option<String>: only strings pass; other JSON
+        // types are dropped so the backend doesn't 400 on the batch.
+        let cases: [(serde_json::Value, Option<&str>); 5] = [
+            (serde_json::json!("tour-42"), Some("tour-42")),
+            (serde_json::json!(""), Some("")),
+            (serde_json::json!(42), None),
+            (serde_json::json!(true), None),
+            (serde_json::json!(["a"]), None),
+        ];
+        for (input, expected) in cases {
+            let (options, props) = lift_one("$product_tour_id", input.clone());
+            assert_eq!(
+                options.get("product_tour_id"),
+                expected
+                    .map(|s| serde_json::Value::String(s.to_string()))
+                    .as_ref(),
+                "product_tour_id input={:?}",
+                input
+            );
+            assert!(
+                !props.contains_key("$product_tour_id"),
+                "magic key must be stripped, input={:?}",
+                input
+            );
+        }
     }
 
     // -- session/window extraction -------------------------------------------

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -111,10 +111,10 @@ fn coerce_option(kind: OptionKind, val: Value) -> Option<Value> {
     }
 }
 
-/// Coerce a value to bool using the same truthiness rules the backend would
-/// accept: native bool passes through; common string/numeric forms are
-/// accepted (`"true"`/`"1"`/`1`/`1.0` → true, `"false"`/`"0"`/`0` → false).
-/// Returns `None` when the value is not interpretable as a boolean.
+/// Coerce a value to bool, mirroring posthog-go: native bool passes through;
+/// the strings `"true"`/`"1"` (and `"false"`/`"0"`), trimmed and
+/// case-insensitive, are accepted; any non-zero number is true and zero is
+/// false. Returns `None` when the value is not interpretable as a boolean.
 fn coerce_bool(val: Value) -> Option<bool> {
     match val {
         Value::Bool(b) => Some(b),
@@ -340,24 +340,35 @@ mod tests {
         }
 
         // All three bool option keys behave identically: a non-coercible value
-        // is dropped, a coercible one is normalized.
+        // is dropped, a coercible one is normalized — and either way the magic
+        // key is stripped from properties (it must never reach v1 backend props).
         for (prop_key, wire_key) in [
             ("$cookieless_mode", "cookieless_mode"),
             ("$ignore_sent_at", "disable_skew_correction"),
             ("$process_person_profile", "process_person_profile"),
         ] {
-            let (bad, _) = lift_one(prop_key, serde_json::json!(["nope"]));
+            let (bad, bad_props) = lift_one(prop_key, serde_json::json!(["nope"]));
             assert!(
                 !bad.contains_key(wire_key),
                 "{}: array must be dropped",
                 wire_key
             );
-            let (good, _) = lift_one(prop_key, serde_json::json!("1"));
+            assert!(
+                !bad_props.contains_key(prop_key),
+                "{}: magic key must be stripped even when coercion fails",
+                prop_key
+            );
+            let (good, good_props) = lift_one(prop_key, serde_json::json!("1"));
             assert_eq!(
                 good.get(wire_key),
                 Some(&serde_json::json!(true)),
                 "{}: \"1\" must coerce to true",
                 wire_key
+            );
+            assert!(
+                !good_props.contains_key(prop_key),
+                "{}: magic key must be stripped on coercion success",
+                prop_key
             );
         }
     }


### PR DESCRIPTION
## :bulb: Motivation and Context

The `capture-v1` path lifts magic properties (`$cookieless_mode`, `$ignore_sent_at`, `$product_tour_id`, `$process_person_profile`) from `event.properties` into the wire `options` object, but shipped the caller's **raw value with no type check**. The backend [`Options`](https://github.com/PostHog/posthog/blob/master/rust/capture/src/v1/analytics/types.rs) struct is strict serde (`Option<bool>` x3, `Option<String>` for `product_tour_id`), so a mistyped value (e.g. `insert_prop("$cookieless_mode", "true")`) **400s the entire batch**.

This is the Rust port of the same fix landed in posthog-go ([#235](https://github.com/PostHog/posthog-go/pull/235)) — same `coerce-then-omit` semantics for cross-SDK consistency against the shared backend.

- Tag `OPTIONS_EXTRACTION_TABLE` entries with an `OptionKind` (`Bool`/`Str`) and coerce each lifted value to the expected type before it goes in `options`.
  - `coerce_bool` accepts native bool, `"true"/"false"/"1"/"0"` (trimmed, case-insensitive), and numeric `!= 0`; `coerce_string` accepts only strings.
- On coercion failure the option key is **omitted** (backend applies its default) and a `tracing::debug!` is emitted; the magic key is **always stripped** from `properties` either way (these sentinels must never reach v1 backend properties).
- `session_id`/`window_id` are out of scope — already type-safe via `.and_then(|v| v.as_str())`.

No public API change (all additions are `pub(crate)`/private; `api/public-api.txt` unchanged). No effect on the default v0 capture path.

## :green_heart: How did you test it?

Net-new table-driven tests in `src/event_v1.rs` (repo `let cases = [...]` + for-loop style):

- `v1_options_bool_coercion` — native bool, string/numeric forms, and uninterpretable values (omitted); confirms all three bool option keys share the path.
- `v1_options_product_tour_id_coercion` — only strings pass; numbers/bools/arrays dropped.
- Both assert the always-strip-from-properties invariant on coercion failure.

Full `cargo test --features capture-v1` green (207 unit + all integration suites), `cargo clippy --all-features --all-targets` clean, `cargo fmt --check` clean, `scripts/check-public-api.sh` reports up to date.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
