### PR TITLE
fix: stop duplicating distinct_id in flags person properties

### DIFF
--- a/.github/workflows/sdk-compliance-tests-v0.yml
+++ b/.github/workflows/sdk-compliance-tests-v0.yml
@@ -26,10 +26,10 @@ permissions:
 
 jobs:
   test-rust-sdk-v0:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: compliance/v0/Dockerfile
       adapter-context: .
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"
       report-name: rust-sdk-compliance-report-v0
       concurrency: 10

--- a/.github/workflows/sdk-compliance-tests-v1.yml
+++ b/.github/workflows/sdk-compliance-tests-v1.yml
@@ -26,10 +26,10 @@ permissions:
 
 jobs:
   test-rust-sdk-v1:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: compliance/v1/Dockerfile
       adapter-context: .
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"
       report-name: rust-sdk-compliance-report-v1
       concurrency: 10

--- a/.sampo/changesets/roguish-bard-mielikki.md
+++ b/.sampo/changesets/roguish-bard-mielikki.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Stop duplicating distinct_id inside /flags person properties

--- a/compliance/v0/docker-compose.yml
+++ b/compliance/v0/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10", "--suite", "capture"]
     networks:
       - test-network

--- a/compliance/v1/docker-compose.yml
+++ b/compliance/v1/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--concurrency", "10", "--suite", "capture_v1"]
     networks:
       - test-network

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -539,7 +539,18 @@ impl Client {
             let empty_groups: HashMap<String, String> = HashMap::new();
             let empty_group_props: HashMap<String, HashMap<String, serde_json::Value>> =
                 HashMap::new();
-            let props = person_properties.as_ref().unwrap_or(&empty_props);
+            let mut local_props;
+            let props = if let Some(props) = person_properties.as_ref() {
+                local_props = props.clone();
+                local_props
+                    .entry("distinct_id".to_string())
+                    .or_insert_with(|| json!(distinct_id_str.clone()));
+                &local_props
+            } else {
+                local_props = empty_props;
+                local_props.insert("distinct_id".to_string(), json!(distinct_id_str.clone()));
+                &local_props
+            };
             let groups_ref = groups.as_ref().unwrap_or(&empty_groups);
             let group_props_ref = group_properties.as_ref().unwrap_or(&empty_group_props);
             match evaluator.evaluate_flag(

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -772,11 +772,6 @@ impl Client {
         }
 
         let mut options = options;
-        options
-            .person_properties
-            .get_or_insert_with(HashMap::new)
-            .entry("distinct_id".to_string())
-            .or_insert_with(|| json!(distinct_id.clone()));
         options.groups.get_or_insert_with(HashMap::new);
         options.group_properties.get_or_insert_with(HashMap::new);
 
@@ -784,7 +779,10 @@ impl Client {
         let mut locally_evaluated_keys: HashSet<String> = HashSet::new();
 
         if let Some(evaluator) = &self.local_evaluator {
-            let person_props_owned = options.person_properties.clone().unwrap_or_default();
+            let mut person_props_owned = options.person_properties.clone().unwrap_or_default();
+            person_props_owned
+                .entry("distinct_id".to_string())
+                .or_insert_with(|| json!(distinct_id.clone()));
             let groups_owned = options.groups.clone().unwrap_or_default();
             let group_props_owned = options.group_properties.clone().unwrap_or_default();
             let local_results = evaluator.evaluate_all_flags(
@@ -933,10 +931,7 @@ impl Client {
     ) -> Result<DetailedFlagsResponse, Error> {
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 
-        let mut person_properties = options.person_properties.clone().unwrap_or_default();
-        person_properties
-            .entry("distinct_id".to_string())
-            .or_insert_with(|| json!(distinct_id));
+        let person_properties = options.person_properties.clone().unwrap_or_default();
         let groups = options.groups.clone().unwrap_or_default();
         let group_properties = options.group_properties.clone().unwrap_or_default();
         let effective_disable_geoip = options.disable_geoip.unwrap_or(self.options.disable_geoip);

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -765,11 +765,6 @@ impl Client {
         }
 
         let mut options = options;
-        options
-            .person_properties
-            .get_or_insert_with(HashMap::new)
-            .entry("distinct_id".to_string())
-            .or_insert_with(|| json!(distinct_id.clone()));
         options.groups.get_or_insert_with(HashMap::new);
         options.group_properties.get_or_insert_with(HashMap::new);
 
@@ -777,7 +772,10 @@ impl Client {
         let mut locally_evaluated_keys: HashSet<String> = HashSet::new();
 
         if let Some(evaluator) = &self.local_evaluator {
-            let person_props_owned = options.person_properties.clone().unwrap_or_default();
+            let mut person_props_owned = options.person_properties.clone().unwrap_or_default();
+            person_props_owned
+                .entry("distinct_id".to_string())
+                .or_insert_with(|| json!(distinct_id.clone()));
             let groups_owned = options.groups.clone().unwrap_or_default();
             let group_props_owned = options.group_properties.clone().unwrap_or_default();
             let local_results = evaluator.evaluate_all_flags(
@@ -926,10 +924,7 @@ impl Client {
     ) -> Result<DetailedFlagsResponse, Error> {
         let flags_endpoint = self.options.endpoints().build_url(Endpoint::Flags);
 
-        let mut person_properties = options.person_properties.clone().unwrap_or_default();
-        person_properties
-            .entry("distinct_id".to_string())
-            .or_insert_with(|| json!(distinct_id));
+        let person_properties = options.person_properties.clone().unwrap_or_default();
         let groups = options.groups.clone().unwrap_or_default();
         let group_properties = options.group_properties.clone().unwrap_or_default();
         let effective_disable_geoip = options.disable_geoip.unwrap_or(self.options.disable_geoip);

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -537,7 +537,18 @@ impl Client {
             let empty_groups: HashMap<String, String> = HashMap::new();
             let empty_group_props: HashMap<String, HashMap<String, serde_json::Value>> =
                 HashMap::new();
-            let props = person_properties.as_ref().unwrap_or(&empty_props);
+            let mut local_props;
+            let props = if let Some(props) = person_properties.as_ref() {
+                local_props = props.clone();
+                local_props
+                    .entry("distinct_id".to_string())
+                    .or_insert_with(|| json!(distinct_id_str.clone()));
+                &local_props
+            } else {
+                local_props = empty_props;
+                local_props.insert("distinct_id".to_string(), json!(distinct_id_str.clone()));
+                &local_props
+            };
             let groups_ref = groups.as_ref().unwrap_or(&empty_groups);
             let group_props_ref = group_properties.as_ref().unwrap_or(&empty_group_props);
             match evaluator.evaluate_flag(

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -8,11 +8,10 @@ mod common;
 use common::default_user_agent;
 use httpmock::prelude::*;
 #[cfg(feature = "async-client")]
-use posthog_rs::AsyncFlagPoller;
+use posthog_rs::{AsyncFlagPoller, ClientOptionsBuilder};
 use posthog_rs::{
-    ClientOptionsBuilder, FeatureFlag, FeatureFlagCondition, FeatureFlagFilters, FlagCache,
-    FlagPoller, FlagValue, LocalEvaluationConfig, LocalEvaluationResponse, LocalEvaluator,
-    Property,
+    FeatureFlag, FeatureFlagCondition, FeatureFlagFilters, FlagCache, FlagPoller, FlagValue,
+    LocalEvaluationConfig, LocalEvaluationResponse, LocalEvaluator, Property,
 };
 use reqwest::header::USER_AGENT;
 use serde_json::json;
@@ -232,6 +231,72 @@ async fn test_local_evaluation_with_mock_server() {
     assert!(result.unwrap() == Some(FlagValue::Boolean(true)));
 
     eval_mock.assert();
+}
+
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn test_client_adds_distinct_id_for_local_evaluation_only() {
+    let server = MockServer::start();
+
+    let mock_flags = json!({
+        "flags": [
+            {
+                "key": "distinct-id-flag",
+                "active": true,
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": "distinct_id",
+                                    "value": "user-123",
+                                    "operator": "exact"
+                                }
+                            ],
+                            "rollout_percentage": 100.0,
+                            "variant": null
+                        }
+                    ],
+                    "multivariate": null,
+                    "payloads": {}
+                }
+            }
+        ],
+        "group_type_mapping": {},
+        "cohorts": {}
+    });
+
+    let eval_mock = server.mock(|when, then| {
+        when.method(GET).path("/flags/definitions/");
+        then.status(200).json_body(mock_flags);
+    });
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/").query_param("v", "2");
+        then.status(200).json_body(json!({
+            "featureFlags": {"distinct-id-flag": false},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .api_key("test_project_key".to_string())
+        .personal_api_key("test_personal_key".to_string())
+        .enable_local_evaluation(true)
+        .poll_interval_seconds(60)
+        .build()
+        .unwrap();
+
+    let client = posthog_rs::client(options).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let result = client
+        .get_feature_flag("distinct-id-flag", "user-123", None, None, None)
+        .await;
+
+    assert_eq!(result.unwrap(), Some(FlagValue::Boolean(true)));
+    eval_mock.assert();
+    flags_mock.assert_hits(0);
 }
 
 #[cfg(feature = "async-client")]


### PR DESCRIPTION
## :bulb: Motivation and Context
`/flags` requests already send `distinct_id` at the top level. Automatically copying the same value into `person_properties.distinct_id` sends duplicated identity data and differs from the desired payload shape.

This PR keeps the top-level `distinct_id` for remote `/flags` calls while still adding it to the local-evaluation copy where local property matching expects it.

## :green_heart: How did you test it?

- `cargo test --test test_async --test test_evaluate_flags`
- `cargo test --no-default-features --test test_blocking`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This was implemented with pi in dedicated git worktrees. I changed the /flags request construction so SDKs keep the top-level distinct_id while no longer auto-copying it into person_properties; explicit caller-provided person_properties['distinct_id'] values are still preserved where covered.
