### PR TITLE
ci: Configure SDK compliance suite selection

### DIFF
--- a/.github/workflows/sdk-compliance-tests-v0.yml
+++ b/.github/workflows/sdk-compliance-tests-v0.yml
@@ -26,10 +26,13 @@ permissions:
 
 jobs:
   test-rust-sdk-v0:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: compliance/v0/Dockerfile
       adapter-context: .
       test-harness-version: "0.8.0"
       report-name: rust-sdk-compliance-report-v0
       concurrency: 10
+      suite: "capture"
+      sdk-type: "server"
+      continue-on-error: false

--- a/.github/workflows/sdk-compliance-tests-v1.yml
+++ b/.github/workflows/sdk-compliance-tests-v1.yml
@@ -26,10 +26,13 @@ permissions:
 
 jobs:
   test-rust-sdk-v1:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: compliance/v1/Dockerfile
       adapter-context: .
       test-harness-version: "0.8.0"
       report-name: rust-sdk-compliance-report-v1
       concurrency: 10
+      suite: "capture_v1"
+      sdk-type: "server"
+      continue-on-error: false

--- a/compliance/v0/docker-compose.yml
+++ b/compliance/v0/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
   test-harness:
     image: ghcr.io/posthog/sdk-test-harness:0.8.0
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10", "--suite", "capture"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--concurrency", "10", "--suite", "capture"]
     networks:
       - test-network
     depends_on:

--- a/compliance/v1/docker-compose.yml
+++ b/compliance/v1/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
   test-harness:
     image: ghcr.io/posthog/sdk-test-harness:0.8.0
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10", "--suite", "capture_v1"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--concurrency", "10", "--suite", "capture_v1"]
     networks:
       - test-network
     depends_on:


### PR DESCRIPTION
## Problem

SDK compliance workflows need explicit harness suite/sdk-type selection and configurable blocking behavior so CI only runs the intended contract checks.

## Changes

- Point v0 and v1 compliance jobs to the harness branch with new workflow inputs.
- Run v0 with `suite: capture` and v1 with `suite: capture_v1`.
- Keep Rust compliance blocking.
- Align local compose commands with the same suite/sdk types.

## Testing

- Parsed workflow YAML.
- Ran `docker compose config` for v0 and v1 compose files.
- Ran `git diff --check`.

## Release / changeset

No SDK package changeset: CI/local compliance configuration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using dedicated git worktrees. The change was requested to align SDK compliance harness setup across SDK repositories while keeping non-ready SDKs non-blocking.
