### PR TITLE
chore(deps): bump httpmock from 0.7.0 to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,15 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,39 +58,6 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -115,141 +73,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.2",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-object-pool"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
 dependencies = [
- "async-std",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
  "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.2",
- "futures-lite",
- "rustix",
+ "event-listener",
 ]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -307,10 +149,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -338,8 +180,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -366,41 +208,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "basic-cookies"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
-dependencies = [
- "lalrpop",
- "lalrpop-util",
- "regex",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -424,19 +234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -471,6 +268,9 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -558,15 +358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,12 +405,6 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -718,27 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,21 +536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "either"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
-
-[[package]]
-name = "ena"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,12 +553,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
@@ -824,7 +567,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.2",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -837,12 +580,6 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -861,12 +598,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -948,19 +679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +700,12 @@ name = "futures-task"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1044,15 +768,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
+name = "h2"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
- "futures-channel",
+ "atomic-waker",
+ "bytes",
+ "fnv",
  "futures-core",
- "js-sys",
- "wasm-bindgen",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1062,20 +793,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
+name = "headers"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
 
 [[package]]
-name = "http"
-version = "0.2.12"
+name = "headers-core"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "bytes",
- "fnv",
- "itoa",
+ "http",
 ]
 
 [[package]]
@@ -1090,23 +828,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.5.0",
+ "http",
 ]
 
 [[package]]
@@ -1117,8 +844,8 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1136,53 +863,36 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
- "async-std",
  "async-trait",
- "base64 0.21.7",
- "basic-cookies",
+ "base64",
+ "bytes",
  "crossbeam-utils",
  "form_urlencoded",
+ "futures-timer",
  "futures-util",
- "hyper 0.14.32",
- "lazy_static",
- "levenshtein",
- "log",
+ "headers",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "path-tree",
  "regex",
  "serde",
  "serde_json",
  "serde_regex",
  "similar",
+ "stringmetrics",
+ "tabwriter",
+ "thiserror",
  "tokio",
- "url",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
  "tracing",
- "want",
+ "url",
 ]
 
 [[package]]
@@ -1195,8 +905,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.5.0",
- "http-body 1.1.0",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1212,8 +923,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.5.0",
- "hyper 1.11.0",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "tokio",
@@ -1227,18 +938,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
- "hyper 1.11.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1400,15 +1111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,7 +1128,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.20",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -1485,71 +1187,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
-
-[[package]]
-name = "libredox"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "link-section"
@@ -1562,12 +1209,6 @@ name = "linktime-proc-macro"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1589,9 +1230,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru-slab"
@@ -1646,12 +1284,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1909,35 +1541,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -1946,41 +1562,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "posthog-rs"
@@ -2021,12 +1606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,8 +1627,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
- "thiserror 2.0.20",
+ "socket2",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2072,7 +1651,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.20",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2087,7 +1666,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2143,17 +1722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,15 +1756,15 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -2254,19 +1822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2563,12 +2118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,16 +2128,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -2607,16 +2146,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
+name = "stringmetrics"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
 
 [[package]]
 name = "strsim"
@@ -2629,17 +2162,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2684,23 +2206,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
+name = "tabwriter"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
 dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2709,18 +2220,7 @@ version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.20",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2741,15 +2241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2789,7 +2280,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2824,6 +2315,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2855,8 +2347,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -2960,10 +2452,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
+name = "unicode-width"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"
@@ -3006,12 +2498,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068e763e8279de7ab94b6afebded2cb701678af094feb1c12ccb061b4783c1be"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ zstd = { version = "0.13", optional = true }
 dotenv = "0.15.0"
 ctor = "1.0.12"
 tokio = { version = "1", features = ["full"] }
-httpmock = "0.7"
+httpmock = "0.8"
 serde_json = "1.0"
 futures = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -1485,10 +1485,7 @@ mod tests {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.method(POST).matches(|req| {
-                let Some(bytes) = req.body.as_deref() else {
-                    return false;
-                };
-                let Ok(json) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+                let Ok(json) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
                     return false;
                 };
                 let event_ts = json["batch"][0]["timestamp"].as_str().and_then(parse_ts);

--- a/src/error_tracking.rs
+++ b/src/error_tracking.rs
@@ -1775,10 +1775,7 @@ mod tests {
     /// Match the panic `$exception` event inside the transport's batch envelope
     /// (`batch[0]`) — the same event shape for the V0 and V1 wire formats.
     fn request_has_panic_payload(req: &HttpMockRequest) -> bool {
-        let Some(body) = req.body.as_deref() else {
-            return false;
-        };
-        let Ok(body) = serde_json::from_slice::<Value>(body) else {
+        let Ok(body) = serde_json::from_slice::<Value>(req.body_ref()) else {
             return false;
         };
         let event = &body["batch"][0];
@@ -1913,7 +1910,7 @@ mod tests {
         let server = MockServer::start();
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
-                .body_contains(r#""value":"tokio task boom""#);
+                .body_includes(r#""value":"tokio task boom""#);
             then.status(200);
         });
         let options = ClientOptionsBuilder::default()

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -532,7 +532,7 @@ async fn test_capture_batch_sends_to_batch_endpoint() {
         when.method(POST)
             .path("/batch/")
             .header(USER_AGENT.to_string(), default_user_agent())
-            .body_contains(r#""historical_migration":false"#);
+            .body_includes(r#""historical_migration":false"#);
         then.status(200);
     });
 
@@ -553,7 +553,7 @@ async fn test_capture_batch_historical_migration() {
     let batch_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/batch/")
-            .body_contains(r#""historical_migration":true"#);
+            .body_includes(r#""historical_migration":true"#);
         then.status(200);
     });
 
@@ -617,7 +617,7 @@ async fn v0_capture_injects_is_server_by_default() {
         when.method(POST)
             .path("/batch/")
             .header(USER_AGENT.to_string(), default_user_agent())
-            .body_contains("\"$is_server\":true");
+            .body_includes("\"$is_server\":true");
         then.status(200).body("ok");
     });
 
@@ -644,8 +644,8 @@ async fn v0_capture_applies_runtime_context_defaults_and_preserves_caller_values
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/batch/")
-                .body_contains(expected_os)
-                .body_contains(expected_os_version);
+                .body_includes(expected_os)
+                .body_includes(expected_os_version);
             then.status(200).body("ok");
         });
 
@@ -669,7 +669,7 @@ async fn v0_capture_caller_override_wins_for_is_server() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/batch/")
-            .body_contains("\"$is_server\":false");
+            .body_includes("\"$is_server\":false");
         then.status(200).body("ok");
     });
 

--- a/tests/test_blocking.rs
+++ b/tests/test_blocking.rs
@@ -347,7 +347,7 @@ fn test_capture_batch_sends_to_batch_endpoint() {
         when.method(POST)
             .path("/batch/")
             .header(USER_AGENT.to_string(), default_user_agent())
-            .body_contains(r#""historical_migration":false"#);
+            .body_includes(r#""historical_migration":false"#);
         then.status(200);
     });
 
@@ -368,7 +368,7 @@ fn test_capture_batch_historical_migration() {
     let batch_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/batch/")
-            .body_contains(r#""historical_migration":true"#);
+            .body_includes(r#""historical_migration":true"#);
         then.status(200);
     });
 
@@ -432,7 +432,7 @@ fn v0_capture_injects_is_server_by_default() {
         when.method(POST)
             .path("/batch/")
             .header(USER_AGENT.to_string(), default_user_agent())
-            .body_contains("\"$is_server\":true");
+            .body_includes("\"$is_server\":true");
         then.status(200).body("ok");
     });
 
@@ -451,7 +451,7 @@ fn v0_capture_caller_override_wins_for_is_server() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/batch/")
-            .body_contains("\"$is_server\":false");
+            .body_includes("\"$is_server\":false");
         then.status(200).body("ok");
     });
 

--- a/tests/test_capture_immediate.rs
+++ b/tests/test_capture_immediate.rs
@@ -210,7 +210,7 @@ mod async_v1 {
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/i/v1/analytics/events")
-                .body_contains("\"historical_migration\":true");
+                .body_includes("\"historical_migration\":true");
             then.status(200).json_body(json!({ "results": {} }));
         });
 
@@ -384,7 +384,7 @@ mod async_v0 {
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/batch/")
-                .body_contains("\"historical_migration\":true");
+                .body_includes("\"historical_migration\":true");
             then.status(200);
         });
 
@@ -397,10 +397,7 @@ mod async_v0 {
     }
 
     fn body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
-        let Some(body) = req.body.as_ref() else {
-            return false;
-        };
-        let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+        let mut decoder = flate2::read::GzDecoder::new(req.body_ref());
         let mut decoded = String::new();
         match decoder.read_to_string(&mut decoded) {
             Ok(_) => decoded.contains(r#""distinct_id":"user1""#),

--- a/tests/test_error_tracking.rs
+++ b/tests/test_error_tracking.rs
@@ -33,10 +33,7 @@ impl fmt::Display for PanicDisplayError {
 impl StdError for PanicDisplayError {}
 
 fn request_has_capture_exception_user_frame_last(req: &HttpMockRequest) -> bool {
-    let Some(body) = req.body.as_deref() else {
-        return false;
-    };
-    let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
         return false;
     };
     // Canonical wire order is outermost first, so the capture-site user frame
@@ -49,10 +46,7 @@ fn request_has_capture_exception_user_frame_last(req: &HttpMockRequest) -> bool 
 }
 
 fn request_has_capture_exception_with_user_frame_last(req: &HttpMockRequest) -> bool {
-    let Some(body) = req.body.as_deref() else {
-        return false;
-    };
-    let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
         return false;
     };
     let crash_function = last_exception_stack_function(&body);
@@ -63,10 +57,7 @@ fn request_has_capture_exception_with_user_frame_last(req: &HttpMockRequest) -> 
 }
 
 fn request_has_no_stacktrace(req: &HttpMockRequest) -> bool {
-    let Some(body) = req.body.as_deref() else {
-        return false;
-    };
-    let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
         return false;
     };
 
@@ -102,12 +93,12 @@ mod blocking {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/batch/")
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""$process_person_profile":false"#)
-                .body_contains(r#""$exception_level":"error""#)
-                .body_contains(r#""value":"payment failed""#)
-                .body_contains(r#""platform":"native""#)
-                .body_contains(r#""lang":"rust""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""$process_person_profile":false"#)
+                .body_includes(r#""$exception_level":"error""#)
+                .body_includes(r#""value":"payment failed""#)
+                .body_includes(r#""platform":"native""#)
+                .body_includes(r#""lang":"rust""#)
                 .matches(request_has_capture_exception_user_frame_last);
             then.status(200);
         });
@@ -125,12 +116,12 @@ mod blocking {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/batch/")
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""distinct_id":"user-1""#)
-                .body_contains(r#""route":"/checkout""#)
-                .body_contains(r#""$groups":{"company":"company-1"}"#)
-                .body_contains(r#""$exception_fingerprint":"checkout-error""#)
-                .body_contains(r#""$exception_level":"warning""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""distinct_id":"user-1""#)
+                .body_includes(r#""route":"/checkout""#)
+                .body_includes(r#""$groups":{"company":"company-1"}"#)
+                .body_includes(r#""$exception_fingerprint":"checkout-error""#)
+                .body_includes(r#""$exception_level":"warning""#)
                 .matches(request_has_capture_exception_with_user_frame_last);
             then.status(200);
         });
@@ -178,8 +169,8 @@ mod blocking {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/batch/")
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""value":"payment failed""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""value":"payment failed""#)
                 .matches(request_has_no_stacktrace);
             then.status(200);
         });
@@ -220,12 +211,12 @@ mod async_client {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/batch/")
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""$process_person_profile":false"#)
-                .body_contains(r#""$exception_level":"error""#)
-                .body_contains(r#""value":"payment failed""#)
-                .body_contains(r#""platform":"native""#)
-                .body_contains(r#""lang":"rust""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""$process_person_profile":false"#)
+                .body_includes(r#""$exception_level":"error""#)
+                .body_includes(r#""value":"payment failed""#)
+                .body_includes(r#""platform":"native""#)
+                .body_includes(r#""lang":"rust""#)
                 .matches(request_has_capture_exception_user_frame_last);
             then.status(200);
         });
@@ -243,12 +234,12 @@ mod async_client {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/batch/")
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""distinct_id":"user-1""#)
-                .body_contains(r#""route":"/checkout""#)
-                .body_contains(r#""$groups":{"company":"company-1"}"#)
-                .body_contains(r#""$exception_fingerprint":"checkout-error""#)
-                .body_contains(r#""$exception_level":"warning""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""distinct_id":"user-1""#)
+                .body_includes(r#""route":"/checkout""#)
+                .body_includes(r#""$groups":{"company":"company-1"}"#)
+                .body_includes(r#""$exception_fingerprint":"checkout-error""#)
+                .body_includes(r#""$exception_level":"warning""#)
                 .matches(request_has_capture_exception_with_user_frame_last);
             then.status(200);
         });
@@ -298,8 +289,8 @@ mod async_client {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/batch/")
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""value":"payment failed""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""value":"payment failed""#)
                 .matches(request_has_no_stacktrace);
             then.status(200);
         });

--- a/tests/test_error_tracking_v1.rs
+++ b/tests/test_error_tracking_v1.rs
@@ -47,10 +47,7 @@ fn last_exception_stack_function(body: &serde_json::Value) -> &str {
 }
 
 fn request_has_capture_exception_user_frame_last(req: &HttpMockRequest) -> bool {
-    let Some(body) = req.body.as_deref() else {
-        return false;
-    };
-    let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
         return false;
     };
     // Canonical wire order is outermost first, so the capture-site user frame
@@ -63,10 +60,7 @@ fn request_has_capture_exception_user_frame_last(req: &HttpMockRequest) -> bool 
 }
 
 fn request_has_capture_exception_with_user_frame_last(req: &HttpMockRequest) -> bool {
-    let Some(body) = req.body.as_deref() else {
-        return false;
-    };
-    let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
         return false;
     };
     let crash_function = last_exception_stack_function(&body);
@@ -97,11 +91,11 @@ mod blocking {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(V1_CAPTURE_PATH)
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""process_person_profile":false"#)
-                .body_contains(r#""$exception_level":"error""#)
-                .body_contains(r#""value":"payment failed""#)
-                .body_contains(r#""platform":"native""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""process_person_profile":false"#)
+                .body_includes(r#""$exception_level":"error""#)
+                .body_includes(r#""value":"payment failed""#)
+                .body_includes(r#""platform":"native""#)
                 .matches(request_has_capture_exception_user_frame_last);
             then.status(200)
                 .header("content-type", "application/json")
@@ -121,12 +115,12 @@ mod blocking {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(V1_CAPTURE_PATH)
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""distinct_id":"user-1""#)
-                .body_contains(r#""route":"/checkout""#)
-                .body_contains(r#""$groups":{"company":"company-1"}"#)
-                .body_contains(r#""$exception_fingerprint":"checkout-error""#)
-                .body_contains(r#""$exception_level":"warning""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""distinct_id":"user-1""#)
+                .body_includes(r#""route":"/checkout""#)
+                .body_includes(r#""$groups":{"company":"company-1"}"#)
+                .body_includes(r#""$exception_fingerprint":"checkout-error""#)
+                .body_includes(r#""$exception_level":"warning""#)
                 .matches(request_has_capture_exception_with_user_frame_last);
             then.status(200)
                 .header("content-type", "application/json")
@@ -192,11 +186,11 @@ mod async_client {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(V1_CAPTURE_PATH)
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""process_person_profile":false"#)
-                .body_contains(r#""$exception_level":"error""#)
-                .body_contains(r#""value":"payment failed""#)
-                .body_contains(r#""platform":"native""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""process_person_profile":false"#)
+                .body_includes(r#""$exception_level":"error""#)
+                .body_includes(r#""value":"payment failed""#)
+                .body_includes(r#""platform":"native""#)
                 .matches(request_has_capture_exception_user_frame_last);
             then.status(200)
                 .header("content-type", "application/json")
@@ -216,12 +210,12 @@ mod async_client {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(V1_CAPTURE_PATH)
-                .body_contains(r#""event":"$exception""#)
-                .body_contains(r#""distinct_id":"user-1""#)
-                .body_contains(r#""route":"/checkout""#)
-                .body_contains(r#""$groups":{"company":"company-1"}"#)
-                .body_contains(r#""$exception_fingerprint":"checkout-error""#)
-                .body_contains(r#""$exception_level":"warning""#)
+                .body_includes(r#""event":"$exception""#)
+                .body_includes(r#""distinct_id":"user-1""#)
+                .body_includes(r#""route":"/checkout""#)
+                .body_includes(r#""$groups":{"company":"company-1"}"#)
+                .body_includes(r#""$exception_fingerprint":"checkout-error""#)
+                .body_includes(r#""$exception_level":"warning""#)
                 .matches(request_has_capture_exception_with_user_frame_last);
             then.status(200)
                 .header("content-type", "application/json")

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -634,9 +634,9 @@ mod blocking {
     fn flag_keys_forwarded_to_request_body() {
         let server = MockServer::start();
         let flags_mock = server.mock(|when, then| {
-            when.method(POST)
-                .path("/flags/")
-                .json_body_partial(json!({"flag_keys_to_evaluate": ["alpha", "beta"]}).to_string());
+            when.method(POST).path("/flags/").json_body_includes(
+                json!({"flag_keys_to_evaluate": ["alpha", "beta"]}).to_string(),
+            );
             then.status(200).json_body(flags_response_fixture());
         });
         let client = create_test_client(server.base_url());
@@ -836,8 +836,8 @@ mod blocking {
                     "posthog-sdk-info",
                     format!("posthog-rs/{}", env!("CARGO_PKG_VERSION")),
                 )
-                .body_contains("$feature_flag_called")
-                .body_contains("\"$feature_flag\":\"alpha\"");
+                .body_includes("$feature_flag_called")
+                .body_includes("\"$feature_flag\":\"alpha\"");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({ "results": {} }));
@@ -1128,8 +1128,8 @@ mod async_tests {
         let capture_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(CAPTURE_PATH)
-                .body_contains("\"$is_server\":true")
-                .body_contains("\"$lib\":\"posthog-rs\"");
+                .body_includes("\"$is_server\":true")
+                .body_includes("\"$lib\":\"posthog-rs\"");
             then.status(200);
         });
         let client = create_test_client(server.base_url()).await;
@@ -1169,7 +1169,7 @@ mod async_tests {
         let flags_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/flags/")
-                .json_body_partial(json!({"flag_keys_to_evaluate": ["alpha"]}).to_string());
+                .json_body_includes(json!({"flag_keys_to_evaluate": ["alpha"]}).to_string());
             then.status(200).json_body(flags_response_fixture());
         });
         let client = create_test_client(server.base_url()).await;
@@ -1217,8 +1217,8 @@ mod async_tests {
                     "posthog-sdk-info",
                     format!("posthog-rs/{}", env!("CARGO_PKG_VERSION")),
                 )
-                .body_contains("$feature_flag_called")
-                .body_contains("\"$feature_flag\":\"alpha\"");
+                .body_includes("$feature_flag_called")
+                .body_includes("\"$feature_flag\":\"alpha\"");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({ "results": {} }));

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -547,10 +547,8 @@ async fn test_etag_sent_on_second_poll() {
             .query_param("send_cohorts", "")
             .matches(|req| {
                 // Match only if If-None-Match header exists with the correct value
-                req.headers.as_ref().is_some_and(|headers| {
-                    headers.iter().any(|(name, value)| {
-                        name.to_lowercase() == "if-none-match" && value == "\"abc123\""
-                    })
+                req.headers_vec().iter().any(|(name, value)| {
+                    name.eq_ignore_ascii_case("if-none-match") && value == "\"abc123\""
                 })
             });
         then.status(304);
@@ -635,10 +633,8 @@ async fn test_304_preserves_cache() {
             .query_param("send_cohorts", "")
             .matches(|req| {
                 // Match only if If-None-Match header exists with the correct value
-                req.headers.as_ref().is_some_and(|headers| {
-                    headers.iter().any(|(name, value)| {
-                        name.to_lowercase() == "if-none-match" && value == "\"v1\""
-                    })
+                req.headers_vec().iter().any(|(name, value)| {
+                    name.eq_ignore_ascii_case("if-none-match") && value == "\"v1\""
                 })
             });
         then.status(304);
@@ -777,10 +773,8 @@ fn test_sync_etag_sent_on_second_poll() {
             .query_param("send_cohorts", "")
             .matches(|req| {
                 // Match only if If-None-Match header exists with the correct value
-                req.headers.as_ref().is_some_and(|headers| {
-                    headers.iter().any(|(name, value)| {
-                        name.to_lowercase() == "if-none-match" && value == "\"sync-abc123\""
-                    })
+                req.headers_vec().iter().any(|(name, value)| {
+                    name.eq_ignore_ascii_case("if-none-match") && value == "\"sync-abc123\""
                 })
             });
         then.status(304);
@@ -862,10 +856,8 @@ fn test_sync_304_preserves_cache() {
             .query_param("send_cohorts", "")
             .matches(|req| {
                 // Match only if If-None-Match header exists with the correct value
-                req.headers.as_ref().is_some_and(|headers| {
-                    headers.iter().any(|(name, value)| {
-                        name.to_lowercase() == "if-none-match" && value == "\"sync-v1\""
-                    })
+                req.headers_vec().iter().any(|(name, value)| {
+                    name.eq_ignore_ascii_case("if-none-match") && value == "\"sync-v1\""
                 })
             });
         then.status(304);

--- a/tests/test_panic_global.rs
+++ b/tests/test_panic_global.rs
@@ -28,10 +28,7 @@ fn integration_panic_site() {
 /// frames obey the canonical wire order (outermost first, crash site last) with
 /// the SDK's own capture plumbing stripped from the crash-site tail.
 fn is_panic_exception(req: &HttpMockRequest) -> bool {
-    let Some(body) = req.body.as_deref() else {
-        return false;
-    };
-    let Ok(body) = serde_json::from_slice::<serde_json::Value>(body) else {
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
         return false;
     };
     let is_panic = body.pointer("/batch/0/event").and_then(|v| v.as_str()) == Some("$exception")

--- a/tests/test_transport.rs
+++ b/tests/test_transport.rs
@@ -43,10 +43,7 @@ fn wait_for_hits(mock: &httpmock::Mock, want: usize) {
 }
 
 fn body_contains(req: &HttpMockRequest, needle: &str) -> bool {
-    req.body
-        .as_deref()
-        .map(|b| String::from_utf8_lossy(b).contains(needle))
-        .unwrap_or(false)
+    String::from_utf8_lossy(req.body_ref()).contains(needle)
 }
 
 // --- flush -----------------------------------------------------------------
@@ -187,10 +184,7 @@ async fn batcher_preserves_fifo_order_within_a_batch() {
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
         when.method(POST).matches(|r| {
-            let Some(body) = r.body.as_deref() else {
-                return false;
-            };
-            let s = String::from_utf8_lossy(body);
+            let s = String::from_utf8_lossy(r.body_ref());
             match (s.find("First"), s.find("Second"), s.find("Third")) {
                 (Some(a), Some(b), Some(c)) => a < b && b < c,
                 _ => false,

--- a/tests/test_v0_blocking_retry.rs
+++ b/tests/test_v0_blocking_retry.rs
@@ -123,7 +123,7 @@ fn retries_resend_identical_event() {
     // The mock only matches requests carrying the original UUID, so reaching
     // 3 hits proves every retry resent the same event identity.
     let mock = server.mock(|when, then| {
-        when.method(POST).body_contains(FIXED_UUID);
+        when.method(POST).body_includes(FIXED_UUID);
         then.status(503);
     });
 
@@ -140,10 +140,7 @@ fn retries_resend_identical_event() {
 
 /// Matcher: the request body is valid gzip that decodes to the expected event.
 fn body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
-    let Some(body) = req.body.as_ref() else {
-        return false;
-    };
-    let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+    let mut decoder = flate2::read::GzDecoder::new(req.body_ref());
     let mut decoded = String::new();
     match decoder.read_to_string(&mut decoded) {
         Ok(_) => decoded.contains(r#""distinct_id":"user1""#),

--- a/tests/test_v0_retry.rs
+++ b/tests/test_v0_retry.rs
@@ -128,7 +128,7 @@ async fn retries_resend_identical_event() {
     // The mock only matches requests carrying the original UUID, so reaching
     // 3 hits proves every retry resent the same event identity.
     let mock = server.mock(|when, then| {
-        when.method(POST).body_contains(FIXED_UUID);
+        when.method(POST).body_includes(FIXED_UUID);
         then.status(503);
     });
 
@@ -145,10 +145,7 @@ async fn retries_resend_identical_event() {
 
 /// Matcher: the request body is valid gzip that decodes to the expected event.
 fn body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
-    let Some(body) = req.body.as_ref() else {
-        return false;
-    };
-    let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+    let mut decoder = flate2::read::GzDecoder::new(req.body_ref());
     let mut decoded = String::new();
     match decoder.read_to_string(&mut decoded) {
         Ok(_) => decoded.contains(r#""distinct_id":"user1""#),

--- a/tests/test_v1_blocking.rs
+++ b/tests/test_v1_blocking.rs
@@ -30,10 +30,7 @@ const PARTIAL_UUID_RETRY: &str = "01920000-0000-7000-8000-0000000000a2";
 const PARTIAL_UUID_DROP: &str = "01920000-0000-7000-8000-0000000000a3";
 
 fn body_string(req: &HttpMockRequest) -> String {
-    req.body
-        .as_ref()
-        .map(|b| String::from_utf8_lossy(b).into_owned())
-        .unwrap_or_default()
+    String::from_utf8_lossy(req.body_ref()).into_owned()
 }
 
 /// Matcher: retry event present, ok event pruned.
@@ -153,8 +150,8 @@ fn v1_blocking_partial_batch_retry() {
         when.method(POST)
             .path("/i/v1/analytics/events")
             .header("posthog-attempt", "1")
-            .body_contains(PARTIAL_UUID_OK)
-            .body_contains(PARTIAL_UUID_RETRY);
+            .body_includes(PARTIAL_UUID_OK)
+            .body_includes(PARTIAL_UUID_RETRY);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(first_resp);
@@ -266,9 +263,9 @@ fn v1_blocking_whole_batch_resent_on_retryable_status() {
             when.method(POST)
                 .path("/i/v1/analytics/events")
                 .header("posthog-attempt", "2")
-                .body_contains(&uuid1_str)
-                .body_contains(&uuid2_str)
-                .body_contains(ts);
+                .body_includes(&uuid1_str)
+                .body_includes(&uuid2_str)
+                .body_includes(ts);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -321,8 +318,8 @@ fn v1_blocking_prunes_terminal_events_on_partial_retry() {
         when.method(POST)
             .path("/i/v1/analytics/events")
             .header("posthog-attempt", "1")
-            .body_contains(PARTIAL_UUID_RETRY)
-            .body_contains(PARTIAL_UUID_DROP);
+            .body_includes(PARTIAL_UUID_RETRY)
+            .body_includes(PARTIAL_UUID_DROP);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(first_resp);
@@ -390,12 +387,10 @@ fn v1_blocking_partial_retry_exhausts_attempts() {
 static CAPTURED_REQUEST_IDS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
 
 fn capture_request_id(req: &HttpMockRequest) -> bool {
-    if let Some(headers) = req.headers.as_ref() {
-        for (key, value) in headers {
-            if key.eq_ignore_ascii_case("posthog-request-id") {
-                CAPTURED_REQUEST_IDS.lock().unwrap().push(value.clone());
-                break;
-            }
+    for (key, value) in req.headers_vec() {
+        if key.eq_ignore_ascii_case("posthog-request-id") {
+            CAPTURED_REQUEST_IDS.lock().unwrap().push(value.clone());
+            break;
         }
     }
     true
@@ -512,8 +507,8 @@ fn v1_blocking_sends_event_options() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"cookieless_mode\":true")
-            .body_contains("\"process_person_profile\":false");
+            .body_includes("\"cookieless_mode\":true")
+            .body_includes("\"process_person_profile\":false");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -536,7 +531,7 @@ fn v1_blocking_injects_geoip_disable_when_configured() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"$geoip_disable\":true");
+            .body_includes("\"$geoip_disable\":true");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -562,7 +557,7 @@ fn v1_blocking_injects_is_server_by_default() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"$is_server\":true");
+            .body_includes("\"$is_server\":true");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -581,7 +576,7 @@ fn v1_blocking_caller_override_wins_for_is_server() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"$is_server\":false");
+            .body_includes("\"$is_server\":false");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -602,7 +597,7 @@ fn v1_blocking_batch_sets_historical_migration() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"historical_migration\":true");
+            .body_includes("\"historical_migration\":true");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -619,10 +614,7 @@ fn v1_blocking_batch_sets_historical_migration() {
 fn v1_body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
     use std::io::Read;
 
-    let Some(body) = req.body.as_ref() else {
-        return false;
-    };
-    let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+    let mut decoder = flate2::read::GzDecoder::new(req.body_ref());
     let mut decoded = String::new();
     match decoder.read_to_string(&mut decoded) {
         Ok(_) => decoded.contains(r#""distinct_id":"user-1""#),
@@ -668,8 +660,8 @@ fn v1_blocking_preserves_uuid_and_timestamp_across_retries() {
         when.method(POST)
             .path("/i/v1/analytics/events")
             .header("posthog-attempt", "1")
-            .body_contains(uuid.to_string())
-            .body_contains(ts);
+            .body_includes(uuid.to_string())
+            .body_includes(ts);
         then.status(503)
             .header("retry-after", "0")
             .json_body(json!({ "error": "service_unavailable" }));
@@ -678,8 +670,8 @@ fn v1_blocking_preserves_uuid_and_timestamp_across_retries() {
         when.method(POST)
             .path("/i/v1/analytics/events")
             .header("posthog-attempt", "2")
-            .body_contains(uuid.to_string())
-            .body_contains(ts);
+            .body_includes(uuid.to_string())
+            .body_includes(ts);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));

--- a/tests/test_v1_capture.rs
+++ b/tests/test_v1_capture.rs
@@ -35,10 +35,7 @@ const PARTIAL_UUID_RETRY: &str = "01920000-0000-7000-8000-0000000000a2";
 const PARTIAL_UUID_DROP: &str = "01920000-0000-7000-8000-0000000000a3";
 
 fn body_string(req: &HttpMockRequest) -> String {
-    req.body
-        .as_ref()
-        .map(|b| String::from_utf8_lossy(b).into_owned())
-        .unwrap_or_default()
+    String::from_utf8_lossy(req.body_ref()).into_owned()
 }
 
 /// Matcher: retry event present, ok event pruned.
@@ -237,8 +234,8 @@ async fn v1_capture_partial_batch_retry() {
         when.method(POST)
             .path("/i/v1/analytics/events")
             .header("posthog-attempt", "1")
-            .body_contains(PARTIAL_UUID_OK)
-            .body_contains(PARTIAL_UUID_RETRY);
+            .body_includes(PARTIAL_UUID_OK)
+            .body_includes(PARTIAL_UUID_RETRY);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(first_resp);
@@ -350,9 +347,9 @@ async fn v1_capture_whole_batch_resent_on_retryable_status() {
             when.method(POST)
                 .path("/i/v1/analytics/events")
                 .header("posthog-attempt", "2")
-                .body_contains(&uuid1_str)
-                .body_contains(&uuid2_str)
-                .body_contains(ts);
+                .body_includes(&uuid1_str)
+                .body_includes(&uuid2_str)
+                .body_includes(ts);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -447,8 +444,8 @@ async fn v1_capture_sends_event_options() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"cookieless_mode\":true")
-            .body_contains("\"process_person_profile\":false");
+            .body_includes("\"cookieless_mode\":true")
+            .body_includes("\"process_person_profile\":false");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({
@@ -473,7 +470,7 @@ async fn v1_capture_injects_geoip_disable_when_configured() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"$geoip_disable\":true");
+            .body_includes("\"$geoip_disable\":true");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -499,7 +496,7 @@ async fn v1_capture_injects_is_server_by_default() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"$is_server\":true");
+            .body_includes("\"$is_server\":true");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -526,8 +523,8 @@ async fn v1_capture_applies_runtime_context_defaults_and_preserves_caller_values
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/i/v1/analytics/events")
-                .body_contains(expected_os)
-                .body_contains(expected_os_version);
+                .body_includes(expected_os)
+                .body_includes(expected_os_version);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({ "results": {} }));
@@ -552,7 +549,7 @@ async fn v1_capture_caller_override_wins_for_is_server() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"$is_server\":false");
+            .body_includes("\"$is_server\":false");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -573,7 +570,7 @@ async fn v1_before_send_runs_after_capture_defaults() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"hook_saw_defaults\":true");
+            .body_includes("\"hook_saw_defaults\":true");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -607,7 +604,7 @@ async fn v1_batch_before_send_runs_after_capture_defaults() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"hook_saw_defaults\":true");
+            .body_includes("\"hook_saw_defaults\":true");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -641,7 +638,7 @@ async fn v1_capture_batch_sets_historical_migration() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/i/v1/analytics/events")
-            .body_contains("\"historical_migration\":true");
+            .body_includes("\"historical_migration\":true");
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -664,8 +661,8 @@ async fn v1_capture_preserves_uuid_and_timestamp_across_retries() {
         when.method(POST)
             .path("/i/v1/analytics/events")
             .header("posthog-attempt", "1")
-            .body_contains(uuid.to_string())
-            .body_contains(ts);
+            .body_includes(uuid.to_string())
+            .body_includes(ts);
         then.status(503)
             .header("retry-after", "0")
             .json_body(json!({ "error": "service_unavailable" }));
@@ -674,8 +671,8 @@ async fn v1_capture_preserves_uuid_and_timestamp_across_retries() {
         when.method(POST)
             .path("/i/v1/analytics/events")
             .header("posthog-attempt", "2")
-            .body_contains(uuid.to_string())
-            .body_contains(ts);
+            .body_includes(uuid.to_string())
+            .body_includes(ts);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(json!({ "results": {} }));
@@ -703,10 +700,7 @@ async fn v1_capture_preserves_uuid_and_timestamp_across_retries() {
 fn v1_body_gunzips_to_user1(req: &HttpMockRequest) -> bool {
     use std::io::Read;
 
-    let Some(body) = req.body.as_ref() else {
-        return false;
-    };
-    let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+    let mut decoder = flate2::read::GzDecoder::new(req.body_ref());
     let mut decoded = String::new();
     match decoder.read_to_string(&mut decoded) {
         Ok(_) => decoded.contains(r#""distinct_id":"user-1""#),
@@ -818,8 +812,8 @@ async fn v1_capture_prunes_terminal_events_on_partial_retry() {
         when.method(POST)
             .path("/i/v1/analytics/events")
             .header("posthog-attempt", "1")
-            .body_contains(PARTIAL_UUID_RETRY)
-            .body_contains(PARTIAL_UUID_DROP);
+            .body_includes(PARTIAL_UUID_RETRY)
+            .body_includes(PARTIAL_UUID_DROP);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(first_resp);
@@ -852,12 +846,10 @@ async fn v1_capture_prunes_terminal_events_on_partial_retry() {
 static CAPTURED_REQUEST_IDS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
 
 fn capture_request_id(req: &HttpMockRequest) -> bool {
-    if let Some(headers) = req.headers.as_ref() {
-        for (key, value) in headers {
-            if key.eq_ignore_ascii_case("posthog-request-id") {
-                CAPTURED_REQUEST_IDS.lock().unwrap().push(value.clone());
-                break;
-            }
+    for (key, value) in req.headers_vec() {
+        if key.eq_ignore_ascii_case("posthog-request-id") {
+            CAPTURED_REQUEST_IDS.lock().unwrap().push(value.clone());
+            break;
         }
     }
     true


### PR DESCRIPTION
## :bulb: Motivation and Context

Recreates #191, which updated the test-only `httpmock` dependency but failed because 0.8 changed request accessors and matcher names.

This upgrades `httpmock` from 0.7.0 to 0.8.3 and adapts the affected tests without changing production runtime behavior or the public API. `httpmock` remains a dev dependency, so published consumers retain the crate's Rust 1.78 MSRV; contributors need Rust 1.88+ to build the updated test dependency.

## :green_heart: How did you test it?

- `cargo test --workspace --all-features`
- `cargo test --workspace`
- `cargo test --features capture-v1`
- `cargo test --no-default-features --features capture-v1`
- `cargo test --no-default-features --features error-tracking`
- `cargo test --no-default-features --features error-tracking,capture-v1`
- `cargo test --features e2e-test --no-default-features`
- `cargo clippy -- -D warnings`
- `cargo fmt -- --check`
- `cargo publish --dry-run --locked --allow-dirty`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
