### PR TITLE
fix(capture): clamp Retry-After to retry_max_backoff_ms

### DIFF
--- a/.sampo/changesets/retry-after-clamp.md
+++ b/.sampo/changesets/retry-after-clamp.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Clamp a server `Retry-After` to `retry_max_backoff_ms` (default 30s) instead of an internal 1-day cap, so a single retry wait never exceeds the configured max backoff. `Retry-After` still acts as a minimum and the configured backoff itself is never truncated. This unifies the default retry-wait ceiling (30s) with posthog-go and posthog-python.

--- a/.sampo/changesets/retry-after-clamp.md
+++ b/.sampo/changesets/retry-after-clamp.md
@@ -1,5 +1,5 @@
 ---
-cargo/posthog-rs: minor
+cargo/posthog-rs: patch
 ---
 
 Clamp a server `Retry-After` to `retry_max_backoff_ms` (default 30s) instead of an internal 1-day cap, so a single retry wait never exceeds the configured max backoff. `Retry-After` still acts as a minimum and the configured backoff itself is never truncated. This unifies the default retry-wait ceiling (30s) with posthog-go and posthog-python.

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -291,15 +291,23 @@ mod tests {
                 1,
                 Duration::from_millis(5000),
             ),
+            // Below configured_delay -> configured_delay wins.
             (
                 Some(Duration::from_millis(1)),
                 1,
                 Duration::from_millis(100),
             ),
+            // Equal to configured_delay -> same either way.
             (
                 Some(Duration::from_millis(100)),
                 1,
                 Duration::from_millis(100),
+            ),
+            // Between configured_delay and max -> un-clamped Retry-After wins.
+            (
+                Some(Duration::from_millis(500)),
+                1,
+                Duration::from_millis(500),
             ),
         ];
         for &(retry_after, attempt, expected) in cases {

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -93,18 +93,13 @@ fn datetime_to_system_time(dt: DateTime<Utc>) -> Option<SystemTime> {
     SystemTime::UNIX_EPOCH.checked_add(Duration::new(secs as u64, dt.timestamp_subsec_nanos()))
 }
 
-/// Hard cap on any scheduled retry delay. Guards the worker's `Instant + delay`
-/// from overflowing — which would panic the worker thread and silently drop all
-/// later captures — on a hostile/buggy `Retry-After` (or an extreme
-/// `retry_max_backoff_ms`). A day is far beyond any sane retry delay.
-const RETRY_BACKOFF_CAP: Duration = Duration::from_secs(86_400);
-
 /// Backoff before `attempt`: exponential growth from
 /// `retry_initial_backoff_ms`, clamped to `retry_max_backoff_ms`. When present,
 /// `Retry-After` is treated as a server-provided minimum delay, so the client
-/// waits for the longer of the configured backoff and `Retry-After`. The result
-/// is capped at [`RETRY_BACKOFF_CAP`] so an absurd value can't overflow the
-/// worker's `next_at` computation.
+/// waits for the longer of the configured backoff and `Retry-After` — but the
+/// `Retry-After` is itself clamped to `retry_max_backoff_ms`, so a hostile/buggy
+/// server header can't push a single wait past the ceiling the caller already
+/// configured (default 30s). The configured backoff is never truncated.
 pub(crate) fn backoff_duration(
     opts: &ClientOptions,
     attempt: u32,
@@ -114,8 +109,9 @@ pub(crate) fn backoff_duration(
     let max_ms = opts.retry_max_backoff_ms;
     let backoff_ms = base_ms.saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)));
     let configured_delay = Duration::from_millis(backoff_ms.min(max_ms));
-    let delay = retry_after.map_or(configured_delay, |d| configured_delay.max(d));
-    delay.min(RETRY_BACKOFF_CAP)
+    let max_backoff = Duration::from_millis(max_ms);
+    let clamped_retry_after = retry_after.map(|d| d.min(max_backoff));
+    clamped_retry_after.map_or(configured_delay, |d| configured_delay.max(d))
 }
 
 /// Sans-IO decision for a completed V0 capture response. `attempt` is the
@@ -286,9 +282,15 @@ mod tests {
     fn backoff_retry_after_minimum_semantics() {
         let opts = test_opts(); // initial=100ms, max=5000ms
                                 // (retry_after, attempt, expected): Retry-After is a minimum, so the
-                                // client waits for the longer of the configured backoff and Retry-After.
+                                // client waits for the longer of the configured backoff and Retry-After,
+                                // but Retry-After is clamped to retry_max_backoff_ms (5000ms here).
         let cases: &[(Option<Duration>, u32, Duration)] = &[
-            (Some(Duration::from_secs(42)), 1, Duration::from_secs(42)),
+            // Above the ceiling -> clamped to retry_max_backoff_ms.
+            (
+                Some(Duration::from_secs(42)),
+                1,
+                Duration::from_millis(5000),
+            ),
             (
                 Some(Duration::from_millis(1)),
                 1,
@@ -329,12 +331,18 @@ mod tests {
     }
 
     #[test]
-    fn backoff_caps_absurd_retry_after() {
-        // A hostile `Retry-After` must be capped, not overflow `Instant` later.
+    fn backoff_clamps_retry_after_to_max_backoff() {
+        // A hostile `Retry-After` is clamped to the configured max backoff
+        // (`retry_max_backoff_ms`, 5000ms in test_opts) rather than honored.
         let opts = test_opts();
         assert_eq!(
             backoff_duration(&opts, 1, Some(Duration::from_secs(u64::MAX))),
-            RETRY_BACKOFF_CAP
+            Duration::from_millis(opts.retry_max_backoff_ms)
+        );
+        // A Retry-After above the ceiling is also clamped to it.
+        assert_eq!(
+            backoff_duration(&opts, 1, Some(Duration::from_secs(600))),
+            Duration::from_millis(opts.retry_max_backoff_ms)
         );
     }
 

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -436,9 +436,8 @@ fn run_worker(
     let max_batch_size = options.max_batch_size.max(1);
     let flush_interval = Duration::from_millis(options.flush_interval_ms);
     // Clamp so an absurd `shutdown_timeout_ms` can't overflow the `now +
-    // shutdown_timeout` deadlines below and panic the worker — the same class of
-    // guard `RETRY_BACKOFF_CAP` applies to retry backoff. A day is far beyond any
-    // sane teardown budget.
+    // shutdown_timeout` deadlines below and panic the worker. A day is far beyond
+    // any sane teardown budget.
     let shutdown_timeout =
         Duration::from_millis(options.shutdown_timeout_ms).min(MAX_SHUTDOWN_TIMEOUT);
     let mut pipeline = Pipeline::new(&options, Arc::clone(&clock), len);

--- a/tests/test_v0_blocking_retry.rs
+++ b/tests/test_v0_blocking_retry.rs
@@ -21,8 +21,10 @@ fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
         .api_key("phc_test_token".to_string())
         .host(base_url)
         .max_capture_attempts(max_attempts)
+        // Tiny initial backoff keeps retries fast; max kept above the 1s
+        // Retry-After the retry-after test asserts (Retry-After is clamped to it).
         .retry_initial_backoff_ms(1u64)
-        .retry_max_backoff_ms(5u64)
+        .retry_max_backoff_ms(2000u64)
         .build()
         .unwrap();
     posthog_rs::client(options)

--- a/tests/test_v0_retry.rs
+++ b/tests/test_v0_retry.rs
@@ -23,10 +23,11 @@ async fn create_v0_client(base_url: String, max_attempts: u32) -> Client {
         .api_key("phc_test_token".to_string())
         .host(base_url)
         .max_capture_attempts(max_attempts)
-        // Tiny backoffs keep the scheduled-retry test fast; the retry-after test
-        // relies on these being far smaller than the header value it asserts.
+        // Tiny initial backoff keeps the scheduled-retry test fast; the max is
+        // kept above the 1s Retry-After the retry-after test asserts, since
+        // Retry-After is now clamped to retry_max_backoff_ms.
         .retry_initial_backoff_ms(1u64)
-        .retry_max_backoff_ms(5u64)
+        .retry_max_backoff_ms(2000u64)
         .build()
         .unwrap();
     posthog_rs::client(options).await

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -20,8 +20,10 @@ async fn create_v1_client(base_url: String) -> posthog_rs::Client {
         .api_key("phc_test_token".to_string())
         .host(base_url)
         .max_capture_attempts(3u32)
+        // Small initial backoff keeps retries fast; max kept above the 1s
+        // Retry-After the retry-after test asserts (Retry-After is clamped to it).
         .retry_initial_backoff_ms(10u64)
-        .retry_max_backoff_ms(50u64)
+        .retry_max_backoff_ms(2000u64)
         .build()
         .unwrap();
     posthog_rs::client(options).await


### PR DESCRIPTION
## :bulb: Motivation and Context

Cross-SDK capture retry parity. posthog-rs previously bounded a server `Retry-After` only by an internal 1-day `RETRY_BACKOFF_CAP`, far larger than any sane analytics retry wait. This clamps `Retry-After` to `retry_max_backoff_ms` (default 30s) so a single wait can no longer exceed the caller's configured max backoff, unifying the default 30s retry-wait ceiling with posthog-go and posthog-python.

- `Retry-After` stays a *minimum* (client waits the larger of the configured backoff and the clamped `Retry-After`); the configured backoff is never truncated.
- Removes the internal 1-day cap; an absurd user-set `retry_max_backoff_ms` is the user's own ceiling.
- Applies to the shared v0 + v1 backoff path (`backoff_duration`); feature-flags/poller are unaffected (they pass no `Retry-After`).

## :green_heart: How did you test it?

- Updated `retry.rs` unit tests: a hostile/large `Retry-After` now clamps to `retry_max_backoff_ms` (was the 1-day cap).
- Updated the three integration retry-after tests to use a max backoff above the 1s header they assert (since `Retry-After` is now clamped to that ceiling).
- `cargo test` and `cargo test --features capture-v1` green; `cargo clippy --features capture-v1` clean.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] Behavioral change (`Retry-After` now bounded by `retry_max_backoff_ms`); changeset added.

### If releasing new changes

- [x] Added a sampo changeset (`minor`)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Cursor (Claude Opus 4.8) as part of a cross-SDK capture retry unification (paired with posthog-go #255 and the posthog-python capture-v1 stack). Prod telemetry showed the backend sends `Retry-After: 1s` and retryable responses are ~1 in 18M, so the cap only ever guards pathological values; 30s (the existing default max backoff) is the agreed unified ceiling.
