### PR TITLE
fix: Retry flags requests on 502 and 504

### DIFF
--- a/.sampo/changesets/gentle-flags-retry.md
+++ b/.sampo/changesets/gentle-flags-retry.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Retry remote feature flag requests after transient 502 and 504 responses.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -958,14 +958,11 @@ impl Client {
                     attempt,
                     response.status().as_u16(),
                 ) {
-                    super::retry::Step::Backoff(delay) => {
+                    super::retry::FeatureFlagsResponseStep::Backoff(delay) => {
                         tokio::time::sleep(delay).await;
                         attempt += 1;
                     }
-                    super::retry::Step::Done => return Ok(response),
-                    super::retry::Step::Fail(_) => {
-                        unreachable!("feature flag response handling cannot fail without a body")
-                    }
+                    super::retry::FeatureFlagsResponseStep::Done => return Ok(response),
                 },
                 Err(e) => {
                     let err_msg = e.to_string();
@@ -975,11 +972,11 @@ impl Client {
                         is_retryable_feature_flags_error(&e),
                         err_msg,
                     ) {
-                        super::retry::Step::Backoff(delay) => {
+                        super::retry::FeatureFlagsTransportStep::Backoff(delay) => {
                             tokio::time::sleep(delay).await;
                             attempt += 1;
                         }
-                        super::retry::Step::Fail(err) => {
+                        super::retry::FeatureFlagsTransportStep::Fail(err) => {
                             report_flags_error(
                                 &self.options.on_error,
                                 flags_endpoint,
@@ -989,9 +986,6 @@ impl Client {
                                 &err,
                             );
                             return Err(err);
-                        }
-                        super::retry::Step::Done => {
-                            unreachable!("feature flag transport errors cannot complete")
                         }
                     }
                 }

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -953,7 +953,20 @@ impl Client {
             let result = request.send().await;
 
             match result {
-                Ok(response) => return Ok(response),
+                Ok(response) => match super::retry::feature_flags_after_response(
+                    &self.options,
+                    attempt,
+                    response.status().as_u16(),
+                ) {
+                    super::retry::Step::Backoff(delay) => {
+                        tokio::time::sleep(delay).await;
+                        attempt += 1;
+                    }
+                    super::retry::Step::Done => return Ok(response),
+                    super::retry::Step::Fail(_) => {
+                        unreachable!("feature flag response handling cannot fail without a body")
+                    }
+                },
                 Err(e) => {
                     let err_msg = e.to_string();
                     match super::retry::feature_flags_after_transport_error(

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -947,7 +947,20 @@ impl Client {
             let result = request.send();
 
             match result {
-                Ok(response) => return Ok(response),
+                Ok(response) => match super::retry::feature_flags_after_response(
+                    &self.options,
+                    attempt,
+                    response.status().as_u16(),
+                ) {
+                    super::retry::Step::Backoff(delay) => {
+                        std::thread::sleep(delay);
+                        attempt += 1;
+                    }
+                    super::retry::Step::Done => return Ok(response),
+                    super::retry::Step::Fail(_) => {
+                        unreachable!("feature flag response handling cannot fail without a body")
+                    }
+                },
                 Err(e) => {
                     let err_msg = e.to_string();
                     match super::retry::feature_flags_after_transport_error(

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -952,14 +952,11 @@ impl Client {
                     attempt,
                     response.status().as_u16(),
                 ) {
-                    super::retry::Step::Backoff(delay) => {
+                    super::retry::FeatureFlagsResponseStep::Backoff(delay) => {
                         std::thread::sleep(delay);
                         attempt += 1;
                     }
-                    super::retry::Step::Done => return Ok(response),
-                    super::retry::Step::Fail(_) => {
-                        unreachable!("feature flag response handling cannot fail without a body")
-                    }
+                    super::retry::FeatureFlagsResponseStep::Done => return Ok(response),
                 },
                 Err(e) => {
                     let err_msg = e.to_string();
@@ -969,11 +966,11 @@ impl Client {
                         is_retryable_feature_flags_error(&e),
                         err_msg,
                     ) {
-                        super::retry::Step::Backoff(delay) => {
+                        super::retry::FeatureFlagsTransportStep::Backoff(delay) => {
                             std::thread::sleep(delay);
                             attempt += 1;
                         }
-                        super::retry::Step::Fail(err) => {
+                        super::retry::FeatureFlagsTransportStep::Fail(err) => {
                             report_flags_error(
                                 &self.options.on_error,
                                 flags_endpoint,
@@ -983,9 +980,6 @@ impl Client {
                                 &err,
                             );
                             return Err(err);
-                        }
-                        super::retry::Step::Done => {
-                            unreachable!("feature flag transport errors cannot complete")
                         }
                     }
                 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -168,8 +168,9 @@ pub struct ClientOptions {
     #[builder(default = "3")]
     feature_flags_request_timeout_seconds: u64,
 
-    /// Maximum number of retries after a transient network error for remote `/flags` requests.
-    /// Defaults to `1`. Set to `0` to disable retries.
+    /// Maximum number of retries after a transient remote `/flags` failure
+    /// (transport error or HTTP 502/504). Defaults to `1`. Set to `0` to
+    /// disable retries.
     #[builder(default = "1")]
     pub(crate) feature_flags_request_max_retries: u32,
 

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -141,6 +141,25 @@ pub(crate) fn v0_after_transport_error(
     Step::Backoff(backoff_duration(opts, attempt, None))
 }
 
+fn is_retryable_feature_flags_status(status: u16) -> bool {
+    matches!(status, 502 | 504)
+}
+
+/// Sans-IO decision for a completed remote `/flags` response. Only 502 and 504
+/// are retried here; other HTTP statuses remain terminal for the caller.
+pub(crate) fn feature_flags_after_response(
+    opts: &ClientOptions,
+    attempt: u32,
+    status: u16,
+) -> Step {
+    if is_retryable_feature_flags_status(status)
+        && attempt <= opts.feature_flags_request_max_retries
+    {
+        return Step::Backoff(backoff_duration(opts, attempt, None));
+    }
+    Step::Done
+}
+
 /// Sans-IO decision for a remote `/flags` transport error. The feature-flags
 /// option counts retries after the initial attempt, so `attempt == 1` is still
 /// allowed when `feature_flags_request_max_retries == 1`.
@@ -399,6 +418,34 @@ mod tests {
             v0_after_transport_error(&opts, 3, "timeout".into()),
             Step::Fail(Error::Connection(_))
         ));
+    }
+
+    #[test]
+    fn feature_flags_http_status_uses_retry_budget_for_502_and_504_only() {
+        let opts = ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .feature_flags_request_max_retries(1u32)
+            .retry_initial_backoff_ms(1u64)
+            .retry_max_backoff_ms(5u64)
+            .build()
+            .unwrap();
+
+        for status in [502, 504] {
+            assert!(matches!(
+                feature_flags_after_response(&opts, 1, status),
+                Step::Backoff(_)
+            ));
+            assert!(matches!(
+                feature_flags_after_response(&opts, 2, status),
+                Step::Done
+            ));
+        }
+        for status in [500, 503, 429] {
+            assert!(matches!(
+                feature_flags_after_response(&opts, 1, status),
+                Step::Done
+            ));
+        }
     }
 
     #[test]

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -18,6 +18,18 @@ pub(crate) enum Step {
     Fail(Error),
 }
 
+#[derive(Debug)]
+pub(crate) enum FeatureFlagsResponseStep {
+    Done,
+    Backoff(Duration),
+}
+
+#[derive(Debug)]
+pub(crate) enum FeatureFlagsTransportStep {
+    Backoff(Duration),
+    Fail(Error),
+}
+
 /// Statuses worth retrying. Everything else (including 429) is terminal so the
 /// caller surfaces it without burning the attempt budget.
 pub(crate) fn is_retryable_status(status: u16) -> bool {
@@ -151,13 +163,13 @@ pub(crate) fn feature_flags_after_response(
     opts: &ClientOptions,
     attempt: u32,
     status: u16,
-) -> Step {
+) -> FeatureFlagsResponseStep {
     if is_retryable_feature_flags_status(status)
         && attempt <= opts.feature_flags_request_max_retries
     {
-        return Step::Backoff(backoff_duration(opts, attempt, None));
+        return FeatureFlagsResponseStep::Backoff(backoff_duration(opts, attempt, None));
     }
-    Step::Done
+    FeatureFlagsResponseStep::Done
 }
 
 /// Sans-IO decision for a remote `/flags` transport error. The feature-flags
@@ -168,11 +180,11 @@ pub(crate) fn feature_flags_after_transport_error(
     attempt: u32,
     retryable: bool,
     err_msg: String,
-) -> Step {
+) -> FeatureFlagsTransportStep {
     if !retryable || attempt > opts.feature_flags_request_max_retries {
-        return Step::Fail(Error::Connection(err_msg));
+        return FeatureFlagsTransportStep::Fail(Error::Connection(err_msg));
     }
-    Step::Backoff(backoff_duration(opts, attempt, None))
+    FeatureFlagsTransportStep::Backoff(backoff_duration(opts, attempt, None))
 }
 
 #[cfg(test)]
@@ -433,17 +445,17 @@ mod tests {
         for status in [502, 504] {
             assert!(matches!(
                 feature_flags_after_response(&opts, 1, status),
-                Step::Backoff(_)
+                FeatureFlagsResponseStep::Backoff(_)
             ));
             assert!(matches!(
                 feature_flags_after_response(&opts, 2, status),
-                Step::Done
+                FeatureFlagsResponseStep::Done
             ));
         }
         for status in [500, 503, 429] {
             assert!(matches!(
                 feature_flags_after_response(&opts, 1, status),
-                Step::Done
+                FeatureFlagsResponseStep::Done
             ));
         }
     }
@@ -460,15 +472,15 @@ mod tests {
 
         assert!(matches!(
             feature_flags_after_transport_error(&opts, 1, true, "reset".into()),
-            Step::Backoff(_)
+            FeatureFlagsTransportStep::Backoff(_)
         ));
         assert!(matches!(
             feature_flags_after_transport_error(&opts, 2, true, "reset".into()),
-            Step::Fail(Error::Connection(_))
+            FeatureFlagsTransportStep::Fail(Error::Connection(_))
         ));
         assert!(matches!(
             feature_flags_after_transport_error(&opts, 1, false, "refused".into()),
-            Step::Fail(Error::Connection(_))
+            FeatureFlagsTransportStep::Fail(Error::Connection(_))
         ));
     }
 }

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -401,6 +401,33 @@ mod blocking {
     }
 
     #[test]
+    fn evaluate_flags_returns_error_after_502_and_504_retry_budget() {
+        for status in [502, 504] {
+            let server = MockServer::start();
+            let flags_mock = server.mock(|when, then| {
+                when.method(POST).path("/flags/");
+                then.status(status).body("transient flags error");
+            });
+            let options = posthog_rs::ClientOptionsBuilder::default()
+                .api_key("test_api_key".to_string())
+                .host(server.base_url())
+                .feature_flags_request_max_retries(1u32)
+                .retry_initial_backoff_ms(1u64)
+                .retry_max_backoff_ms(1u64)
+                .build()
+                .unwrap();
+            let client = posthog_rs::client(options);
+
+            let err = client
+                .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+                .expect_err("retryable status should error after retry budget is exhausted");
+
+            assert!(err.to_string().contains(&status.to_string()));
+            flags_mock.assert_hits(2);
+        }
+    }
+
+    #[test]
     fn evaluate_flags_does_not_retry_500_status() {
         let server = MockServer::start();
         let flags_mock = server.mock(|when, then| {
@@ -988,6 +1015,34 @@ mod async_tests {
 
             assert_eq!(snapshot.get_flag("alpha"), Some(FlagValue::Boolean(true)));
             server.assert_retry_succeeded();
+        }
+    }
+
+    #[tokio::test]
+    async fn evaluate_flags_returns_error_after_502_and_504_retry_budget() {
+        for status in [502, 504] {
+            let server = MockServer::start();
+            let flags_mock = server.mock(|when, then| {
+                when.method(POST).path("/flags/");
+                then.status(status).body("transient flags error");
+            });
+            let options = posthog_rs::ClientOptionsBuilder::default()
+                .api_key("test_api_key".to_string())
+                .host(server.base_url())
+                .feature_flags_request_max_retries(1u32)
+                .retry_initial_backoff_ms(1u64)
+                .retry_max_backoff_ms(1u64)
+                .build()
+                .unwrap();
+            let client = posthog_rs::client(options).await;
+
+            let err = client
+                .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+                .await
+                .expect_err("retryable status should error after retry budget is exhausted");
+
+            assert!(err.to_string().contains(&status.to_string()));
+            flags_mock.assert_hits(2);
         }
     }
 

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -212,6 +212,90 @@ fn start_resetting_flags_server(expected_attempts: usize) -> ResettingFlagsServe
     }
 }
 
+struct StatusThenSuccessFlagsServer {
+    base_url: String,
+    attempts: Arc<AtomicUsize>,
+    saw_flags_path: Arc<AtomicBool>,
+    handle: thread::JoinHandle<()>,
+}
+
+impl StatusThenSuccessFlagsServer {
+    fn assert_retry_succeeded(self) {
+        self.handle.join().expect("status flags server thread");
+        assert_eq!(self.attempts.load(Ordering::SeqCst), 2);
+        assert!(self.saw_flags_path.load(Ordering::SeqCst));
+    }
+}
+
+fn start_status_then_success_flags_server(
+    first_status: u16,
+    success_body: String,
+) -> StatusThenSuccessFlagsServer {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind status flags server");
+    listener
+        .set_nonblocking(true)
+        .expect("set status flags server nonblocking");
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let saw_flags_path = Arc::new(AtomicBool::new(false));
+    let thread_attempts = attempts.clone();
+    let thread_saw_flags_path = saw_flags_path.clone();
+    let handle = thread::spawn(move || {
+        let started = Instant::now();
+        while thread_attempts.load(Ordering::SeqCst) < 2
+            && started.elapsed() < Duration::from_secs(5)
+        {
+            match listener.accept() {
+                Ok((mut stream, _addr)) => {
+                    let attempt = thread_attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                    let _ = stream.set_read_timeout(Some(Duration::from_secs(1)));
+                    let mut request = Vec::new();
+                    let mut buf = [0; 1024];
+                    loop {
+                        match stream.read(&mut buf) {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                request.extend_from_slice(&buf[..n]);
+                                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    if String::from_utf8_lossy(&request).contains("POST /flags/?v=2") {
+                        thread_saw_flags_path.store(true, Ordering::SeqCst);
+                    }
+
+                    let (status, body) = if attempt == 1 {
+                        (first_status, "transient flags error".to_string())
+                    } else {
+                        (200, success_body.clone())
+                    };
+                    let response = format!(
+                        "HTTP/1.1 {status} Status\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    StatusThenSuccessFlagsServer {
+        base_url,
+        attempts,
+        saw_flags_path,
+        handle,
+    }
+}
+
 // ---------- blocking ----------
 
 #[cfg(not(feature = "async-client"))]
@@ -288,6 +372,32 @@ mod blocking {
 
         assert!(matches!(err, posthog_rs::Error::Connection(_)));
         server.assert_attempts(2);
+    }
+
+    #[test]
+    fn evaluate_flags_retries_502_and_504_status_then_succeeds() {
+        for status in [502, 504] {
+            let server = start_status_then_success_flags_server(
+                status,
+                flags_response_fixture().to_string(),
+            );
+            let options = posthog_rs::ClientOptionsBuilder::default()
+                .api_key("test_api_key".to_string())
+                .host(server.base_url.clone())
+                .feature_flags_request_max_retries(1u32)
+                .retry_initial_backoff_ms(1u64)
+                .retry_max_backoff_ms(1u64)
+                .build()
+                .unwrap();
+            let client = posthog_rs::client(options);
+
+            let snapshot = client
+                .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+                .expect("evaluate_flags should retry retryable status");
+
+            assert_eq!(snapshot.get_flag("alpha"), Some(FlagValue::Boolean(true)));
+            server.assert_retry_succeeded();
+        }
     }
 
     #[test]
@@ -852,6 +962,33 @@ mod async_tests {
 
         assert!(matches!(err, posthog_rs::Error::Connection(_)));
         server.assert_attempts(2);
+    }
+
+    #[tokio::test]
+    async fn evaluate_flags_retries_502_and_504_status_then_succeeds() {
+        for status in [502, 504] {
+            let server = start_status_then_success_flags_server(
+                status,
+                flags_response_fixture().to_string(),
+            );
+            let options = posthog_rs::ClientOptionsBuilder::default()
+                .api_key("test_api_key".to_string())
+                .host(server.base_url.clone())
+                .feature_flags_request_max_retries(1u32)
+                .retry_initial_backoff_ms(1u64)
+                .retry_max_backoff_ms(1u64)
+                .build()
+                .unwrap();
+            let client = posthog_rs::client(options).await;
+
+            let snapshot = client
+                .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+                .await
+                .expect("evaluate_flags should retry retryable status");
+
+            assert_eq!(snapshot.get_flag("alpha"), Some(FlagValue::Boolean(true)));
+            server.assert_retry_succeeded();
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## :bulb: Motivation and Context
Remote `/flags` requests already retried transient transport errors using `feature_flags_request_max_retries`, but returned immediately on HTTP responses. The SDK test harness now expects `/flags` to retry HTTP 502 and 504 once and then return the successful flag response.

This change scopes status retries to remote `/flags` requests only, and only for 502/504. Capture retry behavior is unchanged, and 500 remains terminal for `/flags`.

## :green_heart: How did you test it?
- `cargo test feature_flags_http_status_uses_retry_budget_for_502_and_504_only`
- `cargo test --test test_evaluate_flags evaluate_flags_retries_502_and_504_status_then_succeeds`
- `cargo test --test test_evaluate_flags evaluate_flags_does_not_retry_500_status`
- `cargo test --no-default-features --test test_evaluate_flags evaluate_flags_retries_502_and_504_status_then_succeeds`
- `cargo test --no-default-features --test test_evaluate_flags evaluate_flags_does_not_retry_500_status`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
