### PR TITLE
ci: update SDK harness to 0.9.0

### DIFF
--- a/.github/workflows/sdk-compliance-tests-v0.yml
+++ b/.github/workflows/sdk-compliance-tests-v0.yml
@@ -26,10 +26,10 @@ permissions:
 
 jobs:
   test-rust-sdk-v0:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
     with:
       adapter-dockerfile: compliance/v0/Dockerfile
       adapter-context: .
-      test-harness-version: "0.8.0"
+      test-harness-version: "0.9.0"
       report-name: rust-sdk-compliance-report-v0
       concurrency: 10

--- a/.github/workflows/sdk-compliance-tests-v1.yml
+++ b/.github/workflows/sdk-compliance-tests-v1.yml
@@ -26,10 +26,10 @@ permissions:
 
 jobs:
   test-rust-sdk-v1:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
     with:
       adapter-dockerfile: compliance/v1/Dockerfile
       adapter-context: .
-      test-harness-version: "0.8.0"
+      test-harness-version: "0.9.0"
       report-name: rust-sdk-compliance-report-v1
       concurrency: 10

--- a/compliance/v0/docker-compose.yml
+++ b/compliance/v0/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.8.0
+    image: ghcr.io/posthog/sdk-test-harness:0.9.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10", "--suite", "capture"]
     networks:
       - test-network

--- a/compliance/v1/docker-compose.yml
+++ b/compliance/v1/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.8.0
+    image: ghcr.io/posthog/sdk-test-harness:0.9.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10", "--suite", "capture_v1"]
     networks:
       - test-network


### PR DESCRIPTION
## :bulb: Motivation and Context

Update the Rust SDK compliance setup to use posthog-sdk-test-harness 0.9.0. The reusable workflows are pinned to the 0.9.0 release commit SHA (`68498bcf3ae95ac941476e6ca3d42d6086e1c7fd`) instead of a tag, while the harness Docker images use the published `0.9.0` image tag.

## :green_heart: How did you test it?

- Confirmed the PR branch has no remaining references to the previous harness workflow SHA or `0.8.0` harness image/version.
- Parsed changed GitHub Actions workflow YAML locally.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
