### PR TITLE
Exclude eyre from default in-app frames & add eyre example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1355,12 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -1943,6 +1959,7 @@ dependencies = [
  "ctor",
  "derive_builder",
  "dotenv",
+ "eyre",
  "flate2",
  "futures",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ httpmock = "0.7"
 serde_json = "1.0"
 futures = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+eyre = "0.6.12"
 
 [features]
 default = ["async-client", "error-tracking"]

--- a/examples/error_tracking.rs
+++ b/examples/error_tracking.rs
@@ -27,6 +27,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Personless capture.
     client.capture_exception(&error).await?;
 
+    // Capturing an `eyre::Report`
+    let result: eyre::Result<()> = do_work();
+    if let Err(err) = result {
+        // `eyre::Report` implements `AsRef` for both `dyn Error` and
+        // `dyn Error + Send + Sync`, so annotate which one we want.
+        let source: &dyn std::error::Error = err.as_ref();
+        client.capture_exception(source).await?;
+    }
+
+    Ok(())
+}
+
+/// Dummy for real application logic that fails with an `eyre::Report`.
+#[cfg(all(feature = "async-client", feature = "error-tracking"))]
+fn do_work() -> eyre::Result<()> {
+    use eyre::WrapErr;
+
+    std::fs::read_to_string("/nonexistent/config.toml")
+        .wrap_err("while attempting to load the checkout service config")?;
     Ok(())
 }
 

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -896,13 +896,16 @@ fn default_in_app_function(function: &str) -> bool {
         "alloc"
             | "anyhow"
             | "backtrace"
+            | "color_eyre"
             | "core"
+            | "eyre"
             | "futures_core"
             | "futures_util"
             | "log"
             | "posthog_rs"
             | "reqwest"
             | "std"
+            | "stable_eyre"
             | "tokio"
             | "tracing"
             | "tracing_core"
@@ -1446,6 +1449,8 @@ mod tests {
             "tokio::runtime::task::raw::poll",
             "futures_util::future::FutureExt::poll",
             "anyhow::error::Error::msg",
+            "eyre::Report::msg",
+            "color_eyre::config::EyreHook::into_eyre_hook::{{closure}}",
             "tracing::span::Span::record",
             "tracing_core::dispatcher::get_default",
             "log::__private_api::log",


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`eyre` is a widely used error handling like `anyhow`, that many people prefer to use. 

This PR:
1. Adds `eyre` example to `examples/error_tracking.rs`. This example is relevant to `anyhow` as well 
2. Extends `default_in_app_function` so `eyre`, `color_eyre`, and `stable_eyre` (all under same umbrella). `eyre` frames are excluded from in-app classification, similar to how `anyhow` is already handled. 

PS: the anyhow example at https://posthog.com/docs/error-tracking/installation/rust is broken, which prompted me to dig deeper and write this PR

## :green_heart: How did you test it?

`cargo check` & `cargo test`. I did not run the example with the real posthog key and account

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.