### PR TITLE
fix: match SDK capture frames across demangler renderings

### DIFF
--- a/.sampo/changesets/demangler-robust-frame-strip.md
+++ b/.sampo/changesets/demangler-robust-frame-strip.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+fix: strip SDK capture frames under newer demangler renderings (`<Type>::method::<T>`), which previously survived at the crash-site end of the stack

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1176,6 +1176,11 @@ fn is_panic_dispatcher_frame(function: &str) -> bool {
 // the strip loop stops at them and they survive, classified out-of-app for the
 // UI to collapse.
 fn is_internal_capture_frame(function: &str) -> bool {
+    // Demanglers differ on qualified-path rendering across toolchain versions:
+    // older output is `Exception::from_error`, newer output wraps the type as
+    // `<posthog_rs::error_tracking::Exception>::from_error::<T>`. Strip the
+    // angle brackets before matching so both forms hit.
+    let function: String = function.replace(['<', '>'], "");
     function.starts_with("backtrace::")
         || function.contains("capture_frames_current_first")
         || function.contains("capture_raw_frames")
@@ -1964,6 +1969,24 @@ mod tests {
             normalize_function_name("<[u8] as checkout_service::Digest>::digest"),
             "<[u8] as checkout_service::Digest>::digest"
         );
+    }
+
+    #[test]
+    fn internal_capture_frames_match_both_demangler_renderings() {
+        // Older toolchains demangle as `Type::method`, newer ones as
+        // `<path::Type>::method::<T>` — the strip must catch both, or an SDK
+        // frame survives at the crash-site end of the canonical order.
+        for name in [
+            "posthog_rs::error_tracking::Exception::from_error",
+            "<posthog_rs::error_tracking::Exception>::from_error::<posthog_rs::error_tracking::tests::OuterError>",
+            "<posthog_rs::error_tracking::Exception>::from_message",
+            "<posthog_rs::client::Client>::capture_exception::<E>",
+        ] {
+            assert!(is_internal_capture_frame(name), "should strip {name:?}");
+        }
+        assert!(!is_internal_capture_frame(
+            "my_app::checkout::Exception_from_error_report"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

CI on main went red after #176 merged: `from_error_builds_exception_list_with_stacktrace` fails on Linux with `expected user frame last, got "<posthog_rs::error_tracking::Exception>::from_error::<...>"`.

Root cause is not the wire-order flip itself: `is_internal_capture_frame` matches SDK capture helpers by substring (e.g. `Exception::from_error`), but newer toolchain/demangler output renders qualified paths as `<posthog_rs::error_tracking::Exception>::from_error::<T>` — the closing `>` breaks the substring match, so the SDK frame survives the strip and sits at the crash-site end of the canonical order. The PR's own CI was green a week earlier under the older rendering, and macOS still renders bracket-free, which is why this only surfaced on the post-merge Linux run. `Exception::from_message` and `Client::capture_exception` had the same latent hole.

Released 0.19.0 carries the bug: manual `from_error`/`capture_exception` captures built under newer toolchains keep one SDK frame at the stack tail (consistent per error, so grouping is stable — but the tail frame is wrong and the fingerprint includes SDK noise).

## Changes

- `is_internal_capture_frame` strips `<`/`>` from the demangled name before matching, so both renderings (and monomorphized generic suffixes) hit all existing patterns. Panic/unwind runtime frames remain deliberately unmatched, as before.
- Regression test pinning both renderings for the affected helpers, plus a non-SDK name that must not match.
- `patch` changeset → 0.19.1. The cymbal wire-order cutoff is `0.19.0`, so the patch passes the gate as canonical, which is correct — it contains the flip.

## How did you test this code?

Automated only:

- Reproduced the exact main failure in a Linux container (rust:1, current stable), then verified the fix: all 28 `error_tracking` tests pass there, including the previously failing one.
- Full `cargo test --lib` on macOS (188 passed) — the older bracket-free rendering still matches.
- Pre-existing `personal_api_key` deprecation warnings in `test_on_error.rs` (from #174) are untouched/out of scope.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code diagnosed and fixed this under my direction: pulled the failing main run, reproduced in a Linux container to get the assertion text CI logs omitted, bisected the discrepancy to demangler rendering differences rather than the #176 logic, and validated on both renderings.
