### PR TITLE
fix(ci): sign the commit this workflow opens against posthog

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -86,6 +86,10 @@ jobs:
           HUSKY: "0"
         with:
           token: ${{ steps.upgrader.outputs.token }}
+          # PostHog/posthog requires signed commits, so the bump has to be
+          # committed through the GitHub API rather than pushed with git.
+          # This works only because the token above comes from a GitHub App.
+          sign-commits: true
           commit-message: "chore(deps): Update ${{ github.event.inputs.package_name }} to ${{ github.event.inputs.package_version }}"
           branch: ${{ steps.generate-branch-name.outputs.branch_name }}
           delete-branch: true


### PR DESCRIPTION
## :bulb: Motivation and Context

`posthog-upgrade.yml` opens a PR against `PostHog/posthog` with `peter-evans/create-pull-request`, which pushes the commit with plain `git` by default. `PostHog/posthog` is covered by the org's "Require signed commits" ruleset (no bypass actors), so that push is rejected and the upgrade PR is never opened. Setting `sign-commits: true` routes the commit through the GitHub API instead, where GitHub signs it with its own key and attributes it to the app that owns the token.

Found while inventorying org-wide which workflows still create unsigned commits, ahead of enabling the signing ruleset for every repo. `PostHog/posthog-js`'s copy of this same workflow already sets `sign-commits: true`, so this brings the Rust SDK in line with it.

The step already authenticates with a GitHub App token. That matters: `create-pull-request` only signs when the token is bot-generated, so this input would silently do nothing with a PAT.

## :green_heart: How did you test it?

Not run end to end, since the workflow is `workflow_dispatch`-only and fires on a real SDK release. The change is a single documented input on an action already pinned at v8.0.0, which has supported `sign-commits` since v7, and `actionlint` is clean on the file. No Rust code is touched, so the build, test, fmt, clippy, and public-API checks are unaffected.

Worth watching the next release-triggered run to confirm the PR opens and its commit shows as Verified.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
