### PR TITLE
fix: route flag called events through capture transport

### DIFF
--- a/.sampo/changesets/doughty-thunderbearer-otso.md
+++ b/.sampo/changesets/doughty-thunderbearer-otso.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Route feature flag called events through the normal capture transport.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -4,8 +4,7 @@ use std::error::Error as StdError;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use reqwest::header::USER_AGENT;
-use reqwest::{header::CONTENT_TYPE, Client as HttpClient};
+use reqwest::{header::CONTENT_TYPE, header::USER_AGENT, Client as HttpClient};
 use serde_json::json;
 use tracing::{debug, instrument, trace, warn};
 
@@ -13,8 +12,6 @@ use super::get_default_user_agent;
 use crate::endpoints::Endpoint;
 #[cfg(feature = "error-tracking")]
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
-#[cfg(not(feature = "capture-v1"))]
-use crate::event::InnerEvent;
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
     FlagCalledEventParams,
@@ -23,29 +20,13 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
-#[cfg(not(feature = "capture-v1"))]
-use super::common::apply_before_send_hooks;
 use super::common::{
     already_reported, build_dedup_key, extract_flag_details, flag_called_event,
     flag_event_dedup_cache, local_record, remote_record_from_detail, DetailedFlagsResponse,
     FlagEventDedupCache,
 };
 use super::transport::{Completion, Control, TransportHandle};
-use super::{BeforeSendHook, ClientOptions};
-
-#[cfg(not(feature = "capture-v1"))]
-async fn check_response(response: reqwest::Response) -> Result<(), Error> {
-    let status = response.status().as_u16();
-    let body = response
-        .text()
-        .await
-        .unwrap_or_else(|_| "Unknown error".to_string());
-
-    match Error::from_http_response(status, body) {
-        Some(err) => Err(err),
-        None => Ok(()),
-    }
-}
+use super::ClientOptions;
 
 /// A [`Client`] facilitates interactions with the PostHog API over HTTP.
 pub struct Client {
@@ -55,141 +36,31 @@ pub struct Client {
     _flag_poller: Option<AsyncFlagPoller>,
     flag_event_host: OnceLock<Arc<dyn FeatureFlagEvaluationsHost>>,
     /// Background event transport. `None` for disabled clients.
-    transport: Option<TransportHandle>,
+    transport: Option<Arc<TransportHandle>>,
 }
 
 /// Implementation of [`FeatureFlagEvaluationsHost`] that emits dedup-aware
-/// `$feature_flag_called` events through a clone of the async [`Client`]'s
-/// HTTP transport. The event ship is fire-and-forget: errors are logged at
-/// `debug` level but do not surface to the caller, matching the JS SDK.
-///
-/// With `capture-v1`, events ship to the V1 endpoint (single attempt);
-/// otherwise the legacy v0 `/i/v0/e/` path.
+/// `$feature_flag_called` events through the same background capture transport
+/// as any other event.
 struct AsyncFlagEventHost {
-    http_client: HttpClient,
     options: ClientOptions,
-    capture_url: String,
-    // Read by the v0 ship path only; unused under capture-v1, where the
-    // flag-event path does not currently apply before_send hooks.
-    #[cfg_attr(feature = "capture-v1", allow(dead_code))]
-    before_send: Vec<BeforeSendHook>,
+    transport: Option<Arc<TransportHandle>>,
     dedup_cache: FlagEventDedupCache,
-    /// Tokio runtime handle captured at host construction (which always runs
-    /// inside the runtime that hosts `evaluate_flags`). This lets snapshot
-    /// access methods spawn `$feature_flag_called` shipping from any thread —
-    /// including ones without an entered runtime — by routing through the
-    /// captured handle instead of the free `tokio::spawn` (which would panic).
-    runtime: tokio::runtime::Handle,
 }
 
 impl AsyncFlagEventHost {
-    fn from_options(options: &ClientOptions, http_client: HttpClient) -> Self {
-        #[cfg(feature = "capture-v1")]
-        let capture_url = options
-            .endpoints()
-            .build_custom_url(super::v1_capture::V1_CAPTURE_PATH);
-        #[cfg(not(feature = "capture-v1"))]
-        let capture_url = options.endpoints().build_url(Endpoint::Capture);
+    fn from_options(options: &ClientOptions, transport: Option<Arc<TransportHandle>>) -> Self {
         Self {
-            http_client,
             options: options.clone(),
-            capture_url,
-            before_send: options.before_send.clone(),
+            transport,
             dedup_cache: flag_event_dedup_cache(),
-            runtime: tokio::runtime::Handle::current(),
         }
     }
 
-    fn spawn_ship(&self, event: Event) {
-        if self.options.is_disabled() {
-            return;
+    fn enqueue(&self, event: Event) {
+        if let Some(transport) = &self.transport {
+            transport.enqueue(event);
         }
-        #[cfg(feature = "capture-v1")]
-        self.spawn_ship_v1(event);
-        #[cfg(not(feature = "capture-v1"))]
-        self.spawn_ship_v0(event);
-    }
-
-    /// Single attempt, no retries — matches v0 flag-event semantics: losses
-    /// aren't worth retry traffic and shipping must never slow flag reads.
-    #[cfg(feature = "capture-v1")]
-    fn spawn_ship_v1(&self, event: Event) {
-        let (headers, body) =
-            match super::v1_capture::build_flag_event_request(&self.options, &event) {
-                Ok(parts) => parts,
-                Err(e) => {
-                    debug!(error = %e, "failed to serialize $feature_flag_called event");
-                    return;
-                }
-            };
-        let http_client = self.http_client.clone();
-        let url = self.capture_url.clone();
-        self.runtime.spawn(async move {
-            match http_client
-                .post(&url)
-                .headers(headers)
-                .body(body)
-                .send()
-                .await
-            {
-                Ok(resp) => {
-                    let status = resp.status().as_u16();
-                    if !(200..=299).contains(&status) {
-                        let message = resp
-                            .text()
-                            .await
-                            .unwrap_or_else(|_| "Unknown error".to_string());
-                        debug!(
-                            status,
-                            "$feature_flag_called event rejected by server: {message}"
-                        );
-                    }
-                }
-                Err(send_err) => {
-                    let message = send_err.to_string();
-                    debug!("failed to send $feature_flag_called event: {message}");
-                }
-            }
-        });
-    }
-
-    #[cfg(not(feature = "capture-v1"))]
-    fn spawn_ship_v0(&self, mut event: Event) {
-        event.prepare_for_v0();
-        let Some(event) = apply_before_send_hooks(&self.before_send, event) else {
-            return;
-        };
-        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
-        let payload = match serde_json::to_string(&inner_event) {
-            Ok(p) => p,
-            Err(e) => {
-                debug!(error = %e, "failed to serialize $feature_flag_called event");
-                return;
-            }
-        };
-        let http_client = self.http_client.clone();
-        let url = self.capture_url.clone();
-        self.runtime.spawn(async move {
-            let response = match http_client
-                .post(&url)
-                .header(CONTENT_TYPE, "application/json")
-                .header(USER_AGENT, get_default_user_agent())
-                .body(payload)
-                .send()
-                .await
-            {
-                Ok(r) => r,
-                Err(send_err) => {
-                    let message = send_err.to_string();
-                    debug!("failed to send $feature_flag_called event: {message}");
-                    return;
-                }
-            };
-            if let Err(check_err) = check_response(response).await {
-                let message = check_err.to_string();
-                debug!("$feature_flag_called event rejected by server: {message}");
-            }
-        });
     }
 }
 
@@ -203,7 +74,7 @@ impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
         if let Some(event) =
             flag_called_event(params, self.options.disable_geoip, self.options.is_server)
         {
-            self.spawn_ship(event);
+            self.enqueue(event);
         }
     }
 
@@ -265,7 +136,7 @@ pub async fn client<C: Into<ClientOptions>>(options: C) -> Client {
     let transport = if options.is_disabled() {
         None
     } else {
-        Some(TransportHandle::spawn(options.clone()))
+        Some(Arc::new(TransportHandle::spawn(options.clone())))
     };
 
     Client {
@@ -920,7 +791,7 @@ impl Client {
             .get_or_init(|| {
                 Arc::new(AsyncFlagEventHost::from_options(
                     &self.options,
-                    self.client.clone(),
+                    self.transport.clone(),
                 )) as Arc<dyn FeatureFlagEvaluationsHost>
             })
             .clone()

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -15,8 +15,6 @@ use super::get_default_user_agent;
 use crate::endpoints::Endpoint;
 #[cfg(feature = "error-tracking")]
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
-#[cfg(not(feature = "capture-v1"))]
-use crate::event::InnerEvent;
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
     FlagCalledEventParams,
@@ -25,28 +23,13 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
-#[cfg(not(feature = "capture-v1"))]
-use super::common::apply_before_send_hooks;
 use super::common::{
     already_reported, build_dedup_key, extract_flag_details, flag_called_event,
     flag_event_dedup_cache, local_record, remote_record_from_detail, DetailedFlagsResponse,
     FlagEventDedupCache,
 };
 use super::transport::{Completion, Control, TransportHandle};
-use super::{BeforeSendHook, ClientOptions};
-
-#[cfg(not(feature = "capture-v1"))]
-fn check_response(response: reqwest::blocking::Response) -> Result<(), Error> {
-    let status = response.status().as_u16();
-    let body = response
-        .text()
-        .unwrap_or_else(|_| "Unknown error".to_string());
-
-    match Error::from_http_response(status, body) {
-        Some(err) => Err(err),
-        None => Ok(()),
-    }
-}
+use super::ClientOptions;
 
 /// A [`Client`] facilitates interactions with the PostHog API over HTTP.
 pub struct Client {
@@ -56,117 +39,31 @@ pub struct Client {
     _flag_poller: Option<FlagPoller>,
     flag_event_host: OnceLock<Arc<dyn FeatureFlagEvaluationsHost>>,
     /// Background event transport. `None` for disabled clients.
-    transport: Option<TransportHandle>,
+    transport: Option<Arc<TransportHandle>>,
 }
 
 /// Implementation of [`FeatureFlagEvaluationsHost`] that emits dedup-aware
-/// `$feature_flag_called` events through a clone of the blocking [`Client`]'s
-/// HTTP transport. Constructed lazily and cached on the [`Client`] so all
+/// `$feature_flag_called` events through the same background capture transport
+/// as any other event. Constructed lazily and cached on the [`Client`] so all
 /// snapshots share a single dedup cache.
-///
-/// With `capture-v1`, events ship to the V1 endpoint (single synchronous
-/// attempt); otherwise the legacy v0 `/i/v0/e/` path.
 struct BlockingFlagEventHost {
-    http_client: HttpClient,
     options: ClientOptions,
-    capture_url: String,
-    // Read by the v0 ship path only; unused under capture-v1, where the
-    // flag-event path does not currently apply before_send hooks.
-    #[cfg_attr(feature = "capture-v1", allow(dead_code))]
-    before_send: Vec<BeforeSendHook>,
+    transport: Option<Arc<TransportHandle>>,
     dedup_cache: FlagEventDedupCache,
 }
 
 impl BlockingFlagEventHost {
-    fn from_options(options: &ClientOptions, http_client: HttpClient) -> Self {
-        #[cfg(feature = "capture-v1")]
-        let capture_url = options
-            .endpoints()
-            .build_custom_url(super::v1_capture::V1_CAPTURE_PATH);
-        #[cfg(not(feature = "capture-v1"))]
-        let capture_url = options.endpoints().build_url(Endpoint::Capture);
+    fn from_options(options: &ClientOptions, transport: Option<Arc<TransportHandle>>) -> Self {
         Self {
-            http_client,
             options: options.clone(),
-            capture_url,
-            before_send: options.before_send.clone(),
+            transport,
             dedup_cache: flag_event_dedup_cache(),
         }
     }
 
-    fn ship_event(&self, event: Event) {
-        if self.options.is_disabled() {
-            return;
-        }
-        #[cfg(feature = "capture-v1")]
-        self.ship_event_v1(event);
-        #[cfg(not(feature = "capture-v1"))]
-        self.ship_event_v0(event);
-    }
-
-    /// Single attempt, no retries — matches v0 flag-event semantics: losses
-    /// aren't worth retry traffic or extra blocking time on the caller.
-    #[cfg(feature = "capture-v1")]
-    fn ship_event_v1(&self, event: Event) {
-        let (headers, body) =
-            match super::v1_capture::build_flag_event_request(&self.options, &event) {
-                Ok(parts) => parts,
-                Err(e) => {
-                    debug!(error = %e, "failed to serialize $feature_flag_called event");
-                    return;
-                }
-            };
-        let result = self
-            .http_client
-            .post(&self.capture_url)
-            .headers(headers)
-            .body(body)
-            .send();
-        match result {
-            Ok(response) => {
-                let status = response.status().as_u16();
-                if !(200..=299).contains(&status) {
-                    let message = response
-                        .text()
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    debug!(
-                        status,
-                        "$feature_flag_called event rejected by server: {message}"
-                    );
-                }
-            }
-            Err(e) => debug!(error = %e, "failed to send $feature_flag_called event"),
-        }
-    }
-
-    #[cfg(not(feature = "capture-v1"))]
-    fn ship_event_v0(&self, mut event: Event) {
-        event.prepare_for_v0();
-        let Some(event) = apply_before_send_hooks(&self.before_send, event) else {
-            return;
-        };
-        let inner_event = InnerEvent::new(event, self.options.api_key.clone());
-        let payload = match serde_json::to_string(&inner_event) {
-            Ok(p) => p,
-            Err(e) => {
-                debug!(error = %e, "failed to serialize $feature_flag_called event");
-                return;
-            }
-        };
-        let result = self
-            .http_client
-            .post(&self.capture_url)
-            .header(CONTENT_TYPE, "application/json")
-            .header(USER_AGENT, get_default_user_agent())
-            .body(payload)
-            .send();
-        match result {
-            Ok(response) => {
-                if let Err(e) = check_response(response) {
-                    debug!(error = %e, "$feature_flag_called event rejected by server");
-                }
-            }
-            Err(e) => debug!(error = %e, "failed to send $feature_flag_called event"),
+    fn enqueue(&self, event: Event) {
+        if let Some(transport) = &self.transport {
+            transport.enqueue(event);
         }
     }
 }
@@ -181,7 +78,7 @@ impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
         if let Some(event) =
             flag_called_event(params, self.options.disable_geoip, self.options.is_server)
         {
-            self.ship_event(event);
+            self.enqueue(event);
         }
     }
 
@@ -243,7 +140,7 @@ pub fn client<C: Into<ClientOptions>>(options: C) -> Client {
     let transport = if options.is_disabled() {
         None
     } else {
-        Some(TransportHandle::spawn(options.clone()))
+        Some(Arc::new(TransportHandle::spawn(options.clone())))
     };
 
     Client {
@@ -888,7 +785,7 @@ impl Client {
             .get_or_init(|| {
                 Arc::new(BlockingFlagEventHost::from_options(
                     &self.options,
-                    self.client.clone(),
+                    self.transport.clone(),
                 )) as Arc<dyn FeatureFlagEvaluationsHost>
             })
             .clone()

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -24,12 +24,8 @@ use crate::event_v1::{CaptureResponse, EventResult, EventStatus, V1ErrorResponse
 // Request building
 // ---------------------------------------------------------------------------
 
-pub(crate) fn build_events(events: &[Event], defaults: &CaptureDefaults) -> Vec<V1Event> {
-    build_events_at(events, defaults, Utc::now())
-}
-
-/// Like [`build_events`] but with an injected `now` so the transport worker can
-/// stamp deterministic event timestamps from its clock.
+/// Build V1 events with an injected `now` so the transport worker can stamp
+/// deterministic event timestamps from its clock.
 pub(crate) fn build_events_at(
     events: &[Event],
     defaults: &CaptureDefaults,
@@ -56,6 +52,7 @@ pub(crate) fn build_events_at(
         .collect()
 }
 
+#[cfg(test)]
 pub(crate) fn build_headers(opts: &ClientOptions, request_id: &Uuid, attempt: u32) -> HeaderMap {
     build_headers_at(opts, request_id, attempt, Utc::now())
 }
@@ -126,29 +123,6 @@ pub(crate) fn maybe_compress(
         }
     }
     payload
-}
-
-/// Headers + (possibly compressed) body for a single-event, fire-and-forget
-/// `$feature_flag_called` ship over the V1 endpoint. Always one attempt:
-/// flag-event loss isn't worth retry traffic, and shipping must never block
-/// flag reads.
-pub(crate) fn build_flag_event_request(
-    opts: &ClientOptions,
-    event: &Event,
-) -> Result<(HeaderMap, Vec<u8>), Error> {
-    use crate::event_v1::V1BatchRequestRef;
-
-    let batch = build_events(std::slice::from_ref(event), &opts.capture_defaults());
-    let created_at = Utc::now().to_rfc3339();
-    let req = V1BatchRequestRef {
-        created_at: &created_at,
-        historical_migration: None,
-        batch: &batch,
-    };
-    let payload = serde_json::to_vec(&req).map_err(|e| Error::Serialization(e.to_string()))?;
-    let mut headers = build_headers(opts, &Uuid::now_v7(), 1);
-    let body = maybe_compress(opts.capture_compression, &mut headers, payload);
-    Ok((headers, body))
 }
 
 // ---------------------------------------------------------------------------
@@ -736,71 +710,5 @@ mod tests {
         // user-agent mirrors the same identity string.
         let ua = headers.get("user-agent").unwrap().to_str().unwrap();
         assert_eq!(ua, expected);
-    }
-
-    // -- build_flag_event_request ----------------------------------------------
-
-    fn flag_called_test_event() -> Event {
-        let mut event = Event::new("$feature_flag_called", "user-1");
-        event.insert_prop("$feature_flag", "my-flag").unwrap();
-        event.insert_prop("$feature_flag_response", true).unwrap();
-        event
-    }
-
-    #[test]
-    fn build_flag_event_request_single_event_batch() {
-        let opts = test_opts();
-        let (headers, body) = build_flag_event_request(&opts, &flag_called_test_event()).unwrap();
-
-        assert_eq!(headers.get("content-type").unwrap(), "application/json");
-        assert_eq!(headers.get("posthog-attempt").unwrap(), "1");
-        assert!(headers.get("posthog-request-id").is_some());
-        assert_eq!(
-            headers.get("authorization").unwrap().to_str().unwrap(),
-            "Bearer phc_test"
-        );
-        assert!(headers.get("content-encoding").is_none());
-
-        let parsed: crate::event_v1::V1BatchRequest = serde_json::from_slice(&body).unwrap();
-        assert_eq!(parsed.batch.len(), 1);
-        assert_eq!(parsed.batch[0].event, "$feature_flag_called");
-        assert_eq!(parsed.batch[0].distinct_id, "user-1");
-        assert!(parsed.historical_migration.is_none());
-        let props = parsed.batch[0].properties.as_object().unwrap();
-        assert_eq!(props.get("$feature_flag").unwrap(), "my-flag");
-        // V1 carries SDK identity in headers, not properties.
-        assert!(!props.contains_key("$lib"));
-        assert!(!props.contains_key("$lib_version"));
-    }
-
-    #[test]
-    fn build_flag_event_request_applies_capture_defaults() {
-        let opts = ClientOptionsBuilder::default()
-            .api_key("phc_test".to_string())
-            .disable_geoip(true)
-            .is_server(true)
-            .build()
-            .unwrap();
-        let (_, body) = build_flag_event_request(&opts, &flag_called_test_event()).unwrap();
-        let parsed: crate::event_v1::V1BatchRequest = serde_json::from_slice(&body).unwrap();
-        let props = parsed.batch[0].properties.as_object().unwrap();
-        assert_eq!(
-            props.get("$geoip_disable").unwrap(),
-            &serde_json::json!(true)
-        );
-        assert_eq!(props.get("$is_server").unwrap(), &serde_json::json!(true));
-    }
-
-    #[test]
-    fn build_flag_event_request_compresses_when_configured() {
-        let opts = ClientOptionsBuilder::default()
-            .api_key("phc_test".to_string())
-            .capture_compression(CaptureCompression::Gzip)
-            .build()
-            .unwrap();
-        let (headers, body) = build_flag_event_request(&opts, &flag_called_test_event()).unwrap();
-        assert_eq!(headers.get("content-encoding").unwrap(), "gzip");
-        // gzip magic bytes — the body is actually compressed.
-        assert_eq!(&body[..2], &[0x1f, 0x8b]);
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -307,7 +307,7 @@ impl InnerEvent {
     /// Construct a V0 single-event wire event. Expects that
     /// [`Event::prepare_for_v0`] has already been called so properties are fully
     /// decorated.
-    #[cfg_attr(feature = "capture-v1", allow(dead_code))]
+    #[cfg(test)]
     pub fn new(event: Event, api_key: String) -> Self {
         Self::from_event(event, Some(api_key))
     }
@@ -319,6 +319,7 @@ impl InnerEvent {
         Self::from_event(event, None)
     }
 
+    #[cfg_attr(feature = "capture-v1", allow(dead_code))]
     fn from_event(event: Event, api_key: Option<String>) -> Self {
         Self {
             api_key,

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -4,21 +4,11 @@ use common::default_user_agent;
 use httpmock::prelude::*;
 use serde_json::{json, Value};
 
-#[cfg(feature = "async-client")]
-use std::time::Duration;
-
-/// Where `$feature_flag_called` ships: V1 analytics with `capture-v1`, else v0.
+/// Where the background worker ships analytics captures.
 #[cfg(feature = "capture-v1")]
 const CAPTURE_PATH: &str = "/i/v1/analytics/events";
 #[cfg(not(feature = "capture-v1"))]
-const CAPTURE_PATH: &str = "/i/v0/e/";
-
-/// Where the background worker ships analytics captures on v0: the batch
-/// endpoint (single captures are batched too now). Used only by the v0-gated
-/// `event_with_flags` tests below; `$feature_flag_called` still ships via the
-/// fire-and-forget `/i/v0/e/` host path (`CAPTURE_PATH`).
-#[cfg(not(feature = "capture-v1"))]
-const WORKER_CAPTURE_PATH: &str = "/batch/";
+const CAPTURE_PATH: &str = "/batch/";
 
 /// Feature-aware capture mock; the JSON body is required by V1, ignored by v0.
 fn capture_path_mock(server: &MockServer) -> httpmock::Mock<'_> {
@@ -92,7 +82,9 @@ fn flags_response_fixture() -> Value {
 #[cfg(not(feature = "async-client"))]
 mod blocking {
     use super::*;
-    use posthog_rs::{EvaluateFlagsOptions, Event, FlagValue};
+    #[cfg(not(feature = "capture-v1"))]
+    use posthog_rs::Event;
+    use posthog_rs::{EvaluateFlagsOptions, FlagValue};
     use reqwest::header::USER_AGENT;
 
     fn create_test_client(base_url: String) -> posthog_rs::Client {
@@ -168,6 +160,7 @@ mod blocking {
 
         assert!(snapshot.is_enabled("alpha"));
         assert!(snapshot.is_enabled("alpha"));
+        client.flush();
         assert_eq!(
             snapshot.get_flag("variant-flag"),
             Some(FlagValue::String("test".into()))
@@ -176,6 +169,7 @@ mod blocking {
             snapshot.get_flag("variant-flag"),
             Some(FlagValue::String("test".into()))
         );
+        client.flush();
 
         // Two unique (flag, value) combos => two events; repeats deduped.
         capture_mock.assert_hits(2);
@@ -230,7 +224,9 @@ mod blocking {
             )
             .unwrap();
         assert!(snap_1.is_enabled("alpha"));
+        client.flush();
         assert!(snap_2.is_enabled("alpha"));
+        client.flush();
         capture_mock.assert_hits(expected_hits);
     }
 
@@ -273,6 +269,7 @@ mod blocking {
         assert!(snap.is_enabled("alpha"));
         assert!(snap.is_enabled("alpha"));
         assert!(snap.is_enabled("alpha"));
+        client.flush();
         capture_mock.assert_hits(1);
     }
 
@@ -339,7 +336,7 @@ mod blocking {
             then.status(200).json_body(flags_response_fixture());
         });
         let capture_mock = server.mock(|when, then| {
-            when.method(POST).path(WORKER_CAPTURE_PATH);
+            when.method(POST).path(CAPTURE_PATH);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({ "results": {} }));
@@ -515,32 +512,45 @@ mod blocking {
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
             .unwrap();
         assert!(snapshot.is_enabled("alpha"));
+        client.flush();
         v1_mock.assert_hits(1);
         v0_mock.assert_hits(0);
     }
 
-    /// C5: a failed ship is fire-and-forget — one attempt, no surfaced error.
+    /// C5: `$feature_flag_called` uses the normal V1 capture retry path.
     #[cfg(feature = "capture-v1")]
     #[test]
-    fn flag_called_event_v1_failure_is_single_attempt_and_silent() {
+    fn flag_called_event_v1_failure_is_retried() {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let v1_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v1/analytics/events");
+        let first_attempt = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "1");
             then.status(503)
                 .header("content-type", "application/json")
                 .json_body(json!({ "error": "service_unavailable" }));
+        });
+        let retry_attempt = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "2");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "results": {} }));
         });
         let client = create_test_client(server.base_url());
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
             .unwrap();
-        // The flag read still succeeds; the ship is attempted exactly once.
         assert!(snapshot.is_enabled("alpha"));
-        v1_mock.assert_hits(1);
+        client.flush();
+        client.flush();
+        first_attempt.assert_hits(1);
+        retry_attempt.assert_hits(1);
     }
 
     #[test]
@@ -578,12 +588,6 @@ mod async_tests {
     async fn create_test_client(base_url: String) -> posthog_rs::Client {
         let options: posthog_rs::ClientOptions = ("test_api_key", base_url.as_str()).into();
         posthog_rs::client(options).await
-    }
-
-    /// Wait briefly for any `$feature_flag_called` events that the host
-    /// `tokio::spawn`'d in the background to land at the mock.
-    async fn flush_spawned_events() {
-        tokio::time::sleep(Duration::from_millis(150)).await;
     }
 
     #[tokio::test]
@@ -636,11 +640,16 @@ mod async_tests {
             .unwrap();
         assert!(snapshot.is_enabled("alpha"));
         assert!(snapshot.is_enabled("alpha"));
+        client.flush().await;
         assert_eq!(
             snapshot.get_flag("variant-flag"),
             Some(FlagValue::String("test".into()))
         );
-        flush_spawned_events().await;
+        assert_eq!(
+            snapshot.get_flag("variant-flag"),
+            Some(FlagValue::String("test".into()))
+        );
+        client.flush().await;
         capture_mock.assert_hits(2);
     }
 
@@ -654,7 +663,7 @@ mod async_tests {
         });
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/i/v0/e/")
+                .path(CAPTURE_PATH)
                 .body_contains("\"$is_server\":true")
                 .body_contains("\"$lib\":\"posthog-rs\"");
             then.status(200);
@@ -665,7 +674,7 @@ mod async_tests {
             .await
             .unwrap();
         assert!(snapshot.is_enabled("alpha"));
-        flush_spawned_events().await;
+        client.flush().await;
         capture_mock.assert_hits(1);
     }
 
@@ -686,7 +695,7 @@ mod async_tests {
             snapshot.get_flag_payload("variant-flag"),
             Some(json!({"hello": "world"}))
         );
-        flush_spawned_events().await;
+        client.flush().await;
         capture_mock.assert_hits(0);
     }
 
@@ -722,7 +731,7 @@ mod async_tests {
             .await
             .unwrap();
         assert!(!snapshot.is_enabled("alpha"));
-        flush_spawned_events().await;
+        client.flush().await;
         flags_mock.assert_hits(0);
         capture_mock.assert_hits(0);
     }
@@ -760,35 +769,46 @@ mod async_tests {
             .await
             .unwrap();
         assert!(snapshot.is_enabled("alpha"));
-        flush_spawned_events().await;
+        client.flush().await;
         v1_mock.assert_hits(1);
         v0_mock.assert_hits(0);
     }
 
-    /// C5: a failed ship is fire-and-forget — one attempt, no surfaced error.
+    /// C5: `$feature_flag_called` uses the normal V1 capture retry path.
     #[cfg(feature = "capture-v1")]
     #[tokio::test]
-    async fn flag_called_event_v1_failure_is_single_attempt_and_silent() {
+    async fn flag_called_event_v1_failure_is_retried() {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(POST).path("/flags/");
             then.status(200).json_body(flags_response_fixture());
         });
-        let v1_mock = server.mock(|when, then| {
-            when.method(POST).path("/i/v1/analytics/events");
+        let first_attempt = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "1");
             then.status(503)
                 .header("content-type", "application/json")
                 .json_body(json!({ "error": "service_unavailable" }));
+        });
+        let retry_attempt = server.mock(|when, then| {
+            when.method(POST)
+                .path("/i/v1/analytics/events")
+                .header("posthog-attempt", "2");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "results": {} }));
         });
         let client = create_test_client(server.base_url()).await;
         let snapshot = client
             .evaluate_flags("user-1", EvaluateFlagsOptions::default())
             .await
             .unwrap();
-        // The flag read still succeeds; the ship is attempted exactly once.
         assert!(snapshot.is_enabled("alpha"));
-        flush_spawned_events().await;
-        v1_mock.assert_hits(1);
+        client.flush().await;
+        client.flush().await;
+        first_attempt.assert_hits(1);
+        retry_attempt.assert_hits(1);
     }
 
     #[cfg(not(feature = "capture-v1"))]
@@ -800,7 +820,7 @@ mod async_tests {
             then.status(200).json_body(flags_response_fixture());
         });
         let capture_mock = server.mock(|when, then| {
-            when.method(POST).path(WORKER_CAPTURE_PATH);
+            when.method(POST).path(CAPTURE_PATH);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({ "results": {} }));


### PR DESCRIPTION
## :bulb: Motivation and Context

`$feature_flag_called` events were special-cased in Rust for V1 capture: they bypassed the normal transport, sent immediately, and did not retry. This made their routing/retry semantics differ from normal capture events.

This PR routes feature flag called events through the same capture transport as all other events so they are batched, flushed, and retried consistently.

## :green_heart: How did you test it?

- `cargo test`
- `cargo test --features capture-v1`
- `cargo test --no-default-features --features capture-v1 --test test_evaluate_flags`
- `cargo test --no-default-features --test test_evaluate_flags`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
