### PR TITLE
feat(flags): minimize $feature_flag_called events for non-experiment flags

### DIFF
--- a/.sampo/changesets/minimal-flag-called-events.md
+++ b/.sampo/changesets/minimal-flag-called-events.md
@@ -1,0 +1,9 @@
+---
+posthog-rs: minor
+---
+
+`$feature_flag_called` events now carry a tri-state `$feature_flag_has_experiment` property and are minimized for non-experiment flags when the server enables it. The experiment signal is read from `has_experiment` on each flag — from the `/flags?v=2` `metadata` object (remote evaluation) or the `/flags/definitions` flag definitions (local evaluation) — and is sent as `true`/`false` when reported, omitted entirely when the server does not report it (never fabricated as `false`).
+
+When the server-controlled gate is on — `minimalFlagCalledEvents: true` on the `/flags?v=2` response (remote) or `minimal_flag_called_events: true` on the local-evaluation definitions payload (local) — and the evaluated flag has `has_experiment: false`, the event is rebuilt from a strict allowlist (`$feature_flag`, `$feature_flag_response`, `$feature_flag_has_experiment`, `$feature_flag_id`, `$feature_flag_version`, `$feature_flag_reason`, `$feature_flag_request_id`, `$feature_flag_evaluated_at`, `$feature_flag_error`, `locally_evaluated`, `$groups`, `$process_person_profile`, `$geoip_disable`, `$session_id`, `$window_id`, `$device_id`, `$lib`, `$lib_version`, `$is_server`, `$os`, `$os_version`); everything else — `$feature/<key>`, `$feature_flag_payload`, and any user-supplied properties — is stripped. Any missing signal (gate absent, `has_experiment` unknown, experiment-linked flag, legacy response shapes) keeps today's full event shape. The gate is captured per evaluation source and pinned onto each flag's snapshot record, so a concurrent poller refresh cannot reshape an event after its value was determined. The gate is server-controlled per project; no SDK configuration is added.
+
+Local-evaluation support for the `minimal_flag_called_events` field depends on a PostHog server release that emits it; until then the client defaults to the full event shape.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -70,6 +70,7 @@ pub posthog_rs::FeatureFlagsResponse::Legacy::feature_flags: std::collections::h
 pub posthog_rs::FeatureFlagsResponse::V2
 pub posthog_rs::FeatureFlagsResponse::V2::errors_while_computing_flags: bool
 pub posthog_rs::FeatureFlagsResponse::V2::flags: std::collections::hash::map::HashMap<alloc::string::String, posthog_rs::FlagDetail>
+pub posthog_rs::FeatureFlagsResponse::V2::minimal_flag_called_events: bool
 pub posthog_rs::FeatureFlagsResponse::V2::quota_limited: bool
 pub posthog_rs::FeatureFlagsResponse::V2::request_id: core::option::Option<alloc::string::String>
 impl posthog_rs::FeatureFlagsResponse
@@ -242,6 +243,7 @@ pub posthog_rs::EventResult::result: posthog_rs::EventStatus
 pub struct posthog_rs::FeatureFlag
 pub posthog_rs::FeatureFlag::active: bool
 pub posthog_rs::FeatureFlag::filters: posthog_rs::FeatureFlagFilters
+pub posthog_rs::FeatureFlag::has_experiment: core::option::Option<bool>
 pub posthog_rs::FeatureFlag::key: alloc::string::String
 pub struct posthog_rs::FeatureFlagCondition
 pub posthog_rs::FeatureFlagCondition::aggregation_group_type_index: core::option::Option<i32>
@@ -274,6 +276,7 @@ pub fn posthog_rs::FlagCache::get_cohort_definitions(&self) -> std::collections:
 pub fn posthog_rs::FlagCache::get_flag(&self, &str) -> core::option::Option<posthog_rs::FeatureFlag>
 pub fn posthog_rs::FlagCache::get_flags_map(&self) -> std::collections::hash::map::HashMap<alloc::string::String, posthog_rs::FeatureFlag>
 pub fn posthog_rs::FlagCache::get_group_type_mapping(&self) -> std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub fn posthog_rs::FlagCache::minimal_flag_called_events(&self) -> bool
 pub fn posthog_rs::FlagCache::new() -> Self
 pub fn posthog_rs::FlagCache::update(&self, posthog_rs::LocalEvaluationResponse)
 impl core::default::Default for posthog_rs::FlagCache
@@ -286,6 +289,7 @@ pub posthog_rs::FlagDetail::reason: core::option::Option<posthog_rs::FlagReason>
 pub posthog_rs::FlagDetail::variant: core::option::Option<alloc::string::String>
 pub struct posthog_rs::FlagMetadata
 pub posthog_rs::FlagMetadata::description: core::option::Option<alloc::string::String>
+pub posthog_rs::FlagMetadata::has_experiment: core::option::Option<bool>
 pub posthog_rs::FlagMetadata::id: u64
 pub posthog_rs::FlagMetadata::payload: core::option::Option<serde_json::value::Value>
 pub posthog_rs::FlagMetadata::version: u32
@@ -329,6 +333,7 @@ pub struct posthog_rs::LocalEvaluationResponse
 pub posthog_rs::LocalEvaluationResponse::cohorts: std::collections::hash::map::HashMap<alloc::string::String, posthog_rs::Cohort>
 pub posthog_rs::LocalEvaluationResponse::flags: alloc::vec::Vec<posthog_rs::FeatureFlag>
 pub posthog_rs::LocalEvaluationResponse::group_type_mapping: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub posthog_rs::LocalEvaluationResponse::minimal_flag_called_events: bool
 pub struct posthog_rs::LocalEvaluator
 impl posthog_rs::LocalEvaluator
 pub fn posthog_rs::LocalEvaluator::cache(&self) -> &posthog_rs::FlagCache

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -1052,6 +1052,10 @@ impl Client {
                 &groups_owned,
                 &group_props_owned,
             );
+            // Pin the gate from the poller's current definitions snapshot at the
+            // point local evaluation succeeded, so it travels with these records
+            // rather than being re-read from shared state at event time.
+            let local_minimal_gate = evaluator.cache().minimal_flag_called_events();
             for (key, result) in local_results {
                 if let Some(filter) = &options.flag_keys {
                     if !filter.iter().any(|k| k == &key) {
@@ -1059,7 +1063,14 @@ impl Client {
                     }
                 }
                 if let Ok(value) = result {
-                    records.insert(key.clone(), local_record(value));
+                    let has_experiment = evaluator
+                        .cache()
+                        .get_flag(&key)
+                        .and_then(|f| f.has_experiment);
+                    records.insert(
+                        key.clone(),
+                        local_record(value, has_experiment, local_minimal_gate),
+                    );
                     locally_evaluated_keys.insert(key);
                 }
             }
@@ -1088,11 +1099,14 @@ impl Client {
                     request_id = response.request_id;
                     errors_while_computing = response.errors_while_computing_flags;
                     quota_limited = response.quota_limited;
+                    // The remote response is the source of these flags' values,
+                    // so it is also the source of their minimization gate.
+                    let remote_minimal_gate = response.minimal_flag_called_events;
                     for (key, detail) in response.flags {
                         if locally_evaluated_keys.contains(&key) {
                             continue;
                         }
-                        records.insert(key, remote_record_from_detail(detail));
+                        records.insert(key, remote_record_from_detail(detail, remote_minimal_gate));
                     }
                 }
                 Err(e) => {
@@ -1290,5 +1304,146 @@ impl Drop for Client {
         // worker and the flush stays durable. The winner has already sent the
         // Shutdown (synchronously, before any await), so the worker will exit.
         transport.join();
+    }
+}
+
+#[cfg(test)]
+mod minimal_gate_tests {
+    use super::*;
+    use crate::feature_flags::{FeatureFlagCondition, FeatureFlagFilters};
+    use crate::local_evaluation::LocalEvaluationResponse;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingHost {
+        captured: Mutex<Vec<FlagCalledEventParams>>,
+    }
+
+    impl FeatureFlagEvaluationsHost for RecordingHost {
+        fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
+            self.captured.lock().unwrap().push(params);
+        }
+        fn log_warning(&self, _message: &str) {}
+    }
+
+    /// A flag that evaluates locally to `true` (active, 100% rollout, no property
+    /// filters), carrying the given experiment signal.
+    fn gated_flag(has_experiment: Option<bool>) -> FeatureFlag {
+        FeatureFlag {
+            key: "gated".into(),
+            active: true,
+            has_experiment,
+            filters: FeatureFlagFilters {
+                groups: vec![FeatureFlagCondition {
+                    properties: vec![],
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                    aggregation_group_type_index: None,
+                }],
+                multivariate: None,
+                payloads: HashMap::new(),
+                aggregation_group_type_index: None,
+                early_exit: false,
+            },
+        }
+    }
+
+    fn definitions(has_experiment: Option<bool>, gate: bool) -> LocalEvaluationResponse {
+        LocalEvaluationResponse {
+            flags: vec![gated_flag(has_experiment)],
+            group_type_mapping: HashMap::new(),
+            cohorts: HashMap::new(),
+            minimal_flag_called_events: gate,
+        }
+    }
+
+    fn test_client(cache: FlagCache, host: Arc<dyn FeatureFlagEvaluationsHost>) -> Client {
+        let options = ClientOptions::from(("phc_test", "http://localhost:0"));
+        let client = Client {
+            options,
+            client: HttpClient::builder().build().unwrap(),
+            local_evaluator: Some(LocalEvaluator::new(cache)),
+            _flag_poller: None,
+            flag_event_host: OnceLock::new(),
+            transport: None,
+        };
+        client
+            .flag_event_host
+            .set(host)
+            .unwrap_or_else(|_| panic!("host already set"));
+        client
+    }
+
+    async fn evaluate(client: &Client) -> FeatureFlagEvaluations {
+        client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    only_evaluate_locally: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("local evaluate_flags")
+    }
+
+    /// The minimization gate must be pinned to the definitions snapshot that
+    /// produced the flag value, not re-read from the shared cache when the
+    /// deferred event finally fires. Mutating the cache in the gap between
+    /// evaluation and event capture must not reshape the event.
+    #[tokio::test]
+    async fn local_gate_pinned_at_evaluation_survives_cache_mutation_to_off() {
+        let cache = FlagCache::new();
+        cache.update(definitions(Some(false), true)); // gate ON at evaluation
+        let host = Arc::new(RecordingHost::default());
+        let client = test_client(cache.clone(), Arc::clone(&host) as _);
+
+        let snapshot = evaluate(&client).await;
+        // Poller refresh flips the gate OFF after the snapshot was produced.
+        cache.update(definitions(Some(false), false));
+
+        assert!(snapshot.is_enabled("gated"));
+        let captured = host.captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(
+            captured[0].minimal,
+            "event must reflect the gate pinned at evaluation (on), not the mutated cache (off)"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_gate_pinned_at_evaluation_survives_cache_mutation_to_on() {
+        let cache = FlagCache::new();
+        cache.update(definitions(Some(false), false)); // gate OFF at evaluation
+        let host = Arc::new(RecordingHost::default());
+        let client = test_client(cache.clone(), Arc::clone(&host) as _);
+
+        let snapshot = evaluate(&client).await;
+        // Poller refresh flips the gate ON after the snapshot was produced.
+        cache.update(definitions(Some(false), true));
+
+        assert!(snapshot.is_enabled("gated"));
+        let captured = host.captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(
+            !captured[0].minimal,
+            "event must reflect the gate pinned at evaluation (off), not the mutated cache (on)"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_has_experiment_is_threaded_from_definitions() {
+        let cache = FlagCache::new();
+        cache.update(definitions(Some(false), true));
+        let host = Arc::new(RecordingHost::default());
+        let client = test_client(cache, Arc::clone(&host) as _);
+
+        assert!(evaluate(&client).await.is_enabled("gated"));
+        let captured = host.captured.lock().unwrap();
+        assert_eq!(
+            captured[0].properties.get("$feature_flag_has_experiment"),
+            Some(&serde_json::json!(false))
+        );
+        assert!(captured[0].minimal);
     }
 }

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -1063,10 +1063,7 @@ impl Client {
                     }
                 }
                 if let Ok(value) = result {
-                    let has_experiment = evaluator
-                        .cache()
-                        .get_flag(&key)
-                        .and_then(|f| f.has_experiment);
+                    let has_experiment = evaluator.cache().has_experiment(&key);
                     records.insert(
                         key.clone(),
                         local_record(value, has_experiment, local_minimal_gate),
@@ -1310,52 +1307,7 @@ impl Drop for Client {
 #[cfg(test)]
 mod minimal_gate_tests {
     use super::*;
-    use crate::feature_flags::{FeatureFlagCondition, FeatureFlagFilters};
-    use crate::local_evaluation::LocalEvaluationResponse;
-    use std::sync::Mutex;
-
-    #[derive(Default)]
-    struct RecordingHost {
-        captured: Mutex<Vec<FlagCalledEventParams>>,
-    }
-
-    impl FeatureFlagEvaluationsHost for RecordingHost {
-        fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
-            self.captured.lock().unwrap().push(params);
-        }
-        fn log_warning(&self, _message: &str) {}
-    }
-
-    /// A flag that evaluates locally to `true` (active, 100% rollout, no property
-    /// filters), carrying the given experiment signal.
-    fn gated_flag(has_experiment: Option<bool>) -> FeatureFlag {
-        FeatureFlag {
-            key: "gated".into(),
-            active: true,
-            has_experiment,
-            filters: FeatureFlagFilters {
-                groups: vec![FeatureFlagCondition {
-                    properties: vec![],
-                    rollout_percentage: Some(100.0),
-                    variant: None,
-                    aggregation_group_type_index: None,
-                }],
-                multivariate: None,
-                payloads: HashMap::new(),
-                aggregation_group_type_index: None,
-                early_exit: false,
-            },
-        }
-    }
-
-    fn definitions(has_experiment: Option<bool>, gate: bool) -> LocalEvaluationResponse {
-        LocalEvaluationResponse {
-            flags: vec![gated_flag(has_experiment)],
-            group_type_mapping: HashMap::new(),
-            cohorts: HashMap::new(),
-            minimal_flag_called_events: gate,
-        }
-    }
+    use crate::client::minimal_gate_test_support::{definitions, RecordingHost};
 
     fn test_client(cache: FlagCache, host: Arc<dyn FeatureFlagEvaluationsHost>) -> Client {
         let options = ClientOptions::from(("phc_test", "http://localhost:0"));

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1049,10 +1049,7 @@ impl Client {
                     }
                 }
                 if let Ok(value) = result {
-                    let has_experiment = evaluator
-                        .cache()
-                        .get_flag(&key)
-                        .and_then(|f| f.has_experiment);
+                    let has_experiment = evaluator.cache().has_experiment(&key);
                     records.insert(
                         key.clone(),
                         local_record(value, has_experiment, local_minimal_gate),
@@ -1289,52 +1286,7 @@ impl Drop for Client {
 #[cfg(test)]
 mod minimal_gate_tests {
     use super::*;
-    use crate::feature_flags::{FeatureFlagCondition, FeatureFlagFilters};
-    use crate::local_evaluation::LocalEvaluationResponse;
-    use std::sync::Mutex;
-
-    #[derive(Default)]
-    struct RecordingHost {
-        captured: Mutex<Vec<FlagCalledEventParams>>,
-    }
-
-    impl FeatureFlagEvaluationsHost for RecordingHost {
-        fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
-            self.captured.lock().unwrap().push(params);
-        }
-        fn log_warning(&self, _message: &str) {}
-    }
-
-    /// A flag that evaluates locally to `true` (active, 100% rollout, no property
-    /// filters), carrying the given experiment signal.
-    fn gated_flag(has_experiment: Option<bool>) -> FeatureFlag {
-        FeatureFlag {
-            key: "gated".into(),
-            active: true,
-            has_experiment,
-            filters: FeatureFlagFilters {
-                groups: vec![FeatureFlagCondition {
-                    properties: vec![],
-                    rollout_percentage: Some(100.0),
-                    variant: None,
-                    aggregation_group_type_index: None,
-                }],
-                multivariate: None,
-                payloads: HashMap::new(),
-                aggregation_group_type_index: None,
-                early_exit: false,
-            },
-        }
-    }
-
-    fn definitions(has_experiment: Option<bool>, gate: bool) -> LocalEvaluationResponse {
-        LocalEvaluationResponse {
-            flags: vec![gated_flag(has_experiment)],
-            group_type_mapping: HashMap::new(),
-            cohorts: HashMap::new(),
-            minimal_flag_called_events: gate,
-        }
-    }
+    use crate::client::minimal_gate_test_support::{definitions, RecordingHost};
 
     fn test_client(cache: FlagCache, host: Arc<dyn FeatureFlagEvaluationsHost>) -> Client {
         let options = ClientOptions::from(("phc_test", "http://localhost:0"));

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1038,6 +1038,10 @@ impl Client {
                 &groups_owned,
                 &group_props_owned,
             );
+            // Pin the gate from the poller's current definitions snapshot at the
+            // point local evaluation succeeded, so it travels with these records
+            // rather than being re-read from shared state at event time.
+            let local_minimal_gate = evaluator.cache().minimal_flag_called_events();
             for (key, result) in local_results {
                 if let Some(filter) = &options.flag_keys {
                     if !filter.iter().any(|k| k == &key) {
@@ -1045,7 +1049,14 @@ impl Client {
                     }
                 }
                 if let Ok(value) = result {
-                    records.insert(key.clone(), local_record(value));
+                    let has_experiment = evaluator
+                        .cache()
+                        .get_flag(&key)
+                        .and_then(|f| f.has_experiment);
+                    records.insert(
+                        key.clone(),
+                        local_record(value, has_experiment, local_minimal_gate),
+                    );
                     locally_evaluated_keys.insert(key);
                 }
             }
@@ -1074,11 +1085,14 @@ impl Client {
                     request_id = response.request_id;
                     errors_while_computing = response.errors_while_computing_flags;
                     quota_limited = response.quota_limited;
+                    // The remote response is the source of these flags' values,
+                    // so it is also the source of their minimization gate.
+                    let remote_minimal_gate = response.minimal_flag_called_events;
                     for (key, detail) in response.flags {
                         if locally_evaluated_keys.contains(&key) {
                             continue;
                         }
-                        records.insert(key, remote_record_from_detail(detail));
+                        records.insert(key, remote_record_from_detail(detail, remote_minimal_gate));
                     }
                 }
                 Err(e) => {
@@ -1269,5 +1283,145 @@ impl Drop for Client {
         // shutdown/drop path waits for the worker and the flush stays durable. The
         // winner has already sent the Shutdown, so the worker will exit.
         transport.join();
+    }
+}
+
+#[cfg(test)]
+mod minimal_gate_tests {
+    use super::*;
+    use crate::feature_flags::{FeatureFlagCondition, FeatureFlagFilters};
+    use crate::local_evaluation::LocalEvaluationResponse;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingHost {
+        captured: Mutex<Vec<FlagCalledEventParams>>,
+    }
+
+    impl FeatureFlagEvaluationsHost for RecordingHost {
+        fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
+            self.captured.lock().unwrap().push(params);
+        }
+        fn log_warning(&self, _message: &str) {}
+    }
+
+    /// A flag that evaluates locally to `true` (active, 100% rollout, no property
+    /// filters), carrying the given experiment signal.
+    fn gated_flag(has_experiment: Option<bool>) -> FeatureFlag {
+        FeatureFlag {
+            key: "gated".into(),
+            active: true,
+            has_experiment,
+            filters: FeatureFlagFilters {
+                groups: vec![FeatureFlagCondition {
+                    properties: vec![],
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                    aggregation_group_type_index: None,
+                }],
+                multivariate: None,
+                payloads: HashMap::new(),
+                aggregation_group_type_index: None,
+                early_exit: false,
+            },
+        }
+    }
+
+    fn definitions(has_experiment: Option<bool>, gate: bool) -> LocalEvaluationResponse {
+        LocalEvaluationResponse {
+            flags: vec![gated_flag(has_experiment)],
+            group_type_mapping: HashMap::new(),
+            cohorts: HashMap::new(),
+            minimal_flag_called_events: gate,
+        }
+    }
+
+    fn test_client(cache: FlagCache, host: Arc<dyn FeatureFlagEvaluationsHost>) -> Client {
+        let options = ClientOptions::from(("phc_test", "http://localhost:0"));
+        let client = Client {
+            options,
+            client: HttpClient::builder().build().unwrap(),
+            local_evaluator: Some(LocalEvaluator::new(cache)),
+            _flag_poller: None,
+            flag_event_host: OnceLock::new(),
+            transport: None,
+        };
+        client
+            .flag_event_host
+            .set(host)
+            .unwrap_or_else(|_| panic!("host already set"));
+        client
+    }
+
+    fn evaluate(client: &Client) -> FeatureFlagEvaluations {
+        client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    only_evaluate_locally: true,
+                    ..Default::default()
+                },
+            )
+            .expect("local evaluate_flags")
+    }
+
+    /// The minimization gate must be pinned to the definitions snapshot that
+    /// produced the flag value, not re-read from the shared cache when the
+    /// deferred event finally fires. Mutating the cache in the gap between
+    /// evaluation and event capture must not reshape the event.
+    #[test]
+    fn local_gate_pinned_at_evaluation_survives_cache_mutation_to_off() {
+        let cache = FlagCache::new();
+        cache.update(definitions(Some(false), true)); // gate ON at evaluation
+        let host = Arc::new(RecordingHost::default());
+        let client = test_client(cache.clone(), Arc::clone(&host) as _);
+
+        let snapshot = evaluate(&client);
+        // Poller refresh flips the gate OFF after the snapshot was produced.
+        cache.update(definitions(Some(false), false));
+
+        assert!(snapshot.is_enabled("gated"));
+        let captured = host.captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(
+            captured[0].minimal,
+            "event must reflect the gate pinned at evaluation (on), not the mutated cache (off)"
+        );
+    }
+
+    #[test]
+    fn local_gate_pinned_at_evaluation_survives_cache_mutation_to_on() {
+        let cache = FlagCache::new();
+        cache.update(definitions(Some(false), false)); // gate OFF at evaluation
+        let host = Arc::new(RecordingHost::default());
+        let client = test_client(cache.clone(), Arc::clone(&host) as _);
+
+        let snapshot = evaluate(&client);
+        // Poller refresh flips the gate ON after the snapshot was produced.
+        cache.update(definitions(Some(false), true));
+
+        assert!(snapshot.is_enabled("gated"));
+        let captured = host.captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(
+            !captured[0].minimal,
+            "event must reflect the gate pinned at evaluation (off), not the mutated cache (on)"
+        );
+    }
+
+    #[test]
+    fn local_has_experiment_is_threaded_from_definitions() {
+        let cache = FlagCache::new();
+        cache.update(definitions(Some(false), true));
+        let host = Arc::new(RecordingHost::default());
+        let client = test_client(cache, Arc::clone(&host) as _);
+
+        assert!(evaluate(&client).is_enabled("gated"));
+        let captured = host.captured.lock().unwrap();
+        assert_eq!(
+            captured[0].properties.get("$feature_flag_has_experiment"),
+            Some(&serde_json::json!(false))
+        );
+        assert!(captured[0].minimal);
     }
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -179,6 +179,12 @@ pub(super) fn flag_called_event(
     is_server: bool,
 ) -> Option<Event> {
     let mut event = Event::new("$feature_flag_called".to_string(), params.distinct_id);
+    if params.minimal {
+        // Marks the event so the capture pipeline trims it to the minimal
+        // allowlist as its final enrichment step, after system context and SDK
+        // metadata are stamped on.
+        event.mark_minimal_flag_called();
+    }
     for (k, v) in params.properties {
         if event.insert_prop(k, v).is_err() {
             return None;
@@ -203,6 +209,10 @@ pub(super) struct DetailedFlagsResponse {
     pub(super) request_id: Option<String>,
     pub(super) errors_while_computing_flags: bool,
     pub(super) quota_limited: bool,
+    /// The `minimalFlagCalledEvents` gate as reported by this `/flags?v=2`
+    /// response. Pinned here so it travels with the flags it evaluated, rather
+    /// than being re-read from shared state when an event is later captured.
+    pub(super) minimal_flag_called_events: bool,
 }
 
 pub(super) fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFlagsResponse {
@@ -212,11 +222,13 @@ pub(super) fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFl
             request_id,
             errors_while_computing_flags,
             quota_limited,
+            minimal_flag_called_events,
         } => DetailedFlagsResponse {
             flags,
             request_id,
             errors_while_computing_flags,
             quota_limited,
+            minimal_flag_called_events,
         },
         FeatureFlagsResponse::Legacy {
             feature_flags,
@@ -242,6 +254,7 @@ pub(super) fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFl
                             version: 0,
                             description: None,
                             payload: Some(payload),
+                            has_experiment: None,
                         }),
                     },
                 );
@@ -251,12 +264,19 @@ pub(super) fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFl
                 request_id: None,
                 errors_while_computing_flags: errors.is_some_and(|e| !e.is_empty()),
                 quota_limited: false,
+                // The legacy response shape carries no minimization gate, so it
+                // fails safe to the full event shape.
+                minimal_flag_called_events: false,
             }
         }
     }
 }
 
-pub(super) fn local_record(value: FlagValue) -> EvaluatedFlagRecord {
+pub(super) fn local_record(
+    value: FlagValue,
+    has_experiment: Option<bool>,
+    minimal_flag_called_events: bool,
+) -> EvaluatedFlagRecord {
     let (enabled, variant) = match value {
         FlagValue::Boolean(b) => (b, None),
         FlagValue::String(s) => (true, Some(s)),
@@ -270,10 +290,15 @@ pub(super) fn local_record(value: FlagValue) -> EvaluatedFlagRecord {
         version: None,
         reason: Some("Evaluated locally".to_string()),
         locally_evaluated: true,
+        has_experiment,
+        minimal_flag_called_events,
     }
 }
 
-pub(super) fn remote_record_from_detail(detail: FlagDetail) -> EvaluatedFlagRecord {
+pub(super) fn remote_record_from_detail(
+    detail: FlagDetail,
+    minimal_flag_called_events: bool,
+) -> EvaluatedFlagRecord {
     let metadata = detail.metadata;
     let reason = detail
         .reason
@@ -281,6 +306,7 @@ pub(super) fn remote_record_from_detail(detail: FlagDetail) -> EvaluatedFlagReco
         .filter(|s| !s.is_empty());
     let id = metadata.as_ref().map(|m| m.id);
     let version = metadata.as_ref().map(|m| m.version);
+    let has_experiment = metadata.as_ref().and_then(|m| m.has_experiment);
     let payload = metadata.and_then(|m| m.payload).map(normalize_payload);
     EvaluatedFlagRecord {
         enabled: detail.enabled,
@@ -290,6 +316,8 @@ pub(super) fn remote_record_from_detail(detail: FlagDetail) -> EvaluatedFlagReco
         version,
         reason,
         locally_evaluated: false,
+        has_experiment,
+        minimal_flag_called_events,
     }
 }
 
@@ -330,6 +358,7 @@ mod tests {
             groups,
             disable_geoip,
             properties,
+            minimal: false,
         }
     }
 

--- a/src/client/minimal_gate_test_support.rs
+++ b/src/client/minimal_gate_test_support.rs
@@ -1,0 +1,55 @@
+//! Shared fixtures for the minimization-gate tests in `async_client` and
+//! `blocking`. Those two modules are mutually exclusive under the
+//! `async-client` feature, so this lives outside both to avoid two copies
+//! drifting out of sync.
+#![cfg(test)]
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::feature_flag_evaluations::{FeatureFlagEvaluationsHost, FlagCalledEventParams};
+use crate::feature_flags::{FeatureFlag, FeatureFlagCondition, FeatureFlagFilters};
+use crate::local_evaluation::LocalEvaluationResponse;
+
+#[derive(Default)]
+pub(super) struct RecordingHost {
+    pub(super) captured: Mutex<Vec<FlagCalledEventParams>>,
+}
+
+impl FeatureFlagEvaluationsHost for RecordingHost {
+    fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
+        self.captured.lock().unwrap().push(params);
+    }
+    fn log_warning(&self, _message: &str) {}
+}
+
+/// A flag that evaluates locally to `true` (active, 100% rollout, no property
+/// filters), carrying the given experiment signal.
+fn gated_flag(has_experiment: Option<bool>) -> FeatureFlag {
+    FeatureFlag {
+        key: "gated".into(),
+        active: true,
+        has_experiment,
+        filters: FeatureFlagFilters {
+            groups: vec![FeatureFlagCondition {
+                properties: vec![],
+                rollout_percentage: Some(100.0),
+                variant: None,
+                aggregation_group_type_index: None,
+            }],
+            multivariate: None,
+            payloads: HashMap::new(),
+            aggregation_group_type_index: None,
+            early_exit: false,
+        },
+    }
+}
+
+pub(super) fn definitions(has_experiment: Option<bool>, gate: bool) -> LocalEvaluationResponse {
+    LocalEvaluationResponse {
+        flags: vec![gated_flag(has_experiment)],
+        group_type_mapping: HashMap::new(),
+        cohorts: HashMap::new(),
+        minimal_flag_called_events: gate,
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -8,6 +8,8 @@ use derive_builder::Builder;
 use tracing::warn;
 
 mod common;
+#[cfg(test)]
+mod minimal_gate_test_support;
 mod on_error;
 mod summary;
 

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -27,9 +27,6 @@ pub(crate) fn prepare_event(event: &mut Event, defaults: &CaptureDefaults) {
     apply_capture_defaults(event, defaults);
     apply_runtime_context(event);
     event.prepare_for_v0();
-    // Final step: for minimized `$feature_flag_called` events, drop everything
-    // outside the allowlist now that system context and SDK metadata are stamped.
-    event.apply_minimal_flag_called_allowlist();
 }
 
 // ---------------------------------------------------------------------------
@@ -54,7 +51,13 @@ pub(crate) fn build_batch_payload(
         .into_iter()
         .filter_map(|mut event| {
             prepare_event(&mut event, defaults);
-            apply_before_send_hooks(before_send, event).map(InnerEvent::new_for_batch)
+            apply_before_send_hooks(before_send, event).map(|mut event| {
+                // Final step, after before_send: for minimized `$feature_flag_called`
+                // events, drop everything outside the allowlist so a hook cannot
+                // reintroduce properties it strips.
+                event.apply_minimal_flag_called_allowlist();
+                InnerEvent::new_for_batch(event)
+            })
         })
         .collect();
 
@@ -148,6 +151,20 @@ pub(crate) fn prepare_immediate(
 // Header helpers
 // ---------------------------------------------------------------------------
 
+/// Apply test-harness extra headers to a V0 request.
+pub(crate) fn apply_extra_headers(
+    #[allow(unused_variables)] options: &ClientOptions,
+    #[allow(unused_mut)] mut request: RequestBuilder,
+) -> RequestBuilder {
+    #[cfg(feature = "test-harness")]
+    if let Some(ref extra) = options.extra_capture_headers {
+        for (k, v) in extra {
+            request = request.header(k.as_str(), v.as_str());
+        }
+    }
+    request
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,6 +207,9 @@ mod tests {
                 is_server: true,
             },
         );
+        // Mirrors the no-hooks case in `build_batch_payload`, where the trim runs
+        // right after `prepare_event` since `apply_before_send_hooks` is a no-op.
+        event.apply_minimal_flag_called_allowlist();
 
         let keys: HashSet<&str> = event.properties().keys().map(String::as_str).collect();
         let allow: HashSet<&str> = MINIMAL_FLAG_CALLED_EVENT_PROPERTIES
@@ -253,18 +273,43 @@ mod tests {
         );
         assert!(event.properties().contains_key("$lib_version__major"));
     }
-}
 
-/// Apply test-harness extra headers to a V0 request.
-pub(crate) fn apply_extra_headers(
-    #[allow(unused_variables)] options: &ClientOptions,
-    #[allow(unused_mut)] mut request: RequestBuilder,
-) -> RequestBuilder {
-    #[cfg(feature = "test-harness")]
-    if let Some(ref extra) = options.extra_capture_headers {
-        for (k, v) in extra {
-            request = request.header(k.as_str(), v.as_str());
-        }
+    #[test]
+    fn before_send_hook_cannot_reintroduce_properties_after_minimal_trim() {
+        let mut event = Event::new("$feature_flag_called", "user-1");
+        event.mark_minimal_flag_called();
+        event
+            .insert_prop("$feature_flag", json!("my-flag"))
+            .unwrap();
+
+        // A hook that stamps a non-allowlisted property, the way a real
+        // before_send hook (env tags, app version, user metadata) would.
+        let hooks = vec![BeforeSendHook::new(|mut event| {
+            event.insert_prop("from_hook", json!("leak")).unwrap();
+            Some(event)
+        })];
+
+        let (json_body, kept) = build_batch_payload(
+            vec![event],
+            "phc_test".to_string(),
+            false,
+            Utc::now(),
+            &CaptureDefaults {
+                disable_geoip: true,
+                is_server: true,
+            },
+            &hooks,
+        )
+        .unwrap()
+        .expect("event should not be dropped");
+
+        assert_eq!(kept, 1);
+        let parsed: serde_json::Value = serde_json::from_str(&json_body).unwrap();
+        let properties = &parsed["batch"][0]["properties"];
+        assert!(
+            properties.get("from_hook").is_none(),
+            "before_send hook property survived the minimal-event allowlist trim: {:?}",
+            properties
+        );
     }
-    request
 }

--- a/src/client/v0_capture.rs
+++ b/src/client/v0_capture.rs
@@ -27,6 +27,9 @@ pub(crate) fn prepare_event(event: &mut Event, defaults: &CaptureDefaults) {
     apply_capture_defaults(event, defaults);
     apply_runtime_context(event);
     event.prepare_for_v0();
+    // Final step: for minimized `$feature_flag_called` events, drop everything
+    // outside the allowlist now that system context and SDK metadata are stamped.
+    event.apply_minimal_flag_called_allowlist();
 }
 
 // ---------------------------------------------------------------------------
@@ -144,6 +147,113 @@ pub(crate) fn prepare_immediate(
 // ---------------------------------------------------------------------------
 // Header helpers
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::MINIMAL_FLAG_CALLED_EVENT_PROPERTIES;
+    use serde_json::json;
+    use std::collections::HashSet;
+
+    /// Build a `$feature_flag_called` event carrying the full property set the
+    /// snapshot path would produce, plus a non-allowlisted extra to prove
+    /// nothing leaks past the allowlist.
+    fn full_flag_called_event() -> Event {
+        let mut event = Event::new("$feature_flag_called", "user-1");
+        event.add_group("company", "acme");
+        for (k, v) in [
+            ("$feature_flag", json!("my-flag")),
+            ("$feature_flag_response", json!(true)),
+            ("$feature/my-flag", json!(true)),          // stripped
+            ("$feature_flag_payload", json!({"a": 1})), // stripped
+            ("$feature_flag_has_experiment", json!(false)),
+            ("$feature_flag_id", json!(42)),
+            ("$feature_flag_version", json!(7)),
+            ("$feature_flag_reason", json!("condition match")),
+            ("$feature_flag_request_id", json!("req-1")),
+            ("locally_evaluated", json!(false)),
+            ("custom_super_property", json!("leak")), // stripped
+        ] {
+            event.insert_prop(k, v).unwrap();
+        }
+        event
+    }
+
+    #[test]
+    fn minimal_flag_called_event_keeps_only_allowlisted_properties() {
+        let mut event = full_flag_called_event();
+        event.mark_minimal_flag_called();
+        prepare_event(
+            &mut event,
+            &CaptureDefaults {
+                disable_geoip: true,
+                is_server: true,
+            },
+        );
+
+        let keys: HashSet<&str> = event.properties().keys().map(String::as_str).collect();
+        let allow: HashSet<&str> = MINIMAL_FLAG_CALLED_EVENT_PROPERTIES
+            .iter()
+            .copied()
+            .collect();
+
+        // Every surviving key is on the allowlist — the enrichment step's
+        // `$lib_version__major/minor/patch`, `$feature/<key>`,
+        // `$feature_flag_payload`, and the custom super property are all gone.
+        assert!(
+            keys.is_subset(&allow),
+            "unexpected keys leaked: {:?}",
+            keys.difference(&allow).collect::<Vec<_>>()
+        );
+        // Allowlisted evaluation + system-context props are retained.
+        for expected in [
+            "$feature_flag",
+            "$feature_flag_response",
+            "$feature_flag_has_experiment",
+            "locally_evaluated",
+            "$groups",
+            "$geoip_disable",
+            "$is_server",
+            "$lib",
+            "$lib_version",
+            "$os",
+            "$os_version",
+        ] {
+            assert!(
+                keys.contains(expected),
+                "missing allowlisted key {}",
+                expected
+            );
+        }
+        assert!(!keys.contains("$feature/my-flag"));
+        assert!(!keys.contains("$feature_flag_payload"));
+        assert!(!keys.contains("custom_super_property"));
+        assert!(!keys.contains("$lib_version__major"));
+    }
+
+    #[test]
+    fn non_minimal_flag_called_event_keeps_everything() {
+        let mut event = full_flag_called_event();
+        prepare_event(
+            &mut event,
+            &CaptureDefaults {
+                disable_geoip: true,
+                is_server: true,
+            },
+        );
+        // No minimization marker -> the full shape is preserved, including the
+        // super property and `$feature/<key>`.
+        assert_eq!(
+            event.properties().get("custom_super_property"),
+            Some(&json!("leak"))
+        );
+        assert_eq!(
+            event.properties().get("$feature/my-flag"),
+            Some(&json!(true))
+        );
+        assert!(event.properties().contains_key("$lib_version__major"));
+    }
+}
 
 /// Apply test-harness extra headers to a V0 request.
 pub(crate) fn apply_extra_headers(

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::client::get_default_user_agent;
 use crate::error::Error;
-use crate::event::Event;
+use crate::event::{Event, MINIMAL_FLAG_CALLED_EVENT_PROPERTIES};
 use crate::event_v1::{
     CaptureResponse, EventResult, EventStatus, V1BatchRequestRef, V1ErrorResponse, V1Event,
 };
@@ -41,6 +41,7 @@ pub(crate) fn build_events_at(
         .map(|event| {
             let mut event = event.clone();
             apply_runtime_context(&mut event);
+            let minimal = event.is_minimal_flag_called();
             let mut v1 = V1Event::from_event_at(&event, now);
             if let serde_json::Value::Object(ref mut map) = v1.properties {
                 if defaults.disable_geoip {
@@ -50,6 +51,15 @@ pub(crate) fn build_events_at(
                 if defaults.is_server {
                     map.entry("$is_server")
                         .or_insert(serde_json::Value::Bool(true));
+                }
+                // Final step for minimized `$feature_flag_called` events: drop
+                // everything outside the allowlist. Wire-lifted keys
+                // ($session_id/$window_id/$process_person_profile) already moved
+                // off `properties` and are preserved on the event elsewhere.
+                if minimal {
+                    map.retain(|key, _| {
+                        MINIMAL_FLAG_CALLED_EVENT_PROPERTIES.contains(&key.as_str())
+                    });
                 }
             }
             v1
@@ -362,6 +372,75 @@ mod tests {
             .retry_max_backoff_ms(5000u64)
             .build()
             .unwrap()
+    }
+
+    #[test]
+    fn minimal_flag_called_event_v1_keeps_only_allowlisted_properties() {
+        use std::collections::HashSet;
+
+        let mut event = Event::new("$feature_flag_called", "user-1");
+        event.mark_minimal_flag_called();
+        event.add_group("company", "acme");
+        for (k, v) in [
+            ("$feature_flag", serde_json::json!("my-flag")),
+            ("$feature_flag_response", serde_json::json!(true)),
+            ("$feature/my-flag", serde_json::json!(true)), // stripped
+            ("$feature_flag_payload", serde_json::json!({"a": 1})), // stripped
+            ("$feature_flag_has_experiment", serde_json::json!(false)),
+            ("locally_evaluated", serde_json::json!(false)),
+            ("custom_super_property", serde_json::json!("leak")), // stripped
+        ] {
+            event.insert_prop(k, v).unwrap();
+        }
+
+        let defaults = CaptureDefaults {
+            disable_geoip: true,
+            is_server: true,
+        };
+        let built = build_events_at(&[event], &defaults, Utc::now());
+        let map = built[0].properties.as_object().unwrap();
+        let keys: HashSet<&str> = map.keys().map(String::as_str).collect();
+        let allow: HashSet<&str> = MINIMAL_FLAG_CALLED_EVENT_PROPERTIES
+            .iter()
+            .copied()
+            .collect();
+
+        assert!(
+            keys.is_subset(&allow),
+            "unexpected keys leaked: {:?}",
+            keys.difference(&allow).collect::<Vec<_>>()
+        );
+        assert!(keys.contains("$feature_flag"));
+        assert!(keys.contains("$feature_flag_has_experiment"));
+        assert!(keys.contains("$groups"));
+        assert!(keys.contains("$geoip_disable"));
+        assert!(keys.contains("$os"));
+        assert!(!keys.contains("$feature/my-flag"));
+        assert!(!keys.contains("$feature_flag_payload"));
+        assert!(!keys.contains("custom_super_property"));
+    }
+
+    #[test]
+    fn non_minimal_flag_called_event_v1_keeps_everything() {
+        let mut event = Event::new("$feature_flag_called", "user-1");
+        event
+            .insert_prop("$feature/my-flag", serde_json::json!(true))
+            .unwrap();
+        event
+            .insert_prop("custom_super_property", serde_json::json!("keep"))
+            .unwrap();
+
+        let defaults = CaptureDefaults {
+            disable_geoip: false,
+            is_server: false,
+        };
+        let built = build_events_at(&[event], &defaults, Utc::now());
+        let map = built[0].properties.as_object().unwrap();
+        assert_eq!(
+            map.get("custom_super_property"),
+            Some(&serde_json::json!("keep"))
+        );
+        assert_eq!(map.get("$feature/my-flag"), Some(&serde_json::json!(true)));
     }
 
     fn dummy_v1_event() -> V1Event {

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::client::get_default_user_agent;
 use crate::error::Error;
-use crate::event::{Event, MINIMAL_FLAG_CALLED_EVENT_PROPERTIES};
+use crate::event::{is_minimal_flag_called_property, Event};
 use crate::event_v1::{
     CaptureResponse, EventResult, EventStatus, V1BatchRequestRef, V1ErrorResponse, V1Event,
 };
@@ -57,9 +57,7 @@ pub(crate) fn build_events_at(
                 // ($session_id/$window_id/$process_person_profile) already moved
                 // off `properties` and are preserved on the event elsewhere.
                 if minimal {
-                    map.retain(|key, _| {
-                        MINIMAL_FLAG_CALLED_EVENT_PROPERTIES.contains(&key.as_str())
-                    });
+                    map.retain(|key, _| is_minimal_flag_called_property(key));
                 }
             }
             v1
@@ -362,6 +360,7 @@ mod tests {
 
     use super::*;
     use crate::client::ClientOptionsBuilder;
+    use crate::event::MINIMAL_FLAG_CALLED_EVENT_PROPERTIES;
     use crate::event_v1::{CaptureResponse, EventResult, EventStatus, V1Event};
 
     fn test_opts() -> ClientOptions {

--- a/src/event.rs
+++ b/src/event.rs
@@ -49,6 +49,15 @@ pub(crate) const MINIMAL_FLAG_CALLED_EVENT_PROPERTIES: &[&str] = &[
     "$os_version",
 ];
 
+/// Whether `key` survives minimization to [`MINIMAL_FLAG_CALLED_EVENT_PROPERTIES`].
+/// Shared by the V0 (`Event::apply_minimal_flag_called_allowlist`) and V1
+/// (`v1_capture::build_events_at`) capture pipelines so the allowlist check
+/// itself has one implementation even though each pipeline applies it to a
+/// different properties representation.
+pub(crate) fn is_minimal_flag_called_property(key: &str) -> bool {
+    MINIMAL_FLAG_CALLED_EVENT_PROPERTIES.contains(&key)
+}
+
 /// An [`Event`] represents an interaction a user has with your app or
 /// website. Examples include button clicks, pageviews, query completions, and signups.
 /// See the [PostHog documentation](https://posthog.com/docs/data/events)
@@ -292,7 +301,7 @@ impl Event {
     pub(crate) fn apply_minimal_flag_called_allowlist(&mut self) {
         if self.minimal_flag_called {
             self.properties
-                .retain(|key, _| MINIMAL_FLAG_CALLED_EVENT_PROPERTIES.contains(&key.as_str()));
+                .retain(|key, _| is_minimal_flag_called_property(key));
         }
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,6 +9,46 @@ use crate::client::CRATE_VERSION;
 use crate::feature_flag_evaluations::FeatureFlagEvaluations;
 use crate::Error;
 
+/// The only properties retained on a minimized `$feature_flag_called` event.
+///
+/// A fresh allowlist (rather than a denylist) so nothing added upstream — super
+/// properties, context, user-supplied properties, SDK metadata, system context —
+/// can leak past it. Applied as the final capture-pipeline step, after all
+/// enrichment, so the resulting event carries exactly this set intersected with
+/// what the full event would have had. Beyond the evaluation properties it keeps
+/// cheap, static, low-cardinality identity useful for platform/runtime
+/// breakdowns (`$lib`, `$lib_version`, `$os`, `$os_version`), processing-control
+/// sentinels this SDK sets (`$geoip_disable`, `$process_person_profile`,
+/// `$is_server`), correctness-required `$groups`, and linkage identifiers.
+pub(crate) const MINIMAL_FLAG_CALLED_EVENT_PROPERTIES: &[&str] = &[
+    // Identity
+    "$feature_flag",
+    "$feature_flag_response",
+    "$feature_flag_has_experiment",
+    // Evaluation debug
+    "$feature_flag_id",
+    "$feature_flag_version",
+    "$feature_flag_reason",
+    "$feature_flag_request_id",
+    "$feature_flag_evaluated_at",
+    "$feature_flag_error",
+    "locally_evaluated",
+    // Correctness-required / processing-control
+    "$groups",
+    "$process_person_profile",
+    "$geoip_disable",
+    // Linkage / SDK identity
+    "$session_id",
+    "$window_id",
+    "$device_id",
+    "$lib",
+    "$lib_version",
+    "$is_server",
+    // Static platform/runtime identity
+    "$os",
+    "$os_version",
+];
+
 /// An [`Event`] represents an interaction a user has with your app or
 /// website. Examples include button clicks, pageviews, query completions, and signups.
 /// See the [PostHog documentation](https://posthog.com/docs/data/events)
@@ -21,6 +61,11 @@ pub struct Event {
     groups: HashMap<String, String>,
     timestamp: Option<NaiveDateTime>,
     uuid: Uuid,
+    /// When set, the capture pipeline trims this event's properties to
+    /// [`MINIMAL_FLAG_CALLED_EVENT_PROPERTIES`] as its final enrichment step.
+    /// Set only for minimized `$feature_flag_called` events; never serialized.
+    #[serde(skip)]
+    minimal_flag_called: bool,
 }
 
 impl Event {
@@ -41,6 +86,7 @@ impl Event {
             groups: HashMap::new(),
             timestamp: None,
             uuid: Uuid::now_v7(),
+            minimal_flag_called: false,
         }
     }
 
@@ -69,6 +115,7 @@ impl Event {
             groups: HashMap::new(),
             timestamp: None,
             uuid: Uuid::now_v7(),
+            minimal_flag_called: false,
         }
     }
 
@@ -222,6 +269,31 @@ impl Event {
     #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
     pub(crate) fn groups(&self) -> &HashMap<String, String> {
         &self.groups
+    }
+
+    /// Mark this event as a minimized `$feature_flag_called` event. The capture
+    /// pipeline then trims its properties to
+    /// [`MINIMAL_FLAG_CALLED_EVENT_PROPERTIES`] after all enrichment.
+    pub(crate) fn mark_minimal_flag_called(&mut self) {
+        self.minimal_flag_called = true;
+    }
+
+    /// Whether this event is a minimized `$feature_flag_called` event.
+    #[cfg_attr(not(feature = "capture-v1"), allow(dead_code))]
+    pub(crate) fn is_minimal_flag_called(&self) -> bool {
+        self.minimal_flag_called
+    }
+
+    /// Trim this event's properties to [`MINIMAL_FLAG_CALLED_EVENT_PROPERTIES`]
+    /// when it is a minimized `$feature_flag_called` event; a no-op otherwise.
+    /// Called as the final capture step so no property added upstream survives
+    /// outside the allowlist.
+    #[cfg_attr(feature = "capture-v1", allow(dead_code))]
+    pub(crate) fn apply_minimal_flag_called_allowlist(&mut self) {
+        if self.minimal_flag_called {
+            self.properties
+                .retain(|key, _| MINIMAL_FLAG_CALLED_EVENT_PROPERTIES.contains(&key.as_str()));
+        }
     }
 
     /// Inject SDK metadata and `$groups` into V0 properties.

--- a/src/feature_flag_evaluations.rs
+++ b/src/feature_flag_evaluations.rs
@@ -31,6 +31,16 @@ pub(crate) struct EvaluatedFlagRecord {
     pub version: Option<u32>,
     pub reason: Option<String>,
     pub locally_evaluated: bool,
+    /// Server-reported experiment linkage for this flag. Tri-state: `Some(bool)`
+    /// when reported, `None` when unknown. Drives `$feature_flag_has_experiment`
+    /// and, with the gate below, event minimization.
+    pub has_experiment: Option<bool>,
+    /// The minimal-`$feature_flag_called` gate captured from the source that
+    /// produced this record (the poller's local definitions or the remote
+    /// `/flags` response). Pinned per record so the minimization decision uses
+    /// the value tied to this flag's evaluation, never a later read of shared
+    /// mutable client state.
+    pub minimal_flag_called_events: bool,
 }
 
 /// Parameters dispatched to [`FeatureFlagEvaluationsHost::capture_flag_called_event_if_needed`]
@@ -43,6 +53,10 @@ pub(crate) struct FlagCalledEventParams {
     pub groups: HashMap<String, String>,
     pub disable_geoip: Option<bool>,
     pub properties: HashMap<String, Value>,
+    /// Whether this event should be minimized to the strict property allowlist.
+    /// Decided by [`FeatureFlagEvaluations::record_access`] from the flag's own
+    /// pinned gate and experiment signal, then applied as the final capture step.
+    pub minimal: bool,
 }
 
 /// Dependency-inverted host interface used by [`FeatureFlagEvaluations`] to
@@ -301,6 +315,13 @@ impl FeatureFlagEvaluations {
         let response = flag.map(flag_value_for);
         let properties = self.build_called_event_properties(key, flag, &response);
 
+        // Minimize iff the gate pinned on this flag's record is on AND the flag
+        // is known to have no linked experiment. Any missing signal (gate off,
+        // experiment unknown, experiment-linked, or missing flag) keeps the full
+        // event shape. Read from the per-flag record, never from shared state.
+        let minimal =
+            flag.is_some_and(|f| f.minimal_flag_called_events && f.has_experiment == Some(false));
+
         self.host
             .capture_flag_called_event_if_needed(FlagCalledEventParams {
                 distinct_id: self.distinct_id.clone(),
@@ -309,6 +330,7 @@ impl FeatureFlagEvaluations {
                 groups: self.groups.clone(),
                 disable_geoip: self.disable_geoip,
                 properties,
+                minimal,
             });
     }
 
@@ -329,6 +351,13 @@ impl FeatureFlagEvaluations {
 
         let locally_evaluated = flag.is_some_and(|f| f.locally_evaluated);
         props.insert("locally_evaluated".into(), json!(locally_evaluated));
+
+        // Record the server's experiment signal when known, so minimization's
+        // impact can be segmented by it. Omitted entirely when unknown (never
+        // fabricated as `false`).
+        if let Some(has_experiment) = flag.and_then(|f| f.has_experiment) {
+            props.insert("$feature_flag_has_experiment".into(), json!(has_experiment));
+        }
 
         if let Some(flag) = flag {
             if let Some(payload) = &flag.payload {
@@ -453,6 +482,8 @@ mod tests {
             version: Some(7),
             reason: Some("condition match".into()),
             locally_evaluated,
+            has_experiment: None,
+            minimal_flag_called_events: false,
         }
     }
 
@@ -704,6 +735,173 @@ mod tests {
         let _ = child.is_enabled("alpha");
         // Parent's accessed set is still {"alpha"}, not affected by child reads.
         assert_eq!(snap.snapshot_accessed().len(), 1);
+    }
+
+    /// Build a snapshot holding a single flag with an explicit experiment
+    /// signal and pinned minimization gate, mirroring what `evaluate_flags`
+    /// produces per source.
+    fn snapshot_with_flag(
+        host: Arc<dyn FeatureFlagEvaluationsHost>,
+        has_experiment: Option<bool>,
+        minimal_flag_called_events: bool,
+    ) -> FeatureFlagEvaluations {
+        let mut flags = HashMap::new();
+        flags.insert(
+            "gated".into(),
+            EvaluatedFlagRecord {
+                has_experiment,
+                minimal_flag_called_events,
+                ..record("gated", true, None, false)
+            },
+        );
+        FeatureFlagEvaluations::new(
+            host,
+            "u1".into(),
+            flags,
+            HashMap::new(),
+            None,
+            Some("req-1".into()),
+            Some(1700000000),
+            false,
+            false,
+        )
+    }
+
+    #[test]
+    fn has_experiment_true_sets_property() {
+        let host = Arc::new(RecordingHost::default());
+        let snap = snapshot_with_flag(
+            Arc::clone(&host) as Arc<dyn FeatureFlagEvaluationsHost>,
+            Some(true),
+            false,
+        );
+        let _ = snap.is_enabled("gated");
+        let captured = host.captured.lock().unwrap();
+        assert_eq!(
+            captured[0].properties.get("$feature_flag_has_experiment"),
+            Some(&json!(true))
+        );
+    }
+
+    #[test]
+    fn has_experiment_false_sets_property() {
+        let host = Arc::new(RecordingHost::default());
+        let snap = snapshot_with_flag(
+            Arc::clone(&host) as Arc<dyn FeatureFlagEvaluationsHost>,
+            Some(false),
+            false,
+        );
+        let _ = snap.is_enabled("gated");
+        let captured = host.captured.lock().unwrap();
+        assert_eq!(
+            captured[0].properties.get("$feature_flag_has_experiment"),
+            Some(&json!(false))
+        );
+    }
+
+    #[test]
+    fn has_experiment_unknown_omits_property() {
+        let host = Arc::new(RecordingHost::default());
+        let snap = snapshot_with_flag(
+            Arc::clone(&host) as Arc<dyn FeatureFlagEvaluationsHost>,
+            None,
+            true,
+        );
+        let _ = snap.is_enabled("gated");
+        let captured = host.captured.lock().unwrap();
+        // Never fabricated as false when the server did not report it.
+        assert!(!captured[0]
+            .properties
+            .contains_key("$feature_flag_has_experiment"));
+    }
+
+    #[test]
+    fn minimizes_only_when_gate_on_and_no_experiment() {
+        // (has_experiment, gate) -> expected `minimal`
+        let cases = [
+            (Some(false), true, true),   // gate on, no experiment -> minimize
+            (Some(true), true, false),   // experiment-linked -> full
+            (None, true, false),         // experiment unknown -> full
+            (Some(false), false, false), // gate off -> full
+        ];
+        for (has_experiment, gate, expected) in cases {
+            let host = Arc::new(RecordingHost::default());
+            let snap = snapshot_with_flag(
+                Arc::clone(&host) as Arc<dyn FeatureFlagEvaluationsHost>,
+                has_experiment,
+                gate,
+            );
+            let _ = snap.is_enabled("gated");
+            let captured = host.captured.lock().unwrap();
+            assert_eq!(
+                captured[0].minimal, expected,
+                "has_experiment={:?} gate={} should minimal={}",
+                has_experiment, gate, expected
+            );
+        }
+    }
+
+    #[test]
+    fn missing_flag_is_never_minimized() {
+        let host = Arc::new(RecordingHost::default());
+        let snap = snapshot_with_flag(
+            Arc::clone(&host) as Arc<dyn FeatureFlagEvaluationsHost>,
+            Some(false),
+            true,
+        );
+        // A key absent from the snapshot has no pinned gate/experiment signal,
+        // so it always keeps the full shape.
+        let _ = snap.get_flag("not-present");
+        let captured = host.captured.lock().unwrap();
+        assert!(!captured[0].minimal);
+    }
+
+    #[test]
+    fn gate_is_pinned_per_flag_not_shared_across_a_snapshot() {
+        // Two flags in ONE snapshot with different pinned gates: a local flag
+        // whose definitions had the gate on, and a remote flag whose /flags
+        // response had it off. Each event must reflect its own source's gate.
+        // Guards against collapsing the gate into a single shared snapshot field.
+        let host = Arc::new(RecordingHost::default());
+        let mut flags = HashMap::new();
+        flags.insert(
+            "local-gated".into(),
+            EvaluatedFlagRecord {
+                has_experiment: Some(false),
+                minimal_flag_called_events: true,
+                ..record("local-gated", true, None, true)
+            },
+        );
+        flags.insert(
+            "remote-ungated".into(),
+            EvaluatedFlagRecord {
+                has_experiment: Some(false),
+                minimal_flag_called_events: false,
+                ..record("remote-ungated", true, None, false)
+            },
+        );
+        let snap = FeatureFlagEvaluations::new(
+            Arc::clone(&host) as Arc<dyn FeatureFlagEvaluationsHost>,
+            "u1".into(),
+            flags,
+            HashMap::new(),
+            None,
+            Some("req-1".into()),
+            Some(1700000000),
+            false,
+            false,
+        );
+
+        let _ = snap.is_enabled("local-gated");
+        let _ = snap.is_enabled("remote-ungated");
+
+        let captured = host.captured.lock().unwrap();
+        let by_key: HashMap<&str, bool> = captured
+            .iter()
+            .map(|p| (p.key.as_str(), p.minimal))
+            .collect();
+        assert_eq!(by_key.get("local-gated"), Some(&true));
+        assert_eq!(by_key.get("remote-ungated"), Some(&false));
     }
 
     #[test]

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -102,6 +102,12 @@ pub struct FeatureFlag {
     /// Targeting rules and rollout configuration
     #[serde(default)]
     pub filters: FeatureFlagFilters,
+    /// Whether the flag is linked to an experiment, as reported by the
+    /// local-evaluation definitions endpoint. Tri-state: `Some(true)`/`Some(false)`
+    /// when the server reports it, `None` when it does not (older server). Drives
+    /// the `$feature_flag_has_experiment` property and event minimization.
+    #[serde(default)]
+    pub has_experiment: Option<bool>,
 }
 
 /// Targeting rules and configuration for a feature flag.
@@ -312,6 +318,12 @@ pub enum FeatureFlagsResponse {
         #[serde(rename = "requestId")]
         #[serde(default)]
         request_id: Option<String>,
+        /// Server-controlled gate: when `true`, `$feature_flag_called` events for
+        /// non-experiment flags evaluated from this response are minimized to a
+        /// strict property allowlist. Absent (older server) fails safe to `false`.
+        #[serde(rename = "minimalFlagCalledEvents")]
+        #[serde(default)]
+        minimal_flag_called_events: bool,
     },
     /// Legacy format from older decide endpoint
     Legacy {
@@ -419,6 +431,12 @@ pub struct FlagMetadata {
     pub description: Option<String>,
     /// Optional JSON payload associated with the flag
     pub payload: Option<serde_json::Value>,
+    /// Whether the flag is linked to an experiment. Tri-state: `Some(true)`/
+    /// `Some(false)` when the `/flags?v=2` metadata reports it, `None` when it is
+    /// absent (older server or degraded response). Drives the
+    /// `$feature_flag_has_experiment` property and event minimization.
+    #[serde(default)]
+    pub has_experiment: Option<bool>,
 }
 
 const LONG_SCALE: f64 = 0xFFFFFFFFFFFFFFFu64 as f64; // Must be exactly 15 F's to match Python SDK
@@ -1374,6 +1392,7 @@ mod tests {
         let flag = FeatureFlag {
             key: "test-flag".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![FeatureFlagCondition {
                     properties: vec![],
@@ -1424,6 +1443,7 @@ mod tests {
         let flag = FeatureFlag {
             key: "test-flag".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![FeatureFlagCondition {
                     properties: vec![],
@@ -1473,6 +1493,7 @@ mod tests {
         let flag = FeatureFlag {
             key: "inactive-flag".to_string(),
             active: false,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![FeatureFlagCondition {
                     properties: vec![],
@@ -1505,6 +1526,7 @@ mod tests {
         let flag = FeatureFlag {
             key: "rollout-flag".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![FeatureFlagCondition {
                     properties: vec![],
@@ -1646,6 +1668,7 @@ mod tests {
         let flag = FeatureFlag {
             key: "empty-groups".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![],
                 multivariate: None,
@@ -2049,6 +2072,7 @@ mod tests {
             FeatureFlag {
                 key: "prerequisite-flag".to_string(),
                 active: true,
+                has_experiment: None,
                 filters: FeatureFlagFilters {
                     groups: vec![FeatureFlagCondition {
                         properties: vec![],
@@ -2094,6 +2118,7 @@ mod tests {
             FeatureFlag {
                 key: "disabled-flag".to_string(),
                 active: false, // Flag is inactive
+                has_experiment: None,
                 filters: FeatureFlagFilters {
                     groups: vec![],
                     multivariate: None,
@@ -2134,6 +2159,7 @@ mod tests {
             FeatureFlag {
                 key: "ab-test-flag".to_string(),
                 active: true,
+                has_experiment: None,
                 filters: FeatureFlagFilters {
                     groups: vec![FeatureFlagCondition {
                         properties: vec![],
@@ -3247,6 +3273,7 @@ mod tests {
         FeatureFlag {
             key: "early-exit-flag".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![
                     // Group 1: matches on properties (none) but rollout excludes
@@ -3366,6 +3393,7 @@ mod tests {
         let flag = FeatureFlag {
             key: "early-exit-flag".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![
                     FeatureFlagCondition {
@@ -3451,6 +3479,7 @@ mod tests {
         let flag = FeatureFlag {
             key: "early-exit-flag".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![
                     FeatureFlagCondition {

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -66,6 +66,11 @@ pub struct LocalEvaluationResponse {
     /// Cohort definitions for evaluating cohort membership
     #[serde(default)]
     pub cohorts: HashMap<String, Cohort>,
+    /// Server-controlled gate: when `true`, `$feature_flag_called` events for
+    /// non-experiment flags evaluated from these definitions are minimized to a
+    /// strict property allowlist. Absent fails safe to `false` (full event).
+    #[serde(default)]
+    pub minimal_flag_called_events: bool,
 }
 
 /// A cohort definition for local evaluation.
@@ -92,6 +97,11 @@ pub struct FlagCache {
     flags: Arc<RwLock<HashMap<String, FeatureFlag>>>,
     group_type_mapping: Arc<RwLock<HashMap<String, String>>>,
     cohorts: Arc<RwLock<HashMap<String, Cohort>>>,
+    /// The `minimal_flag_called_events` gate from the most recent definitions
+    /// poll. Read once when a local evaluation succeeds and pinned onto that
+    /// flag's record, so the minimization decision reflects the definitions
+    /// snapshot that produced the value.
+    minimal_flag_called_events: Arc<RwLock<bool>>,
 }
 
 impl Default for FlagCache {
@@ -107,6 +117,7 @@ impl FlagCache {
             flags: Arc::new(RwLock::new(HashMap::new())),
             group_type_mapping: Arc::new(RwLock::new(HashMap::new())),
             cohorts: Arc::new(RwLock::new(HashMap::new())),
+            minimal_flag_called_events: Arc::new(RwLock::new(false)),
         }
     }
 
@@ -126,7 +137,16 @@ impl FlagCache {
         let mut cohorts = self.cohorts.write().unwrap();
         *cohorts = response.cohorts;
 
+        *self.minimal_flag_called_events.write().unwrap() = response.minimal_flag_called_events;
+
         debug!(flag_count, "Updated flag cache");
+    }
+
+    /// Whether the most recent definitions poll enabled minimal
+    /// `$feature_flag_called` events. `false` until definitions load, so a
+    /// missing signal always yields full events.
+    pub fn minimal_flag_called_events(&self) -> bool {
+        *self.minimal_flag_called_events.read().unwrap()
     }
 
     /// Return a cached feature flag by key.

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -101,7 +101,7 @@ pub struct FlagCache {
     /// poll. Read once when a local evaluation succeeds and pinned onto that
     /// flag's record, so the minimization decision reflects the definitions
     /// snapshot that produced the value.
-    minimal_flag_called_events: Arc<RwLock<bool>>,
+    minimal_flag_called_events: Arc<AtomicBool>,
 }
 
 impl Default for FlagCache {
@@ -117,7 +117,7 @@ impl FlagCache {
             flags: Arc::new(RwLock::new(HashMap::new())),
             group_type_mapping: Arc::new(RwLock::new(HashMap::new())),
             cohorts: Arc::new(RwLock::new(HashMap::new())),
-            minimal_flag_called_events: Arc::new(RwLock::new(false)),
+            minimal_flag_called_events: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -137,7 +137,8 @@ impl FlagCache {
         let mut cohorts = self.cohorts.write().unwrap();
         *cohorts = response.cohorts;
 
-        *self.minimal_flag_called_events.write().unwrap() = response.minimal_flag_called_events;
+        self.minimal_flag_called_events
+            .store(response.minimal_flag_called_events, Ordering::Relaxed);
 
         debug!(flag_count, "Updated flag cache");
     }
@@ -146,12 +147,22 @@ impl FlagCache {
     /// `$feature_flag_called` events. `false` until definitions load, so a
     /// missing signal always yields full events.
     pub fn minimal_flag_called_events(&self) -> bool {
-        *self.minimal_flag_called_events.read().unwrap()
+        self.minimal_flag_called_events.load(Ordering::Relaxed)
     }
 
     /// Return a cached feature flag by key.
     pub fn get_flag(&self, key: &str) -> Option<FeatureFlag> {
         self.flags.read().unwrap().get(key).cloned()
+    }
+
+    /// Return a flag's `has_experiment` signal without cloning the full
+    /// [`FeatureFlag`] (its filters can hold nested `Vec`s and JSON values).
+    pub(crate) fn has_experiment(&self, key: &str) -> Option<bool> {
+        self.flags
+            .read()
+            .unwrap()
+            .get(key)
+            .and_then(|f| f.has_experiment)
     }
 
     /// Return all cached feature flag definitions.

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -28,6 +28,7 @@ fn test_local_evaluation_basic() {
     let flag = FeatureFlag {
         key: "test-flag".to_string(),
         active: true,
+        has_experiment: None,
         filters: FeatureFlagFilters {
             groups: vec![FeatureFlagCondition {
                 properties: vec![],
@@ -47,6 +48,7 @@ fn test_local_evaluation_basic() {
         flags: vec![flag],
         group_type_mapping: HashMap::new(),
         cohorts: HashMap::new(),
+        minimal_flag_called_events: false,
     };
     cache.update(response);
 
@@ -73,6 +75,7 @@ fn test_local_evaluation_with_properties() {
     let flag = FeatureFlag {
         key: "premium-feature".to_string(),
         active: true,
+        has_experiment: None,
         filters: FeatureFlagFilters {
             groups: vec![FeatureFlagCondition {
                 properties: vec![Property {
@@ -97,6 +100,7 @@ fn test_local_evaluation_with_properties() {
         flags: vec![flag],
         group_type_mapping: HashMap::new(),
         cohorts: HashMap::new(),
+        minimal_flag_called_events: false,
     };
     cache.update(response);
 
@@ -387,6 +391,7 @@ fn test_cache_operations() {
         FeatureFlag {
             key: "flag1".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![],
                 multivariate: None,
@@ -398,6 +403,7 @@ fn test_cache_operations() {
         FeatureFlag {
             key: "flag2".to_string(),
             active: true,
+            has_experiment: None,
             filters: FeatureFlagFilters {
                 groups: vec![],
                 multivariate: None,
@@ -412,6 +418,7 @@ fn test_cache_operations() {
         flags: flags.clone(),
         group_type_mapping: HashMap::new(),
         cohorts: HashMap::new(),
+        minimal_flag_called_events: false,
     };
 
     cache.update(response);
@@ -892,6 +899,7 @@ fn mixed_flag() -> FeatureFlag {
     FeatureFlag {
         key: "mixed-flag".to_string(),
         active: true,
+        has_experiment: None,
         filters: FeatureFlagFilters {
             groups: vec![
                 // Group condition: company plan == enterprise
@@ -931,6 +939,7 @@ fn only_group_flag() -> FeatureFlag {
     FeatureFlag {
         key: "only-group-flag".to_string(),
         active: true,
+        has_experiment: None,
         filters: FeatureFlagFilters {
             groups: vec![FeatureFlagCondition {
                 properties: vec![Property {
@@ -960,6 +969,7 @@ fn cache_with(flag: FeatureFlag) -> FlagCache {
         flags: vec![flag],
         group_type_mapping,
         cohorts: HashMap::new(),
+        minimal_flag_called_events: false,
     });
     cache
 }
@@ -1062,6 +1072,7 @@ fn test_mixed_flag_only_group_condition_no_groups_returns_false() {
     let flag = FeatureFlag {
         key: "mixed-only-group".to_string(),
         active: true,
+        has_experiment: None,
         filters: FeatureFlagFilters {
             groups: vec![FeatureFlagCondition {
                 properties: vec![Property {
@@ -1102,6 +1113,7 @@ fn test_group_condition_uses_group_key_for_bucketing() {
     let flag = FeatureFlag {
         key: "rollout-flag".to_string(),
         active: true,
+        has_experiment: None,
         filters: FeatureFlagFilters {
             groups: vec![FeatureFlagCondition {
                 properties: vec![],

--- a/tests/test_minimal_flag_called_events.rs
+++ b/tests/test_minimal_flag_called_events.rs
@@ -1,0 +1,273 @@
+//! End-to-end coverage for minimized `$feature_flag_called` events over the
+//! remote `/flags?v=2` path: the server-controlled `minimalFlagCalledEvents`
+//! gate plus each flag's `has_experiment` decide whether the captured event
+//! keeps its full property set or is trimmed to the strict allowlist.
+//!
+//! Uses a small recording HTTP server (rather than httpmock) so the exact
+//! `$feature_flag_called` request body can be inspected.
+
+#![cfg(feature = "async-client")]
+
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use posthog_rs::EvaluateFlagsOptions;
+
+#[cfg(feature = "capture-v1")]
+const CAPTURE_PATH: &str = "/i/v1/analytics/events";
+#[cfg(not(feature = "capture-v1"))]
+const CAPTURE_PATH: &str = "/batch/";
+
+/// The full minimal-event allowlist, mirrored from the crate-internal constant
+/// so this black-box test can assert nothing outside it survives.
+const ALLOWLIST: &[&str] = &[
+    "$feature_flag",
+    "$feature_flag_response",
+    "$feature_flag_has_experiment",
+    "$feature_flag_id",
+    "$feature_flag_version",
+    "$feature_flag_reason",
+    "$feature_flag_request_id",
+    "$feature_flag_evaluated_at",
+    "$feature_flag_error",
+    "locally_evaluated",
+    "$groups",
+    "$process_person_profile",
+    "$geoip_disable",
+    "$session_id",
+    "$window_id",
+    "$device_id",
+    "$lib",
+    "$lib_version",
+    "$is_server",
+    "$os",
+    "$os_version",
+];
+
+fn flags_fixture(gate: bool) -> Value {
+    let mut body = json!({
+        "flags": {
+            "plain": {
+                "key": "plain",
+                "enabled": true,
+                "variant": null,
+                "reason": { "code": "condition_match", "description": "matched", "condition_index": 0 },
+                "metadata": { "id": 1, "version": 2, "description": null, "payload": null, "has_experiment": false }
+            },
+            "experiment": {
+                "key": "experiment",
+                "enabled": true,
+                "variant": "test",
+                "reason": { "code": "condition_match", "description": "matched", "condition_index": 0 },
+                "metadata": { "id": 2, "version": 3, "description": null, "payload": null, "has_experiment": true }
+            }
+        },
+        "requestId": "req-xyz"
+    });
+    if gate {
+        body["minimalFlagCalledEvents"] = json!(true);
+    }
+    body
+}
+
+/// A minimal recording HTTP server that answers `/flags/` with the fixture and
+/// records the bodies POSTed to the capture endpoint.
+struct RecordingServer {
+    base_url: String,
+    captured: Arc<Mutex<Vec<Vec<u8>>>>,
+    stop: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for RecordingServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn read_request(stream: &mut std::net::TcpStream) -> Option<(String, Vec<u8>)> {
+    stream.set_read_timeout(Some(Duration::from_secs(1))).ok()?;
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 2048];
+    // Read until headers are complete.
+    let header_end = loop {
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            break pos + 4;
+        }
+        match stream.read(&mut chunk) {
+            Ok(0) => return None,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(_) => return None,
+        }
+    };
+    let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.trim().eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+    let mut body = buf[header_end..].to_vec();
+    while body.len() < content_length {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => body.extend_from_slice(&chunk[..n]),
+            Err(_) => break,
+        }
+    }
+    Some((headers, body))
+}
+
+fn start_recording_server(gate: bool) -> RecordingServer {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind recording server");
+    listener.set_nonblocking(true).expect("set nonblocking");
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let thread_captured = Arc::clone(&captured);
+    let thread_stop = Arc::clone(&stop);
+    let flags_body = flags_fixture(gate).to_string();
+
+    let handle = thread::spawn(move || {
+        while !thread_stop.load(Ordering::SeqCst) {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let Some((headers, body)) = read_request(&mut stream) else {
+                        continue;
+                    };
+                    let request_line = headers.lines().next().unwrap_or("");
+                    let response_body = if request_line.contains("/flags/") {
+                        flags_body.clone()
+                    } else {
+                        if request_line.contains(CAPTURE_PATH) {
+                            thread_captured.lock().unwrap().push(body);
+                        }
+                        "{\"results\":{}}".to_string()
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    RecordingServer {
+        base_url,
+        captured,
+        stop,
+        handle: Some(handle),
+    }
+}
+
+/// Drive one flag evaluation through the real client and return the properties
+/// of the captured `$feature_flag_called` event.
+async fn captured_flag_called_properties(
+    gate: bool,
+    flag_key: &str,
+) -> serde_json::Map<String, Value> {
+    let server = start_recording_server(gate);
+
+    let options: posthog_rs::ClientOptions = ("phc_test", server.base_url.as_str()).into();
+    let client = posthog_rs::client(options).await;
+    let snapshot = client
+        .evaluate_flags("user-1", EvaluateFlagsOptions::default())
+        .await
+        .expect("evaluate_flags");
+    let _ = snapshot.is_enabled(flag_key);
+    client.flush().await;
+
+    // Poll briefly for the capture request the background worker sends.
+    let started = Instant::now();
+    loop {
+        if let Some(props) = extract_flag_called(&server.captured.lock().unwrap()) {
+            return props;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "no $feature_flag_called event was captured"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn extract_flag_called(bodies: &[Vec<u8>]) -> Option<serde_json::Map<String, Value>> {
+    for body in bodies {
+        let parsed: Value = serde_json::from_slice(body).ok()?;
+        let batch = parsed.get("batch").and_then(Value::as_array)?;
+        for event in batch {
+            if event.get("event").and_then(Value::as_str) == Some("$feature_flag_called") {
+                return event.get("properties").and_then(Value::as_object).cloned();
+            }
+        }
+    }
+    None
+}
+
+#[tokio::test]
+async fn remote_gate_on_no_experiment_sends_minimal_event() {
+    let props = captured_flag_called_properties(true, "plain").await;
+
+    for key in props.keys() {
+        assert!(
+            ALLOWLIST.contains(&key.as_str()),
+            "unexpected key leaked: {}",
+            key
+        );
+    }
+    assert_eq!(props.get("$feature_flag"), Some(&json!("plain")));
+    assert_eq!(props.get("$feature_flag_response"), Some(&json!(true)));
+    assert_eq!(
+        props.get("$feature_flag_has_experiment"),
+        Some(&json!(false))
+    );
+    assert_eq!(props.get("locally_evaluated"), Some(&json!(false)));
+    // The bulky per-flag mirror is stripped.
+    assert!(!props.contains_key("$feature/plain"));
+}
+
+#[tokio::test]
+async fn remote_experiment_linked_keeps_full_event() {
+    let props = captured_flag_called_properties(true, "experiment").await;
+    // Experiment-linked flags always keep the full shape for exposure analysis.
+    assert_eq!(
+        props.get("$feature_flag_has_experiment"),
+        Some(&json!(true))
+    );
+    assert_eq!(props.get("$feature/experiment"), Some(&json!("test")));
+}
+
+#[tokio::test]
+async fn remote_gate_off_keeps_full_event() {
+    let props = captured_flag_called_properties(false, "plain").await;
+    // Gate absent -> full event even though the flag has no experiment.
+    assert_eq!(
+        props.get("$feature_flag_has_experiment"),
+        Some(&json!(false))
+    );
+    assert_eq!(props.get("$feature/plain"), Some(&json!(true)));
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

`$feature_flag_called` events carry the full enriched properties dict on every flag evaluation, even for flags with no linked experiment. This adds the same minimization already shipped or in review across the other PostHog SDKs (Python, Go, .NET, Node/JS, iOS, Android, Flutter, PHP, Ruby, Elixir).

Every event gets a tri-state `$feature_flag_has_experiment` property, sourced from each flag's `has_experiment` field on the remote `/flags?v=2` metadata or the local `/flags/definitions` payload. It's sent as true or false when the server reports it and omitted when it doesn't.

Minimization is gated by two server-controlled booleans, both failing safe to the full event shape when absent: `minimalFlagCalledEvents` on the remote response and `minimal_flag_called_events` on the local-evaluation payload. An event is minimized only when its gate is on and the flag's `has_experiment` is exactly false. The gate and experiment signal are pinned onto each flag's evaluation record at the moment its value is determined, from whichever source produced it, so a concurrent poller refresh or another `/flags` call can't reshape an event after the fact.

Both the v0 and capture-v1 wire pipelines apply the allowlist as the final step in `build_batch_payload`, after `before_send` runs, so a hook can't reintroduce a stripped property and nothing outside the allowlist can leak in.

## :green_heart: How did you test it?

Decision-matrix tests covering gate on/off crossed with has_experiment true/false/missing, exact-allowlist assertions on both wire paths, remote and local end-to-end tests, and regression tests proving the gate is tied to the evaluation source rather than shared client state. `cargo test` passes across all feature combinations, `cargo clippy --all-targets --all-features -D warnings` is clean, `cargo fmt` applied.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file