### PR TITLE
fix: send error tracking stack frames in canonical wire order

### DIFF
--- a/.sampo/changesets/canonical-frame-order.md
+++ b/.sampo/changesets/canonical-frame-order.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Error tracking stack frames now ship in canonical wire order — `$exception_list[].stacktrace.frames` is bottom-up, so `frames[0]` is the outermost frame (the entry point, e.g. `main`) and the last frame is the crash/capture site. This matches the other PostHog SDKs and the server-side native symbolication contract, which assumes bottom-up input. The whole flattened stack is globally bottom-up, including client-side inline expansion: within a single physical frame the outermost logical layer comes first and the inlined leaf comes last. Frame trimming now drops the outermost frames from the front and keeps the ones nearest the crash site. This is a breaking change to the wire order; `$exception_list` ordering itself is unchanged (`[0]` is still the outermost error with the `exception_id`/`parent_id` links).

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -941,7 +941,11 @@ fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<St
             // We resolved symbols locally but there's no uploadable debug image,
             // so the server can't symbolicate this address. Keep the client-side
             // inline expansion (one frame per layer, no native addresses) — it's
-            // the only way these inlined calls survive.
+            // the only way these inlined calls survive. Layers are pushed
+            // innermost-first here; the reverse in `capture_raw_frames` /
+            // `capture_raw_panic_frames` later flips them so the outermost
+            // logical layer leads and the inlined leaf is last, matching the
+            // canonical bottom-up wire order.
             for (filename, line_no, function) in layers {
                 frames.push(StackFrame {
                     filename,
@@ -972,21 +976,54 @@ fn capture_frames_current_first(skip: usize, modules: &[LoadedModule]) -> Vec<St
     frames
 }
 
+// Frames are in canonical wire order (outermost first, crash-site frame last),
+// so trimming drops the outermost frames from the front and keeps the ones
+// nearest the crash site.
 fn trim_to_max_frames(frames: &mut Vec<StackFrame>, max_frames: usize) {
     if frames.len() > max_frames {
-        frames.truncate(max_frames);
+        frames.drain(..frames.len() - max_frames);
     }
 }
 
-/// Capture the current raw stacktrace, dropping the leading SDK frames so the
-/// caller's frame comes first, and return the loaded modules those frames point
-/// into for the `$debug_images` property.
+/// Drop the innermost (front, current-first) SDK prefix by matching each frame's
+/// symbol entry address against `pinned_entries` (the SDK capture functions).
+/// This works even in stripped builds where there are no names to match. The SDK
+/// frames sit at the front, so dropping through the last match removes the whole
+/// prefix, including the unwinder frames before our innermost one.
 ///
-/// Frames are current-first, so the SDK's own frames lead. Two passes drop
-/// them: an address-based pass that matches each frame's symbol entry against
-/// `pinned_entries` (the SDK capture functions), which works even in stripped
-/// builds where there are no names; then the name-based `is_internal` pass for
-/// everything the resolver could name.
+/// Platform caveat: this only works where the frame's symbol address is the
+/// runtime function entry (Linux/glibc via `_Unwind_FindEnclosingFunction`). On
+/// macOS the symbolization backend reports the queried address rather than the
+/// function entry, so the address pass never matches there and the caller's
+/// name-based pass does the stripping instead; fully stripped Apple/Windows
+/// builds keep the SDK prefix as address-only frames, which regain names through
+/// server-side symbolication.
+fn strip_pinned_prefix(frames: &mut Vec<StackFrame>, pinned_entries: &[u64]) {
+    let scan = frames.len().min(16);
+    let matches_pinned = |frame: &StackFrame| {
+        frame
+            .symbol_addr
+            .as_deref()
+            .and_then(|addr| u64::from_str_radix(addr.trim_start_matches("0x"), 16).ok())
+            .is_some_and(|addr| pinned_entries.contains(&addr))
+    };
+    if let Some(last_sdk) = frames[..scan].iter().rposition(matches_pinned) {
+        frames.drain(..=last_sdk);
+    }
+}
+
+/// Capture the current raw stacktrace, dropping the leading SDK frames, and
+/// return the loaded modules those frames point into for the `$debug_images`
+/// property. The result is in canonical wire order — outermost frame first,
+/// crash/capture-site frame last — matching the other PostHog SDKs.
+///
+/// `capture_frames_current_first` yields innermost-first, so the SDK's own
+/// frames lead. Two passes drop them: an address-based pass that matches each
+/// frame's symbol entry against `pinned_entries` (the SDK capture functions),
+/// which works even in stripped builds where there are no names; then the
+/// name-based `is_internal` pass for everything the resolver could name. Only
+/// after stripping do we reverse into wire order (see the trailing `reverse`),
+/// so both passes keep operating on the front of the innermost-first vec.
 ///
 /// inline(never): this generic function sits between the pinned non-generic
 /// wrapper and `capture_frames_current_first`; keeping it a physical frame lets
@@ -1001,30 +1038,9 @@ fn capture_raw_frames(
     let modules = collect_loaded_modules();
     let mut frames = capture_frames_current_first(0, &modules);
 
-    // Address-based stripping first: identify the SDK's own capture frames by
-    // function entry address, which works even in stripped builds where the
-    // name-based check below has nothing to match. The SDK frames sit at the
-    // front (current-first), so dropping through the last match removes the
-    // whole prefix, including the unwinder frames before our innermost one.
-    //
-    // Platform caveat: this only works where the frame's symbol address is the
-    // runtime function entry (Linux/glibc via `_Unwind_FindEnclosingFunction`).
-    // On macOS the symbolization backend reports the queried address rather
-    // than the function entry, so the address pass never matches there and the
-    // name-based pass below does the stripping instead; fully stripped
-    // Apple/Windows builds keep the SDK prefix as address-only frames, which
-    // regain names through server-side symbolication.
-    let scan = frames.len().min(16);
-    let matches_pinned = |frame: &StackFrame| {
-        frame
-            .symbol_addr
-            .as_deref()
-            .and_then(|addr| u64::from_str_radix(addr.trim_start_matches("0x"), 16).ok())
-            .is_some_and(|addr| pinned_entries.contains(&addr))
-    };
-    if let Some(last_sdk) = frames[..scan].iter().rposition(matches_pinned) {
-        frames.drain(..=last_sdk);
-    }
+    // Address-based stripping first (see `strip_pinned_prefix`): works even in
+    // stripped builds where the name-based pass below has nothing to match.
+    strip_pinned_prefix(&mut frames, pinned_entries);
 
     while frames
         .first()
@@ -1033,6 +1049,16 @@ fn capture_raw_frames(
     {
         frames.remove(0);
     }
+
+    // Flip innermost-first into canonical wire order: outermost frame first,
+    // crash-site frame last. A single reverse of the flattened vec is correct
+    // because `capture_frames_current_first` pushes both the physical frames
+    // and each frame's inline layers innermost-first, so one reverse flips both
+    // levels at once — the outermost physical frame leads, and within a
+    // client-expanded frame the outermost logical layer leads with the inlined
+    // leaf last, exactly the bottom-up input the server-side native contract
+    // expects.
+    frames.reverse();
 
     let images = referenced_images(modules, &frames);
     (frames, images)
@@ -1068,19 +1094,87 @@ fn capture_raw_application_frames() -> (Vec<StackFrame>, Vec<DebugImage>) {
     capture_raw_frames(is_internal_capture_frame, &pinned)
 }
 
+// inline(never): anchors the address-based capture-helper strip below, exactly
+// like `capture_raw_application_frames` does for the manual path.
+#[inline(never)]
 fn capture_raw_panic_frames() -> (Vec<StackFrame>, Vec<DebugImage>) {
-    // Unlike the manual-capture path, keep *every* frame — including the panic
-    // and capture machinery — and let in-app classification mark the SDK/runtime
-    // frames as `in_app = false`. Dropping by function name was brittle (the list
-    // drifted as internals were renamed/inlined) and threw away data the UI can
-    // collapse on its own via the in-app flag. We still collect the debug images
-    // the kept frames point into so the server can symbolicate them.
+    // We deliberately keep the panic and unwind *runtime* machinery
+    // (`panic_with_hook`, `begin_panic_handler`, `rust_begin_unwind`, ...) — it is
+    // classified out-of-app and the UI collapses it, which is more robust than
+    // dropping runtime internals by an ever-drifting name list. Everything
+    // *innermost of* the panic dispatcher is the SDK's own hook plumbing: the
+    // dispatcher (`rust_panic_with_hook`) synchronously invoked our hook, so our
+    // capture helpers, the `install_hook` closures, and the `catch_unwind` guard
+    // they run under all sit below it. Under the canonical crash-last wire order
+    // the innermost frame becomes the tail, which must be the crash-side runtime
+    // frame — not our hook plumbing — so we strip that inner prefix in three
+    // layers of decreasing robustness:
+    //
+    //   1. Address-based: drop our own `backtrace`/capture-helper frames by
+    //      pinned symbol entry. Works even in stripped builds with no names,
+    //      matching the manual path's first pass.
+    //   2. Dispatcher anchor: if the panic dispatcher is visible by name, drop
+    //      everything up to (but not including) it — a single stable anchor that
+    //      sweeps the whole hook-wrapper chain (closures + `catch_unwind` guard)
+    //      without enumerating its drifting frames.
+    //   3. Name fallback: if the dispatcher isn't nameable, drop the SDK capture
+    //      helpers by name.
+    //
+    // In a fully stripped build only (1) runs; the nameless hook-wrapper frames
+    // then survive as address-only frames that regain names (and normalization)
+    // through server-side symbolication, the same documented limitation the
+    // manual path carries.
     let modules = collect_loaded_modules();
-    let frames = capture_frames_current_first(0, &modules);
+    let mut frames = capture_frames_current_first(0, &modules);
+
+    let pinned = [
+        capture_frames_current_first as *const () as u64,
+        capture_raw_panic_frames as *const () as u64,
+    ];
+    strip_pinned_prefix(&mut frames, &pinned);
+
+    let scan = frames.len().min(24);
+    let dispatcher = frames[..scan]
+        .iter()
+        .position(|frame| is_panic_dispatcher_frame(&frame.function));
+    match dispatcher {
+        Some(index) => {
+            frames.drain(..index);
+        }
+        None => {
+            while frames
+                .first()
+                .map(|frame| is_internal_capture_frame(&frame.function))
+                .unwrap_or(false)
+            {
+                frames.remove(0);
+            }
+        }
+    }
+
+    // Flip innermost-first into canonical wire order: outermost frame first,
+    // panic site last (see `capture_raw_frames` for why one reverse suffices).
+    frames.reverse();
     let images = referenced_images(modules, &frames);
     (frames, images)
 }
 
+// The std panic dispatcher that synchronously invokes the installed hook. Its
+// name has been stable across recent toolchains; everything innermost of it on a
+// panicking thread is our own hook plumbing.
+fn is_panic_dispatcher_frame(function: &str) -> bool {
+    function.contains("rust_panic_with_hook") || function.contains("panicking::panic_with_hook")
+}
+
+// Matches the SDK's own capture-plumbing frames — the ones our capture helpers
+// push onto the innermost end simply by calling `backtrace` from inside
+// themselves. These are always noise and are stripped from the innermost prefix
+// so the canonical tail after the wire-order reverse is the crash site rather
+// than an SDK helper. Only SDK-owned names appear here (stable, we control
+// them); panic/unwind *runtime* frames (`begin_panic_handler`,
+// `rust_begin_unwind`, `panic_with_hook`, ...) are deliberately NOT matched —
+// the strip loop stops at them and they survive, classified out-of-app for the
+// UI to collapse.
 fn is_internal_capture_frame(function: &str) -> bool {
     function.starts_with("backtrace::")
         || function.contains("capture_frames_current_first")
@@ -1906,25 +2000,27 @@ mod tests {
         let frames = exception_list[0]["stacktrace"]["frames"]
             .as_array()
             .expect("expected stack frames");
-        let top_frame = frames.first().expect("expected top frame");
-        assert_eq!(top_frame["platform"], "native");
-        assert_eq!(top_frame["lang"], "rust");
-        let instruction_addr = top_frame["instruction_addr"].as_str().unwrap_or_default();
+        // Canonical wire order is outermost first, so the crash/capture-site
+        // user frame is the last frame.
+        let crash_frame = frames.last().expect("expected crash frame");
+        assert_eq!(crash_frame["platform"], "native");
+        assert_eq!(crash_frame["lang"], "rust");
+        let instruction_addr = crash_frame["instruction_addr"].as_str().unwrap_or_default();
         assert!(
             instruction_addr.starts_with("0x"),
             "expected hex instruction_addr, got {:?}",
             instruction_addr
         );
-        let top_function = top_frame["function"].as_str().unwrap_or_default();
+        let crash_function = crash_frame["function"].as_str().unwrap_or_default();
         assert!(
-            top_function.contains("from_error_builds_exception_list_with_stacktrace"),
-            "expected user frame first, got {:?}",
-            top_function
+            crash_function.contains("from_error_builds_exception_list_with_stacktrace"),
+            "expected user frame last, got {:?}",
+            crash_function
         );
         assert!(
-            !top_function.contains("Exception::"),
+            !crash_function.contains("Exception::"),
             "expected SDK frames to be skipped, got {:?}",
-            top_function
+            crash_function
         );
     }
 
@@ -2192,7 +2288,7 @@ mod tests {
     }
 
     #[test]
-    fn frames_are_trimmed_to_max_frames_keeping_the_top() {
+    fn frames_are_trimmed_to_max_frames_keeping_the_crash_site() {
         let synthetic_frame = |index: usize| StackFrame {
             filename: None,
             line_no: None,
@@ -2224,16 +2320,23 @@ mod tests {
             .as_array()
             .expect("expected stack frames");
         assert_eq!(frames.len(), MAX_FRAMES);
-        // Trimming drops the outermost tail; the crash-site top frame survives.
-        assert_eq!(frames[0]["function"], "frame_0");
+        // Frames arrive in wire order (outermost first, crash site last), so
+        // trimming drops the outermost frames from the front and keeps the
+        // crash-site tail: `frame_0` is gone and the last frame survives.
+        assert_eq!(frames[0]["function"], "frame_5");
+        assert_eq!(
+            frames[MAX_FRAMES - 1]["function"],
+            format!("frame_{}", MAX_FRAMES + 4)
+        );
     }
 
     #[test]
-    fn stacktrace_keeps_top_frame_first() {
+    fn stacktrace_keeps_crash_frame_last() {
         fn capture() -> ExceptionStacktrace {
-            // Empty module slice: this test only asserts frame ordering and
-            // names, which are independent of the loaded-module lookup.
-            let mut frames = capture_frames_current_first(0, &[]);
+            // Go through the real capture path so we assert the wire order the
+            // SDK actually emits (outermost first, crash/capture site last),
+            // not the raw innermost-first order of `capture_frames_current_first`.
+            let mut frames = capture_raw_application_frames().0;
             trim_to_max_frames(&mut frames, 8);
             ExceptionStacktrace::raw(frames)
         }
@@ -2247,16 +2350,16 @@ mod tests {
 
         let capture_index = functions
             .iter()
-            .position(|function| function.contains("stacktrace_keeps_top_frame_first::capture"))
+            .position(|function| function.contains("stacktrace_keeps_crash_frame_last::capture"))
             .expect("expected capture frame");
         let test_index = functions
             .iter()
-            .position(|function| function.ends_with("stacktrace_keeps_top_frame_first"))
+            .position(|function| function.ends_with("stacktrace_keeps_crash_frame_last"))
             .expect("expected test frame");
 
         assert!(
-            capture_index < test_index,
-            "expected top frame before caller, got {:?}",
+            test_index < capture_index,
+            "expected the caller before the innermost (capture-site) frame, got {:?}",
             functions
         );
     }
@@ -2329,13 +2432,15 @@ mod tests {
                 functions
             );
         } else {
-            // Not resolvable: client-side expansion preserves the inline chain,
-            // innermost first.
+            // Not resolvable: client-side expansion preserves the inline chain.
+            // In canonical wire order the outermost logical layer leads and the
+            // inlined leaf is last, so `inline_mid` (the caller) precedes
+            // `inline_leaf` (the inlined callee).
             let leaf_index = functions.iter().position(|f| f.contains("inline_leaf"));
             let mid_index = functions.iter().position(|f| f.contains("inline_mid"));
             assert!(
-                matches!((leaf_index, mid_index), (Some(l), Some(m)) if l < m),
-                "expected client-side inline expansion innermost first, got {:?}",
+                matches!((leaf_index, mid_index), (Some(l), Some(m)) if m < l),
+                "expected client-side inline expansion outermost first, got {:?}",
                 functions
             );
         }

--- a/tests/test_error_tracking.rs
+++ b/tests/test_error_tracking.rs
@@ -32,32 +32,34 @@ impl fmt::Display for PanicDisplayError {
 
 impl StdError for PanicDisplayError {}
 
-fn request_has_capture_exception_user_frame_first(req: &HttpMockRequest) -> bool {
+fn request_has_capture_exception_user_frame_last(req: &HttpMockRequest) -> bool {
     let Some(body) = req.body.as_deref() else {
         return false;
     };
     let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
         return false;
     };
-    let first_function = first_exception_stack_function(&body);
+    // Canonical wire order is outermost first, so the capture-site user frame
+    // is the last frame.
+    let crash_function = last_exception_stack_function(&body);
 
-    first_function.contains("capture_exception_sends_exception_event")
-        && !first_function.contains("Client::capture_exception")
-        && !first_function.contains("build_exception_event")
+    crash_function.contains("capture_exception_sends_exception_event")
+        && !crash_function.contains("Client::capture_exception")
+        && !crash_function.contains("build_exception_event")
 }
 
-fn request_has_capture_exception_with_user_frame_first(req: &HttpMockRequest) -> bool {
+fn request_has_capture_exception_with_user_frame_last(req: &HttpMockRequest) -> bool {
     let Some(body) = req.body.as_deref() else {
         return false;
     };
     let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
         return false;
     };
-    let first_function = first_exception_stack_function(&body);
+    let crash_function = last_exception_stack_function(&body);
 
-    first_function.contains("capture_exception_with_attaches_identity_and_context")
-        && !first_function.contains("Client::capture_exception")
-        && !first_function.contains("build_exception_event")
+    crash_function.contains("capture_exception_with_attaches_identity_and_context")
+        && !crash_function.contains("Client::capture_exception")
+        && !crash_function.contains("build_exception_event")
 }
 
 fn request_has_no_stacktrace(req: &HttpMockRequest) -> bool {
@@ -75,10 +77,10 @@ fn request_has_no_stacktrace(req: &HttpMockRequest) -> bool {
             .is_none()
 }
 
-fn first_exception_stack_function(body: &serde_json::Value) -> &str {
+fn last_exception_stack_function(body: &serde_json::Value) -> &str {
     body.pointer("/batch/0/properties/$exception_list/0/stacktrace/frames")
         .and_then(|value| value.as_array())
-        .and_then(|frames| frames.first())
+        .and_then(|frames| frames.last())
         .and_then(|frame| frame.get("function"))
         .and_then(|value| value.as_str())
         .unwrap_or_default()
@@ -106,7 +108,7 @@ mod blocking {
                 .body_contains(r#""value":"payment failed""#)
                 .body_contains(r#""platform":"native""#)
                 .body_contains(r#""lang":"rust""#)
-                .matches(request_has_capture_exception_user_frame_first);
+                .matches(request_has_capture_exception_user_frame_last);
             then.status(200);
         });
 
@@ -129,7 +131,7 @@ mod blocking {
                 .body_contains(r#""$groups":{"company":"company-1"}"#)
                 .body_contains(r#""$exception_fingerprint":"checkout-error""#)
                 .body_contains(r#""$exception_level":"warning""#)
-                .matches(request_has_capture_exception_with_user_frame_first);
+                .matches(request_has_capture_exception_with_user_frame_last);
             then.status(200);
         });
 
@@ -224,7 +226,7 @@ mod async_client {
                 .body_contains(r#""value":"payment failed""#)
                 .body_contains(r#""platform":"native""#)
                 .body_contains(r#""lang":"rust""#)
-                .matches(request_has_capture_exception_user_frame_first);
+                .matches(request_has_capture_exception_user_frame_last);
             then.status(200);
         });
 
@@ -247,7 +249,7 @@ mod async_client {
                 .body_contains(r#""$groups":{"company":"company-1"}"#)
                 .body_contains(r#""$exception_fingerprint":"checkout-error""#)
                 .body_contains(r#""$exception_level":"warning""#)
-                .matches(request_has_capture_exception_with_user_frame_first);
+                .matches(request_has_capture_exception_with_user_frame_last);
             then.status(200);
         });
 

--- a/tests/test_error_tracking_v1.rs
+++ b/tests/test_error_tracking_v1.rs
@@ -37,41 +37,43 @@ fn v1_ok_response() -> serde_json::Value {
     json!({ "results": {} })
 }
 
-fn first_exception_stack_function(body: &serde_json::Value) -> &str {
+fn last_exception_stack_function(body: &serde_json::Value) -> &str {
     body.pointer("/batch/0/properties/$exception_list/0/stacktrace/frames")
         .and_then(|value| value.as_array())
-        .and_then(|frames| frames.first())
+        .and_then(|frames| frames.last())
         .and_then(|frame| frame.get("function"))
         .and_then(|value| value.as_str())
         .unwrap_or_default()
 }
 
-fn request_has_capture_exception_user_frame_first(req: &HttpMockRequest) -> bool {
+fn request_has_capture_exception_user_frame_last(req: &HttpMockRequest) -> bool {
     let Some(body) = req.body.as_deref() else {
         return false;
     };
     let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
         return false;
     };
-    let first_function = first_exception_stack_function(&body);
+    // Canonical wire order is outermost first, so the capture-site user frame
+    // is the last frame.
+    let crash_function = last_exception_stack_function(&body);
 
-    first_function.contains("capture_exception_sends_exception_event")
-        && !first_function.contains("Client::capture_exception")
-        && !first_function.contains("build_exception_event")
+    crash_function.contains("capture_exception_sends_exception_event")
+        && !crash_function.contains("Client::capture_exception")
+        && !crash_function.contains("build_exception_event")
 }
 
-fn request_has_capture_exception_with_user_frame_first(req: &HttpMockRequest) -> bool {
+fn request_has_capture_exception_with_user_frame_last(req: &HttpMockRequest) -> bool {
     let Some(body) = req.body.as_deref() else {
         return false;
     };
     let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
         return false;
     };
-    let first_function = first_exception_stack_function(&body);
+    let crash_function = last_exception_stack_function(&body);
 
-    first_function.contains("capture_exception_with_attaches_identity_and_context")
-        && !first_function.contains("Client::capture_exception")
-        && !first_function.contains("build_exception_event")
+    crash_function.contains("capture_exception_with_attaches_identity_and_context")
+        && !crash_function.contains("Client::capture_exception")
+        && !crash_function.contains("build_exception_event")
 }
 
 #[cfg(not(feature = "async-client"))]
@@ -100,7 +102,7 @@ mod blocking {
                 .body_contains(r#""$exception_level":"error""#)
                 .body_contains(r#""value":"payment failed""#)
                 .body_contains(r#""platform":"native""#)
-                .matches(request_has_capture_exception_user_frame_first);
+                .matches(request_has_capture_exception_user_frame_last);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(v1_ok_response());
@@ -125,7 +127,7 @@ mod blocking {
                 .body_contains(r#""$groups":{"company":"company-1"}"#)
                 .body_contains(r#""$exception_fingerprint":"checkout-error""#)
                 .body_contains(r#""$exception_level":"warning""#)
-                .matches(request_has_capture_exception_with_user_frame_first);
+                .matches(request_has_capture_exception_with_user_frame_last);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(v1_ok_response());
@@ -195,7 +197,7 @@ mod async_client {
                 .body_contains(r#""$exception_level":"error""#)
                 .body_contains(r#""value":"payment failed""#)
                 .body_contains(r#""platform":"native""#)
-                .matches(request_has_capture_exception_user_frame_first);
+                .matches(request_has_capture_exception_user_frame_last);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(v1_ok_response());
@@ -220,7 +222,7 @@ mod async_client {
                 .body_contains(r#""$groups":{"company":"company-1"}"#)
                 .body_contains(r#""$exception_fingerprint":"checkout-error""#)
                 .body_contains(r#""$exception_level":"warning""#)
-                .matches(request_has_capture_exception_with_user_frame_first);
+                .matches(request_has_capture_exception_with_user_frame_last);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(v1_ok_response());

--- a/tests/test_panic_global.rs
+++ b/tests/test_panic_global.rs
@@ -24,7 +24,9 @@ fn integration_panic_site() {
 
 /// True when the request body carries a personless panic `$exception` event in
 /// the transport's batch envelope (same shape for the V0 and V1 wire formats),
-/// and the user's panic-site frame is kept and marked `in_app = true`.
+/// the user's panic-site frame is kept and marked `in_app = true`, and the
+/// frames obey the canonical wire order (outermost first, crash site last) with
+/// the SDK's own capture plumbing stripped from the crash-site tail.
 fn is_panic_exception(req: &HttpMockRequest) -> bool {
     let Some(body) = req.body.as_deref() else {
         return false;
@@ -37,18 +39,49 @@ fn is_panic_exception(req: &HttpMockRequest) -> bool {
             .pointer("/batch/0/properties/$exception_list/0/type")
             .and_then(|v| v.as_str())
             == Some("Panic");
-    let panic_site_in_app = body
+    let Some(frames) = body
         .pointer("/batch/0/properties/$exception_list/0/stacktrace/frames")
         .and_then(|v| v.as_array())
-        .is_some_and(|frames| {
-            frames.iter().any(|frame| {
-                frame["function"]
-                    .as_str()
-                    .is_some_and(|name| name.contains("integration_panic_site"))
-                    && frame["in_app"] == true
-            })
-        });
-    is_panic && panic_site_in_app
+    else {
+        return false;
+    };
+    let function_names: Vec<&str> = frames
+        .iter()
+        .map(|frame| frame["function"].as_str().unwrap_or_default())
+        .collect();
+    let panic_site_in_app = frames.iter().any(|frame| {
+        frame["function"]
+            .as_str()
+            .is_some_and(|name| name.contains("integration_panic_site"))
+            && frame["in_app"] == true
+    });
+    // Canonical wire order puts the crash site last. The panic hook fires nested
+    // inside the panic runtime, so a naive reverse would leave the SDK's own hook
+    // plumbing (`posthog_rs::error_tracking::*`) as the tail. We strip everything
+    // innermost of the panic dispatcher, so no posthog_rs frame survives at all,
+    // and the tail is the crash-side panic runtime rather than an SDK frame.
+    let no_sdk_frames = !function_names
+        .iter()
+        .any(|name| name.contains("posthog_rs::error_tracking"));
+    let tail_is_panic_runtime = function_names
+        .last()
+        .is_some_and(|name| name.contains("panicking::") || name.contains("panic_with_hook"));
+    // The user's panic site must come *before* (outermore than) the crash-side
+    // panic runtime that follows it — i.e. it is not left innermost/first.
+    let panic_site_before_runtime = function_names
+        .iter()
+        .position(|name| name.contains("integration_panic_site"))
+        .zip(
+            function_names
+                .iter()
+                .rposition(|name| name.contains("panic_with_hook")),
+        )
+        .is_some_and(|(site, runtime)| site < runtime);
+    is_panic
+        && panic_site_in_app
+        && no_sdk_frames
+        && tail_is_panic_runtime
+        && panic_site_before_runtime
 }
 
 #[cfg(feature = "async-client")]


### PR DESCRIPTION
## Problem

Error tracking stack frames were emitted crash-first (`frames[0]` = crash site, outermost/entry point last). Every canonical PostHog SDK and the server-side native symbolication pipeline assume the opposite — bottom-up frames — so Rust native stacks arrived in the wrong order. This is part of the cross-SDK ordering standardization tracked in https://github.com/PostHog/sdk-specs/pull/11.

## Change

Flip `$exception_list[].stacktrace.frames` to canonical wire order:

- `frames[0]` = outermost frame (entry point, e.g. `main`), **last** frame = crash / capture site.
- Frame trimming now drops the **outermost** frames from the front and keeps the crash-site tail.
- **Inline-layer invariant (called out explicitly):** this SDK expands inlined logical frames client-side when the server cannot symbolicate the address. The whole flattened stack must be globally bottom-up *including* those inline layers — within one physical frame the outermost logical layer comes first and the inlined leaf comes last. A single `reverse()` of the innermost-first vec achieves this: the capture path pushes both the physical frames and each frame's inline layers innermost-first, so one reverse flips both levels at once. Reversing only the flattened vec is correct here precisely because it also inverts intra-frame layer order.
- **Panic path:** panic/unwind runtime machinery is still kept (classified out-of-app for the UI to collapse), but the SDK's own hook plumbing must not become the canonical tail. The panic hook fires nested inside the panic runtime, so its capture helpers, `install_hook` closures, and `catch_unwind` guard are innermost. They are stripped before the reverse via a pinned-address pass (stripped-build safe), a panic-dispatcher anchor (`rust_panic_with_hook`) that sweeps the whole hook-wrapper chain, and an SDK-capture-helper name fallback — so the tail is the crash-side panic runtime frame, not an SDK frame.

`$exception_list` ordering is unchanged (`[0]` is still the outermost error carrying the `exception_id` / `parent_id` links — already canonical).

No public API change (the diff touches only private functions, comments, and tests; the `api/public-api.txt` snapshot is unaffected).

## Tests

- Inverted / renamed the frame-order unit tests: crash site is now the last frame (`from_error_builds_exception_list_with_stacktrace`, `stacktrace_keeps_crash_frame_last`), trimming keeps the crash-site tail (`frames_are_trimmed_to_max_frames_keeping_the_crash_site`), and the client-side inline-expansion test asserts outermost-first (`inlined_frames_collapse_for_server_side_expansion`).
- Flipped the v0 and v1 integration assertions (`test_error_tracking.rs`, `test_error_tracking_v1.rs`) to expect the user capture-site frame last.
- Strengthened the end-to-end panic test (`test_panic_global.rs`) to assert canonical order: crash site last, no SDK plumbing frames survive, and the tail is the panic runtime.
- Full suite green across default, `capture-v1`, and `e2e-test --no-default-features`; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Coordination

**BREAKING wire-order change.** Merge and release only after the pipeline normalization gate (cymbal) is live, so the server can normalize order per SDK and version. Ship as a **minor** release (changeset included) so the pipeline can gate on `$lib_version`. Do not merge ahead of the normalization gate.
