### PR TITLE
fix: close default in-app classification gaps for native frames

### DIFF
--- a/.sampo/changesets/in-app-classification-gaps.md
+++ b/.sampo/changesets/in-app-classification-gaps.md
@@ -4,6 +4,6 @@ cargo/posthog-rs: patch
 
 Default in-app frame classification now covers three gaps that left dependency and runtime frames marked as app code:
 
-- Cargo registry/git checkout paths are recognized for cargo homes not named `~/.cargo` — `/usr/local/cargo/registry/...` in the official Rust Docker images, and crates.io registry layouts (`registry/src/index.crates.io-<hash>/`) under any relocated `CARGO_HOME`.
+- Cargo dependency sources are recognized by cargo's own on-disk layouts — `registry/src/index.crates.io-<hash>/` and `git/checkouts/<repo>-<hash>/<rev>/` — under any `CARGO_HOME`, not just `~/.cargo` (e.g. `/usr/local/cargo` in the official Rust Docker images).
 - Crate-denylist matching strips trailing generic arguments first, so DWARF-derived names like `poll_future<tokio::runtime::...>` no longer produce a garbage leading segment (`poll_future<tokio`) that bypasses the check.
 - Fileless thread/process bootstrap symbols (`__clone`, `start_thread`, `_start`, the C `main` shim, and friends) are classified as not in-app. Other bare symbols — `#[no_mangle]` exports, C code linked into the binary — keep their previous in-app classification.

--- a/.sampo/changesets/in-app-classification-gaps.md
+++ b/.sampo/changesets/in-app-classification-gaps.md
@@ -4,6 +4,6 @@ cargo/posthog-rs: patch
 
 Default in-app frame classification now covers three gaps that left dependency and runtime frames marked as app code:
 
-- Cargo registry/git checkout paths are recognized under any `CARGO_HOME`, not just `~/.cargo` — e.g. `/usr/local/cargo/registry/...` in the official Rust Docker images.
+- Cargo registry/git checkout paths are recognized for cargo homes not named `~/.cargo` — `/usr/local/cargo/registry/...` in the official Rust Docker images, and crates.io registry layouts (`registry/src/index.crates.io-<hash>/`) under any relocated `CARGO_HOME`.
 - Crate-denylist matching strips trailing generic arguments first, so DWARF-derived names like `poll_future<tokio::runtime::...>` no longer produce a garbage leading segment (`poll_future<tokio`) that bypasses the check.
-- Bare bootstrap/foreign symbols with no source file and no `::` path (`__clone`, `start_thread`, `main`) are classified as not in-app.
+- Fileless thread/process bootstrap symbols (`__clone`, `start_thread`, `_start`, the C `main` shim, and friends) are classified as not in-app. Other bare symbols — `#[no_mangle]` exports, C code linked into the binary — keep their previous in-app classification.

--- a/.sampo/changesets/in-app-classification-gaps.md
+++ b/.sampo/changesets/in-app-classification-gaps.md
@@ -5,5 +5,5 @@ cargo/posthog-rs: patch
 Default in-app frame classification now covers three gaps that left dependency and runtime frames marked as app code:
 
 - Cargo dependency sources are recognized by cargo's own on-disk layouts — `registry/src/index.crates.io-<hash>/` and `git/checkouts/<repo>-<hash>/<rev>/` — under any `CARGO_HOME`, not just `~/.cargo` (e.g. `/usr/local/cargo` in the official Rust Docker images).
-- Crate-denylist matching strips trailing generic arguments first, so DWARF-derived names like `poll_future<tokio::runtime::...>` no longer produce a garbage leading segment (`poll_future<tokio`) that bypasses the check.
+- Crate-denylist matching strips trailing generic arguments first, so DWARF-derived names like `poll_future<tokio::runtime::...>` no longer feed a garbage segment (`poll_future<tokio`) into the crate check. Such names classify by their file path (fix above); when there is no file, they deliberately stay in-app — generic arguments are instantiation types, not the defining crate, and guessing from them would mislabel app functions generic over vendor types.
 - Fileless thread/process bootstrap symbols (`__clone`, `start_thread`, `_start`, the C `main` shim, and friends) are classified as not in-app. Other bare symbols — `#[no_mangle]` exports, C code linked into the binary — keep their previous in-app classification.

--- a/.sampo/changesets/in-app-classification-gaps.md
+++ b/.sampo/changesets/in-app-classification-gaps.md
@@ -1,0 +1,9 @@
+---
+cargo/posthog-rs: patch
+---
+
+Default in-app frame classification now covers three gaps that left dependency and runtime frames marked as app code:
+
+- Cargo registry/git checkout paths are recognized under any `CARGO_HOME`, not just `~/.cargo` — e.g. `/usr/local/cargo/registry/...` in the official Rust Docker images.
+- Crate-denylist matching strips trailing generic arguments first, so DWARF-derived names like `poll_future<tokio::runtime::...>` no longer produce a garbage leading segment (`poll_future<tokio`) that bypasses the check.
+- Bare bootstrap/foreign symbols with no source file and no `::` path (`__clone`, `start_thread`, `main`) are classified as not in-app.

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1356,10 +1356,12 @@ fn is_bootstrap_symbol(function: &str) -> bool {
 }
 
 /// A trailing `-<hex hash>` on a cargo registry/checkout directory name, e.g.
-/// `index.crates.io-6f17d22bba15001f` or `somecrate-9a8b7c6d5e4f3a2b`.
+/// `index.crates.io-6f17d22bba15001f` or `somecrate-9a8b7c6d5e4f3a2b`. Cargo's
+/// ident hash is a hex-encoded u64, so exactly 16 chars — requiring that
+/// keeps deploy dirs suffixed with short git SHAs (7–12 chars) from matching.
 fn has_cargo_hash_suffix(dir: &str) -> bool {
     dir.rsplit_once('-')
-        .is_some_and(|(_, hash)| hash.len() >= 8 && hash.chars().all(|ch| ch.is_ascii_hexdigit()))
+        .is_some_and(|(_, hash)| hash.len() == 16 && hash.chars().all(|ch| ch.is_ascii_hexdigit()))
 }
 
 /// Matches cargo's registry source layout,
@@ -2398,6 +2400,10 @@ mod tests {
         assert!(options.is_in_app_path("/srv/cargo/registry/my-service/src/main.rs"));
         assert!(options
             .is_in_app_path("/srv/registry/src/index.crates.io-local/my-service/src/main.rs"));
+        // Deploy/checkout dirs suffixed with short git SHAs (< 16 hex chars)
+        // don't pass for cargo's u64 ident hash.
+        assert!(options.is_in_app_path("/opt/app/registry/src/service-a1b2c3d4/modules/api.rs"));
+        assert!(options.is_in_app_path("/srv/git/checkouts/service-deadbeef/0f1e2d3/src/main.rs"));
 
         // DWARF-derived names hide the crate behind generic arguments
         // (`poll_future<tokio::...>`); the frame is still classified out of

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1360,14 +1360,16 @@ fn default_in_app_path(filename: &str) -> bool {
     // CARGO_HOME isn't always `~/.cargo` — the official Rust Docker images use
     // `/usr/local/cargo`. `/cargo/` keeps a path-component boundary so an app
     // under e.g. `/srv/mycargo/` can't match; `/.cargo/` is spelled out because
-    // its dot breaks that boundary. `/registry/src/index.crates.io-` is the
-    // crates.io registry layout itself ($CARGO_HOME/registry/src/<registry>-<hash>/),
-    // which catches renamed cargo homes the name checks can't.
+    // its dot breaks that boundary. The last two patterns are cargo's own
+    // layouts — `$CARGO_HOME/registry/src/<registry>-<hash>/` and
+    // `$CARGO_HOME/git/checkouts/<repo>-<hash>/` — which catch renamed cargo
+    // homes the name checks can't.
     if normalized.contains("/.cargo/registry/")
         || normalized.contains("/.cargo/git/")
         || normalized.contains("/cargo/registry/")
         || normalized.contains("/cargo/git/")
         || normalized.contains("/registry/src/index.crates.io-")
+        || normalized.contains("/git/checkouts/")
         || normalized.contains("/rustc/")
         || normalized.contains("/rustc-")
         || normalized.contains("/library/alloc/src/")
@@ -2334,10 +2336,12 @@ mod tests {
             "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.52.1/src/runtime/task/harness.rs"
         ));
         assert!(!options.is_in_app_path("/usr/local/cargo/git/checkouts/somecrate/src/lib.rs"));
-        // A renamed CARGO_HOME is still caught by the registry layout itself.
+        // A renamed CARGO_HOME is still caught by cargo's own layouts.
         assert!(!options.is_in_app_path(
             "/cache/rust-deps/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.219/src/de/mod.rs"
         ));
+        assert!(!options
+            .is_in_app_path("/cache/rust-deps/git/checkouts/somecrate-9a8b7c6d/0f1e2d/src/lib.rs"));
         // `cargo` must be a whole path component: an app that happens to live
         // under a `*cargo` directory is not dependency code.
         assert!(options.is_in_app_path("/srv/mycargo/registry/src/model.rs"));

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1355,6 +1355,29 @@ fn is_bootstrap_symbol(function: &str) -> bool {
     )
 }
 
+/// A trailing `-<hex hash>` on a cargo registry/checkout directory name, e.g.
+/// `index.crates.io-6f17d22bba15001f` or `somecrate-9a8b7c6d5e4f3a2b`.
+fn has_cargo_hash_suffix(dir: &str) -> bool {
+    dir.rsplit_once('-')
+        .is_some_and(|(_, hash)| hash.len() >= 8 && hash.chars().all(|ch| ch.is_ascii_hexdigit()))
+}
+
+/// Matches cargo's registry source layout,
+/// `$CARGO_HOME/registry/src/<registry>-<hex hash>/<crate>-<version>/...`,
+/// regardless of where the cargo home lives. The hash suffix and a crate
+/// directory beneath are required so app paths that merely contain
+/// registry-like names don't match.
+fn is_cargo_registry_src(normalized: &str) -> bool {
+    let Some(idx) = normalized.find("/registry/src/") else {
+        return false;
+    };
+    let rest = &normalized[idx + "/registry/src/".len()..];
+    let Some((registry_dir, rest)) = rest.split_once('/') else {
+        return false;
+    };
+    has_cargo_hash_suffix(registry_dir) && rest.contains('/')
+}
+
 /// Matches cargo's git dependency layout,
 /// `$CARGO_HOME/git/checkouts/<repo>-<hex ident hash>/<short rev>/...`,
 /// regardless of where the cargo home lives. Both the ident-hash suffix and
@@ -1368,9 +1391,7 @@ fn is_cargo_git_checkout(normalized: &str) -> bool {
     let Some((repo_dir, rest)) = rest.split_once('/') else {
         return false;
     };
-    let ident_ok = repo_dir
-        .rsplit_once('-')
-        .is_some_and(|(_, hash)| hash.len() >= 8 && hash.chars().all(|ch| ch.is_ascii_hexdigit()));
+    let ident_ok = has_cargo_hash_suffix(repo_dir);
     let Some((rev_dir, rest)) = rest.split_once('/') else {
         return false;
     };
@@ -1384,12 +1405,12 @@ fn default_in_app_path(filename: &str) -> bool {
     let normalized = filename.replace('\\', "/");
     // CARGO_HOME isn't always `~/.cargo` — the official Rust Docker images use
     // `/usr/local/cargo`. Rather than guessing at cargo-home names, the
-    // registry-layout pattern ($CARGO_HOME/registry/src/<registry>-<hash>/)
-    // and the git checkout check match cargo's own on-disk layouts under any
-    // home; the `/.cargo/` rules stay as the original home-based fallback.
+    // registry-src and git-checkout checks match cargo's own on-disk layouts
+    // under any home; the `/.cargo/` rules stay as the original home-based
+    // fallback.
     if normalized.contains("/.cargo/registry/")
         || normalized.contains("/.cargo/git/")
-        || normalized.contains("/registry/src/index.crates.io-")
+        || is_cargo_registry_src(&normalized)
         || is_cargo_git_checkout(&normalized)
         || normalized.contains("/rustc/")
         || normalized.contains("/rustc-")
@@ -2375,6 +2396,8 @@ mod tests {
         // look cargo-ish stay in-app.
         assert!(options.is_in_app_path("/srv/mycargo/registry/src/model.rs"));
         assert!(options.is_in_app_path("/srv/cargo/registry/my-service/src/main.rs"));
+        assert!(options
+            .is_in_app_path("/srv/registry/src/index.crates.io-local/my-service/src/main.rs"));
 
         // DWARF-derived names hide the crate behind generic arguments
         // (`poll_future<tokio::...>`); the frame is still classified out of

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1383,15 +1383,12 @@ fn is_cargo_git_checkout(normalized: &str) -> bool {
 fn default_in_app_path(filename: &str) -> bool {
     let normalized = filename.replace('\\', "/");
     // CARGO_HOME isn't always `~/.cargo` — the official Rust Docker images use
-    // `/usr/local/cargo`. `/cargo/` keeps a path-component boundary so an app
-    // under e.g. `/srv/mycargo/` can't match; `/.cargo/` is spelled out because
-    // its dot breaks that boundary. The registry-layout pattern and the git
-    // checkout check are cargo's own layouts, which catch renamed cargo homes
-    // the name checks can't.
+    // `/usr/local/cargo`. Rather than guessing at cargo-home names, the
+    // registry-layout pattern ($CARGO_HOME/registry/src/<registry>-<hash>/)
+    // and the git checkout check match cargo's own on-disk layouts under any
+    // home; the `/.cargo/` rules stay as the original home-based fallback.
     if normalized.contains("/.cargo/registry/")
         || normalized.contains("/.cargo/git/")
-        || normalized.contains("/cargo/registry/")
-        || normalized.contains("/cargo/git/")
         || normalized.contains("/registry/src/index.crates.io-")
         || is_cargo_git_checkout(&normalized)
         || normalized.contains("/rustc/")
@@ -2359,7 +2356,9 @@ mod tests {
         assert!(!options.is_in_app_path(
             "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.52.1/src/runtime/task/harness.rs"
         ));
-        assert!(!options.is_in_app_path("/usr/local/cargo/git/checkouts/somecrate/src/lib.rs"));
+        assert!(!options.is_in_app_path(
+            "/usr/local/cargo/git/checkouts/somecrate-9a8b7c6d5e4f3a2b/0f1e2d3/src/lib.rs"
+        ));
         // A renamed CARGO_HOME is still caught by cargo's own layouts.
         assert!(!options.is_in_app_path(
             "/cache/rust-deps/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.219/src/de/mod.rs"
@@ -2372,9 +2371,10 @@ mod tests {
         // directory stays in-app, even with a hex-looking repo-dir suffix.
         assert!(options.is_in_app_path("/srv/git/checkouts/my-service/src/main.rs"));
         assert!(options.is_in_app_path("/srv/git/checkouts/my-service-deadbeef/src/main.rs"));
-        // `cargo` must be a whole path component: an app that happens to live
-        // under a `*cargo` directory is not dependency code.
+        // Only cargo's real layouts match: apps under directories that merely
+        // look cargo-ish stay in-app.
         assert!(options.is_in_app_path("/srv/mycargo/registry/src/model.rs"));
+        assert!(options.is_in_app_path("/srv/cargo/registry/my-service/src/main.rs"));
 
         // DWARF-derived names hide the crate behind generic arguments
         // (`poll_future<tokio::...>`); the frame is still classified out of

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1355,21 +1355,37 @@ fn is_bootstrap_symbol(function: &str) -> bool {
     )
 }
 
+/// Matches cargo's git dependency layout,
+/// `$CARGO_HOME/git/checkouts/<repo>-<hex ident hash>/<rev>/...`, regardless
+/// of where the cargo home lives. The ident-hash suffix is required so an app
+/// that merely lives under a `git/checkouts/` directory doesn't match.
+fn is_cargo_git_checkout(normalized: &str) -> bool {
+    let Some(idx) = normalized.find("/git/checkouts/") else {
+        return false;
+    };
+    let rest = &normalized[idx + "/git/checkouts/".len()..];
+    let Some((repo_dir, _)) = rest.split_once('/') else {
+        return false;
+    };
+    repo_dir
+        .rsplit_once('-')
+        .is_some_and(|(_, hash)| hash.len() >= 8 && hash.chars().all(|ch| ch.is_ascii_hexdigit()))
+}
+
 fn default_in_app_path(filename: &str) -> bool {
     let normalized = filename.replace('\\', "/");
     // CARGO_HOME isn't always `~/.cargo` — the official Rust Docker images use
     // `/usr/local/cargo`. `/cargo/` keeps a path-component boundary so an app
     // under e.g. `/srv/mycargo/` can't match; `/.cargo/` is spelled out because
-    // its dot breaks that boundary. The last two patterns are cargo's own
-    // layouts — `$CARGO_HOME/registry/src/<registry>-<hash>/` and
-    // `$CARGO_HOME/git/checkouts/<repo>-<hash>/` — which catch renamed cargo
-    // homes the name checks can't.
+    // its dot breaks that boundary. The registry-layout pattern and the git
+    // checkout check are cargo's own layouts, which catch renamed cargo homes
+    // the name checks can't.
     if normalized.contains("/.cargo/registry/")
         || normalized.contains("/.cargo/git/")
         || normalized.contains("/cargo/registry/")
         || normalized.contains("/cargo/git/")
         || normalized.contains("/registry/src/index.crates.io-")
-        || normalized.contains("/git/checkouts/")
+        || is_cargo_git_checkout(&normalized)
         || normalized.contains("/rustc/")
         || normalized.contains("/rustc-")
         || normalized.contains("/library/alloc/src/")
@@ -2340,8 +2356,12 @@ mod tests {
         assert!(!options.is_in_app_path(
             "/cache/rust-deps/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.219/src/de/mod.rs"
         ));
-        assert!(!options
-            .is_in_app_path("/cache/rust-deps/git/checkouts/somecrate-9a8b7c6d/0f1e2d/src/lib.rs"));
+        assert!(!options.is_in_app_path(
+            "/cache/rust-deps/git/checkouts/somecrate-9a8b7c6d5e4f3a2b/0f1e2d/src/lib.rs"
+        ));
+        // ...but only cargo's `<repo>-<hash>` checkout layout: an app that
+        // happens to live under a `git/checkouts/` directory stays in-app.
+        assert!(options.is_in_app_path("/srv/git/checkouts/my-service/src/main.rs"));
         // `cargo` must be a whole path component: an app that happens to live
         // under a `*cargo` directory is not dependency code.
         assert!(options.is_in_app_path("/srv/mycargo/registry/src/model.rs"));
@@ -2359,6 +2379,15 @@ mod tests {
         assert!(
             options.is_in_app_frame(Some("/app/src/worker.rs"), Some("run<tokio::time::Sleep>"),)
         );
+        // A *fileless* DWARF-style name deliberately fails open to in-app: the
+        // generic arguments are instantiation types, not the defining crate,
+        // so guessing the owner from them would mislabel app functions generic
+        // over vendor types. In practice DWARF-derived names ship with file
+        // info, which classifies them (as above).
+        assert!(options.is_in_app_frame(
+            None,
+            Some("poll_future<tokio::runtime::blocking::task::BlockingTask<T>, S>"),
+        ));
         // Qualified-path renderings keep their leading `<` and still resolve
         // the crate segment.
         assert!(!options.is_in_app_frame(

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -151,12 +151,14 @@ impl ErrorTrackingOptions {
             if !default_in_app_function(function) {
                 return false;
             }
-            // A frame with no source file whose name carries no `::` path is
-            // thread/process bootstrap glue (`__clone`, `start_thread`,
-            // `_start`) or a foreign-library symbol: app code resolved by name
-            // always demangles with its `crate::` path, and DWARF-derived
-            // names come with file info.
-            return filename.is_some() || strip_generic_args(function).contains("::");
+            // Only a known-symbol list for fileless bootstrap glue: a broader
+            // "no `::` path and no file" rule would also hide legitimate app
+            // symbols (`#[no_mangle]`/`#[export_name]` functions, C code
+            // linked into the binary) that resolve the same way.
+            if filename.is_none() && is_bootstrap_symbol(function) {
+                return false;
+            }
+            return true;
         }
 
         filename.is_some()
@@ -1333,12 +1335,39 @@ fn is_rust_symbol_hash(segment: &str) -> bool {
         && segment[1..].chars().all(|ch| ch.is_ascii_hexdigit())
 }
 
+/// Thread/process entry symbols from libc/libpthread (`__clone`,
+/// `start_thread`) and the C `main` shim. They resolve from the symbol table
+/// with no source file and no `crate::` path, so the crate denylist can't see
+/// them; matched exactly so app symbols of the same bare shape stay in-app.
+fn is_bootstrap_symbol(function: &str) -> bool {
+    matches!(
+        function,
+        "main"
+            | "_start"
+            | "__libc_start_main"
+            | "clone"
+            | "clone3"
+            | "__clone"
+            | "__clone3"
+            | "start_thread"
+            | "_pthread_start"
+            | "thread_start"
+    )
+}
+
 fn default_in_app_path(filename: &str) -> bool {
     let normalized = filename.replace('\\', "/");
-    // No leading `/.` on the cargo patterns: CARGO_HOME isn't always `~/.cargo`
-    // — the official Rust Docker images use `/usr/local/cargo`.
-    if normalized.contains("cargo/registry/")
-        || normalized.contains("cargo/git/")
+    // CARGO_HOME isn't always `~/.cargo` — the official Rust Docker images use
+    // `/usr/local/cargo`. `/cargo/` keeps a path-component boundary so an app
+    // under e.g. `/srv/mycargo/` can't match; `/.cargo/` is spelled out because
+    // its dot breaks that boundary. `/registry/src/index.crates.io-` is the
+    // crates.io registry layout itself ($CARGO_HOME/registry/src/<registry>-<hash>/),
+    // which catches renamed cargo homes the name checks can't.
+    if normalized.contains("/.cargo/registry/")
+        || normalized.contains("/.cargo/git/")
+        || normalized.contains("/cargo/registry/")
+        || normalized.contains("/cargo/git/")
+        || normalized.contains("/registry/src/index.crates.io-")
         || normalized.contains("/rustc/")
         || normalized.contains("/rustc-")
         || normalized.contains("/library/alloc/src/")
@@ -2305,6 +2334,13 @@ mod tests {
             "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.52.1/src/runtime/task/harness.rs"
         ));
         assert!(!options.is_in_app_path("/usr/local/cargo/git/checkouts/somecrate/src/lib.rs"));
+        // A renamed CARGO_HOME is still caught by the registry layout itself.
+        assert!(!options.is_in_app_path(
+            "/cache/rust-deps/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.219/src/de/mod.rs"
+        ));
+        // `cargo` must be a whole path component: an app that happens to live
+        // under a `*cargo` directory is not dependency code.
+        assert!(options.is_in_app_path("/srv/mycargo/registry/src/model.rs"));
 
         // DWARF-derived names hide the crate behind generic arguments
         // (`poll_future<tokio::...>`); the frame is still classified out of
@@ -2331,8 +2367,11 @@ mod tests {
         assert!(!options.is_in_app_frame(None, Some("__clone")));
         assert!(!options.is_in_app_frame(None, Some("start_thread")));
         assert!(!options.is_in_app_frame(None, Some("main")));
-        // ...but a pathless name backed by a source file keeps the path verdict.
+        // ...but a pathless name backed by a source file keeps the path verdict,
+        // and other bare symbols (`#[no_mangle]` exports, linked-in C code)
+        // stay in-app.
         assert!(options.is_in_app_frame(Some("/app/src/main.rs"), Some("main")));
+        assert!(options.is_in_app_frame(None, Some("my_exported_callback")));
     }
 
     #[test]

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1356,20 +1356,28 @@ fn is_bootstrap_symbol(function: &str) -> bool {
 }
 
 /// Matches cargo's git dependency layout,
-/// `$CARGO_HOME/git/checkouts/<repo>-<hex ident hash>/<rev>/...`, regardless
-/// of where the cargo home lives. The ident-hash suffix is required so an app
-/// that merely lives under a `git/checkouts/` directory doesn't match.
+/// `$CARGO_HOME/git/checkouts/<repo>-<hex ident hash>/<short rev>/...`,
+/// regardless of where the cargo home lives. Both the ident-hash suffix and
+/// the short-rev component are required so an app that merely lives under a
+/// `git/checkouts/` directory (even one named `*-deadbeef`) doesn't match.
 fn is_cargo_git_checkout(normalized: &str) -> bool {
     let Some(idx) = normalized.find("/git/checkouts/") else {
         return false;
     };
     let rest = &normalized[idx + "/git/checkouts/".len()..];
-    let Some((repo_dir, _)) = rest.split_once('/') else {
+    let Some((repo_dir, rest)) = rest.split_once('/') else {
         return false;
     };
-    repo_dir
+    let ident_ok = repo_dir
         .rsplit_once('-')
-        .is_some_and(|(_, hash)| hash.len() >= 8 && hash.chars().all(|ch| ch.is_ascii_hexdigit()))
+        .is_some_and(|(_, hash)| hash.len() >= 8 && hash.chars().all(|ch| ch.is_ascii_hexdigit()));
+    let Some((rev_dir, rest)) = rest.split_once('/') else {
+        return false;
+    };
+    let rev_ok = (7..=40).contains(&rev_dir.len())
+        && rev_dir.chars().all(|ch| ch.is_ascii_hexdigit())
+        && !rest.is_empty();
+    ident_ok && rev_ok
 }
 
 fn default_in_app_path(filename: &str) -> bool {
@@ -2357,11 +2365,13 @@ mod tests {
             "/cache/rust-deps/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.219/src/de/mod.rs"
         ));
         assert!(!options.is_in_app_path(
-            "/cache/rust-deps/git/checkouts/somecrate-9a8b7c6d5e4f3a2b/0f1e2d/src/lib.rs"
+            "/cache/rust-deps/git/checkouts/somecrate-9a8b7c6d5e4f3a2b/0f1e2d3/src/lib.rs"
         ));
-        // ...but only cargo's `<repo>-<hash>` checkout layout: an app that
-        // happens to live under a `git/checkouts/` directory stays in-app.
+        // ...but only cargo's `<repo>-<ident hash>/<short rev>/` checkout
+        // layout: an app that happens to live under a `git/checkouts/`
+        // directory stays in-app, even with a hex-looking repo-dir suffix.
         assert!(options.is_in_app_path("/srv/git/checkouts/my-service/src/main.rs"));
+        assert!(options.is_in_app_path("/srv/git/checkouts/my-service-deadbeef/src/main.rs"));
         // `cargo` must be a whole path component: an app that happens to live
         // under a `*cargo` directory is not dependency code.
         assert!(options.is_in_app_path("/srv/mycargo/registry/src/model.rs"));

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -148,7 +148,15 @@ impl ErrorTrackingOptions {
         }
 
         if let Some(function) = function {
-            return default_in_app_function(function);
+            if !default_in_app_function(function) {
+                return false;
+            }
+            // A frame with no source file whose name carries no `::` path is
+            // thread/process bootstrap glue (`__clone`, `start_thread`,
+            // `_start`) or a foreign-library symbol: app code resolved by name
+            // always demangles with its `crate::` path, and DWARF-derived
+            // names come with file info.
+            return filename.is_some() || strip_generic_args(function).contains("::");
         }
 
         filename.is_some()
@@ -1327,8 +1335,10 @@ fn is_rust_symbol_hash(segment: &str) -> bool {
 
 fn default_in_app_path(filename: &str) -> bool {
     let normalized = filename.replace('\\', "/");
-    if normalized.contains("/.cargo/registry/")
-        || normalized.contains("/.cargo/git/")
+    // No leading `/.` on the cargo patterns: CARGO_HOME isn't always `~/.cargo`
+    // — the official Rust Docker images use `/usr/local/cargo`.
+    if normalized.contains("cargo/registry/")
+        || normalized.contains("cargo/git/")
         || normalized.contains("/rustc/")
         || normalized.contains("/rustc-")
         || normalized.contains("/library/alloc/src/")
@@ -1346,6 +1356,22 @@ fn default_in_app_path(filename: &str) -> bool {
     true
 }
 
+/// Strip trailing generic arguments from a function name so the crate-segment
+/// checks see the path, not the instantiation. DWARF-derived names carry the
+/// bare method name with its generic arguments
+/// (`poll_future<tokio::runtime::blocking::task::BlockingTask<...>>`), where a
+/// naive `::` split would yield a garbage first segment (`poll_future<tokio`).
+/// A *leading* `<` is a qualified-path rendering
+/// (`<alloc::boxed::Box<F> as core::ops::function::FnOnce<Args>>::call_once`),
+/// not generic arguments, so the name is kept whole for the existing
+/// `trim_start_matches('<')` handling.
+fn strip_generic_args(function: &str) -> &str {
+    match function.find('<') {
+        Some(idx) if idx > 0 => &function[..idx],
+        _ => function,
+    }
+}
+
 fn default_in_app_function(function: &str) -> bool {
     // Bare runtime/unwind symbols that carry no `crate::` prefix (so the segment
     // match below can't catch them). `rust_begin_unwind` is the panic entry; the
@@ -1361,7 +1387,7 @@ fn default_in_app_function(function: &str) -> bool {
     }
 
     !matches!(
-        function
+        strip_generic_args(function)
             .trim_start_matches('<')
             .split("::")
             .next()
@@ -2267,6 +2293,46 @@ mod tests {
         assert!(!options.is_in_app_path("/service/vendor/lib.rs"));
         assert!(options.is_in_app_frame(None, Some("my_service::checkout")));
         assert!(!options.is_in_app_frame(None, Some("other_service::checkout")));
+    }
+
+    #[test]
+    fn in_app_defaults_cover_docker_cargo_home_and_dwarf_names() {
+        let options = ErrorTrackingOptions::default();
+
+        // CARGO_HOME isn't always `~/.cargo`: the official Rust Docker images
+        // put the registry under /usr/local/cargo.
+        assert!(!options.is_in_app_path(
+            "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.52.1/src/runtime/task/harness.rs"
+        ));
+        assert!(!options.is_in_app_path("/usr/local/cargo/git/checkouts/somecrate/src/lib.rs"));
+
+        // DWARF-derived names hide the crate behind generic arguments
+        // (`poll_future<tokio::...>`); the frame is still classified out of
+        // app by its registry path, and the garbage `poll_future<tokio`
+        // segment must not make the name override that.
+        assert!(!options.is_in_app_frame(
+            Some("/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.52.1/src/runtime/task/harness.rs"),
+            Some("poll_future<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>"),
+        ));
+        // An app function generic over a vendor type stays in-app: only the
+        // base name (path before `<`) feeds the crate check.
+        assert!(
+            options.is_in_app_frame(Some("/app/src/worker.rs"), Some("run<tokio::time::Sleep>"),)
+        );
+        // Qualified-path renderings keep their leading `<` and still resolve
+        // the crate segment.
+        assert!(!options.is_in_app_frame(
+            None,
+            Some("<alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once"),
+        ));
+
+        // Bare thread/process bootstrap symbols with no source file are not
+        // app code, even though no crate denylist entry can match them.
+        assert!(!options.is_in_app_frame(None, Some("__clone")));
+        assert!(!options.is_in_app_frame(None, Some("start_thread")));
+        assert!(!options.is_in_app_frame(None, Some("main")));
+        // ...but a pathless name backed by a source file keeps the path verdict.
+        assert!(options.is_in_app_frame(Some("/app/src/main.rs"), Some("main")));
     }
 
     #[test]


### PR DESCRIPTION
# Problem

On a production service reporting through posthog-rs from the official Rust Docker image, nearly every stack frame arrived marked `in_app: true` — including dozens of tokio runtime and thread-bootstrap frames — so the UI's vendor collapsing never kicked in and issues rendered 100+ frame stacks. Three gaps in the default classification caused this:

1. The cargo path rule only knew `/.cargo/registry/` and `/.cargo/git/`, but `CARGO_HOME` is `/usr/local/cargo` in the official Rust Docker images (and can live anywhere), so dependency sources like `/usr/local/cargo/registry/src/index.crates.io-<hash>/tokio-1.52.1/...` classified as app code.
2. The crate denylist takes the first `::` segment of the function name, but DWARF-derived names carry the bare method name with generic arguments (`poll_future<tokio::runtime::...>`), producing a garbage segment (`poll_future<tokio`) that matches nothing.
3. Fileless bootstrap symbols (`__clone`, `start_thread`, the C `main` shim) have no `::` path for the denylist to see and classified as app code.

# Changes

- Match cargo dependency sources by cargo's own on-disk layouts — `registry/src/<registry>-<hex hash>/<crate>/...` and `git/checkouts/<repo>-<hex hash>/<rev>/...` — under any cargo home, validating the hash/rev components so app paths that merely look cargo-ish don't match. The original `/.cargo/` rules remain as the home-based fallback.
- Strip trailing generic arguments before the crate-segment check so DWARF-style names can't produce garbage segments. Fileless names of this shape deliberately fail open to in-app: generic arguments are instantiation types, not the defining crate, and guessing from them would mislabel app functions generic over vendor types.
- Classify a fixed list of fileless thread/process bootstrap symbols as not in-app. Kept to exact matches so `#[no_mangle]` exports and C code linked into the binary keep their previous in-app classification.

# Tests

- New `in_app_defaults_cover_docker_cargo_home_and_dwarf_names` unit test covering the Docker cargo home, relocated cargo homes, layout false-positive boundaries (`/srv/mycargo/`, `/srv/cargo/registry/`, `git/checkouts/` app dirs, hex-suffixed dir names), DWARF generic names with and without files, qualified-path renderings, bootstrap symbols, and bare app exports.
- Full suite: 279 passed, 1 ignored. Clippy and rustfmt clean.
