### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers:
+      - "PostHog/team-client-libraries"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    cooldown:
-      default-days: 7
+  - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: weekly
-    reviewers:
-      - "PostHog/team-client-libraries"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## :bulb: Motivation and Context

Configure Dependabot for both dependency sources used by this repository:

- Cargo dependencies for the root workspace, including the compliance adapter workspace member.
- GitHub Actions dependencies for repository workflows.

Both ecosystems run weekly from `/` with a seven-day default cooldown. Review ownership remains assigned automatically by the existing repository-wide `CODEOWNERS` rule (`@PostHog/team-client-libraries`), rather than a Dependabot-specific `reviewers` field.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` as YAML and asserted version 2; the exact `cargo`, `github-actions` ecosystem order; root directories; weekly schedules; seven-day cooldowns; allowed keys; and absence of `reviewers`.
- Ran `cargo metadata --no-deps --format-version 1` and confirmed the root workspace includes `Cargo.toml` and `compliance/adapter/Cargo.toml`.
- Ran `git diff --check origin/main...HEAD`.
- Ran branch autoreview against `origin/main`; it reported no accepted or actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
