### PR TITLE
feat: support starts_with and ends_with operators in local evaluation

### DIFF
--- a/.sampo/changesets/starts-with-ends-with-operators.md
+++ b/.sampo/changesets/starts-with-ends-with-operators.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fall back to remote evaluation.

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -165,7 +165,8 @@ pub struct Property {
     /// The value to compare against
     pub value: serde_json::Value,
     /// Comparison operator. Supported property operators include `"exact"`,
-    /// `"is_not"`, `"icontains"`, `"not_icontains"`, `"regex"`,
+    /// `"is_not"`, `"icontains"`, `"not_icontains"`, `"starts_with"`,
+    /// `"not_starts_with"`, `"ends_with"`, `"not_ends_with"`, `"regex"`,
     /// `"not_regex"`, `"gt"`, `"gte"`, `"lt"`, `"lte"`, `"is_set"`,
     /// `"is_not_set"`, `"is_date_before"`, `"is_date_after"`, and the
     /// `"semver_*"` operators used by PostHog version targeting.
@@ -1225,6 +1226,34 @@ fn match_property(
             let search_str = value_to_string(&property.value);
             !prop_str.to_lowercase().contains(&search_str.to_lowercase())
         }
+        "starts_with" => {
+            let prop_str = value_to_string(value);
+            let search_str = value_to_string(&property.value);
+            prop_str
+                .to_lowercase()
+                .starts_with(&search_str.to_lowercase())
+        }
+        "not_starts_with" => {
+            let prop_str = value_to_string(value);
+            let search_str = value_to_string(&property.value);
+            !prop_str
+                .to_lowercase()
+                .starts_with(&search_str.to_lowercase())
+        }
+        "ends_with" => {
+            let prop_str = value_to_string(value);
+            let search_str = value_to_string(&property.value);
+            prop_str
+                .to_lowercase()
+                .ends_with(&search_str.to_lowercase())
+        }
+        "not_ends_with" => {
+            let prop_str = value_to_string(value);
+            let search_str = value_to_string(&property.value);
+            !prop_str
+                .to_lowercase()
+                .ends_with(&search_str.to_lowercase())
+        }
         "regex" => {
             let prop_str = value_to_string(value);
             let regex_str = value_to_string(&property.value);
@@ -1596,6 +1625,116 @@ mod tests {
 
         properties.insert("name".to_string(), json!("regular_user"));
         assert!(!match_property(&prop, &properties).unwrap());
+    }
+
+    #[test]
+    fn test_starts_with_operator() {
+        let prop = Property {
+            key: "name".to_string(),
+            value: json!("Val"),
+            operator: "starts_with".to_string(),
+            property_type: None,
+        };
+
+        // Case-insensitive match anchored to the start.
+        let mut properties = HashMap::new();
+        properties.insert("name".to_string(), json!("value"));
+        assert!(match_property(&prop, &properties).unwrap());
+
+        properties.insert("name".to_string(), json!("VALUE"));
+        assert!(match_property(&prop, &properties).unwrap());
+
+        // Substring present but not at the start.
+        properties.insert("name".to_string(), json!("prevalue"));
+        assert!(!match_property(&prop, &properties).unwrap());
+
+        properties.insert("name".to_string(), json!("Alakazam"));
+        assert!(!match_property(&prop, &properties).unwrap());
+
+        // Numeric property values are stringified before matching.
+        let numeric_prop = Property {
+            key: "name".to_string(),
+            value: json!("3"),
+            operator: "starts_with".to_string(),
+            property_type: None,
+        };
+
+        properties.insert("name".to_string(), json!(323));
+        assert!(match_property(&numeric_prop, &properties).unwrap());
+
+        properties.insert("name".to_string(), json!(123));
+        assert!(!match_property(&numeric_prop, &properties).unwrap());
+
+        let negated_prop = Property {
+            key: "name".to_string(),
+            value: json!("Val"),
+            operator: "not_starts_with".to_string(),
+            property_type: None,
+        };
+
+        properties.insert("name".to_string(), json!("value"));
+        assert!(!match_property(&negated_prop, &properties).unwrap());
+
+        properties.insert("name".to_string(), json!("prevalue"));
+        assert!(match_property(&negated_prop, &properties).unwrap());
+
+        // Missing property is inconclusive.
+        assert!(match_property(&prop, &HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn test_ends_with_operator() {
+        let prop = Property {
+            key: "name".to_string(),
+            value: json!("lUe"),
+            operator: "ends_with".to_string(),
+            property_type: None,
+        };
+
+        // Case-insensitive match anchored to the end.
+        let mut properties = HashMap::new();
+        properties.insert("name".to_string(), json!("value"));
+        assert!(match_property(&prop, &properties).unwrap());
+
+        properties.insert("name".to_string(), json!("VALUE"));
+        assert!(match_property(&prop, &properties).unwrap());
+
+        // Substring present but not at the end.
+        properties.insert("name".to_string(), json!("value2"));
+        assert!(!match_property(&prop, &properties).unwrap());
+
+        properties.insert("name".to_string(), json!("Alakazam"));
+        assert!(!match_property(&prop, &properties).unwrap());
+
+        // Numeric property values are stringified before matching.
+        let numeric_prop = Property {
+            key: "name".to_string(),
+            value: json!("3"),
+            operator: "ends_with".to_string(),
+            property_type: None,
+        };
+
+        properties.insert("name".to_string(), json!(323));
+        assert!(match_property(&numeric_prop, &properties).unwrap());
+
+        properties.insert("name".to_string(), json!(321));
+        assert!(!match_property(&numeric_prop, &properties).unwrap());
+
+        let negated_prop = Property {
+            key: "name".to_string(),
+            value: json!("lUe"),
+            operator: "not_ends_with".to_string(),
+            property_type: None,
+        };
+
+        properties.insert("name".to_string(), json!("value"));
+        assert!(!match_property(&negated_prop, &properties).unwrap());
+
+        properties.insert("name".to_string(), json!("value2"));
+        assert!(match_property(&negated_prop, &properties).unwrap());
+
+        // Missing property is inconclusive.
+        assert!(match_property(&prop, &HashMap::new()).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog/posthog#72992 added four case-insensitive property filter operators — `starts_with`, `not_starts_with`, `ends_with`, `not_ends_with` — across HogQL, the flags service, and the UI. The UI surface is gated behind a feature flag until server-side SDKs can evaluate these operators locally; on SDK versions without support, flags using them fall back to remote evaluation.

This adds local evaluation support for the four operators, mirroring `icontains`: both sides are stringified and lowercased, and the `not_` variants are exact negations. Filter values are single strings — server-side validation rejects list values for these operators, matching the flags service behavior.

## :green_heart: How did you test it?

New unit tests mirror the flags service's own test matrix for these operators: case-insensitive anchored matching, mid-string non-matches (`prevalue` does not match `starts_with: "Val"`), numeric stringification (`323` matches `starts_with: "3"`, `123` does not), negation inverses, and missing-key inconclusive behavior.

`cargo test --lib feature_flags::tests` passes locally (81 tests, including the new `test_starts_with_operator` and `test_ends_with_operator`); `cargo fmt` and `cargo clippy` are clean for the changed code.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a changeset file (minor)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
