### PR TITLE
feat(flags): surface payloads from local flag evaluation

### DIFF
--- a/.sampo/changesets/local-evaluation-flag-payloads.md
+++ b/.sampo/changesets/local-evaluation-flag-payloads.md
@@ -1,0 +1,7 @@
+---
+cargo/posthog-rs: patch
+---
+
+Surface feature flag payloads from local evaluation.
+
+The definitions manifest carries each flag's payloads, but locally evaluated flags always reported `payload: None`, so `FeatureFlagEvaluations::get_flag_payload` returned nothing for them. When `flag_keys` was fully covered locally there was also no `/flags` round trip left to recover the payload from. Local evaluation now resolves the payload for the matched value (`"true"` for a boolean match, the variant key for a multivariate one) and decodes it exactly like a `/flags` payload, so a flag returns the same payload whichever path evaluated it. As a result, `$feature_flag_called` events for locally evaluated flags now carry `$feature_flag_payload`, matching remote evaluation.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -1046,7 +1046,7 @@ impl Client {
                 .or_insert_with(|| json!(distinct_id.clone()));
             let groups_owned = options.groups.clone().unwrap_or_default();
             let group_props_owned = options.group_properties.clone().unwrap_or_default();
-            let local_results = evaluator.evaluate_all_flags(
+            let local_results = evaluator.evaluate_all_flags_with_details(
                 &distinct_id,
                 &person_props_owned,
                 &groups_owned,
@@ -1062,12 +1062,15 @@ impl Client {
                         continue;
                     }
                 }
-                if let Ok(value) = result {
-                    let has_experiment = evaluator.cache().has_experiment(&key);
-                    let payload = evaluator.cache().flag_payload(&key, &value);
+                if let Ok(value) = result.result {
                     records.insert(
                         key.clone(),
-                        local_record(value, payload, has_experiment, local_minimal_gate),
+                        local_record(
+                            value,
+                            result.payload,
+                            result.has_experiment,
+                            local_minimal_gate,
+                        ),
                     );
                     locally_evaluated_keys.insert(key);
                 }

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -1064,9 +1064,10 @@ impl Client {
                 }
                 if let Ok(value) = result {
                     let has_experiment = evaluator.cache().has_experiment(&key);
+                    let payload = evaluator.cache().flag_payload(&key, &value);
                     records.insert(
                         key.clone(),
-                        local_record(value, has_experiment, local_minimal_gate),
+                        local_record(value, payload, has_experiment, local_minimal_gate),
                     );
                     locally_evaluated_keys.insert(key);
                 }
@@ -1397,5 +1398,98 @@ mod minimal_gate_tests {
             Some(&serde_json::json!(false))
         );
         assert!(captured[0].minimal);
+    }
+}
+
+#[cfg(test)]
+mod local_payload_tests {
+    use super::*;
+    use crate::client::local_payload_test_support::payload_definitions;
+    use crate::client::minimal_gate_test_support::RecordingHost;
+    use serde_json::json;
+
+    async fn snapshot() -> FeatureFlagEvaluations {
+        let cache = FlagCache::new();
+        cache.update(payload_definitions());
+        let options = ClientOptions::from(("phc_test", "http://localhost:0"));
+        let client = Client {
+            options,
+            client: HttpClient::builder().build().unwrap(),
+            local_evaluator: Some(LocalEvaluator::new(cache)),
+            _flag_poller: None,
+            flag_event_host: OnceLock::new(),
+            transport: None,
+        };
+        client
+            .flag_event_host
+            .set(Arc::new(RecordingHost::default()) as _)
+            .unwrap_or_else(|_| panic!("host already set"));
+        client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    only_evaluate_locally: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("local evaluate_flags")
+    }
+
+    /// Payloads live in the definitions manifest, so local evaluation must
+    /// surface them the same way `/flags` does — including the JSON decoding,
+    /// or the same flag would yield different payloads depending on which path
+    /// evaluated it.
+    #[tokio::test]
+    async fn local_evaluation_surfaces_payloads_matching_the_remote_shape() {
+        let snapshot = snapshot().await;
+
+        assert_eq!(
+            snapshot.get_flag_payload("json-string-payload"),
+            Some(json!({"color": "blue"}))
+        );
+        assert_eq!(
+            snapshot.get_flag_payload("parsed-payload"),
+            Some(json!({"color": "blue"}))
+        );
+        assert_eq!(
+            snapshot.get_flag_payload("quoted-string-payload"),
+            Some(json!("just text"))
+        );
+        assert_eq!(
+            snapshot.get_flag_payload("undecodable-payload"),
+            Some(json!("not json"))
+        );
+    }
+
+    #[tokio::test]
+    async fn local_payload_is_keyed_by_the_matched_variant() {
+        let snapshot = snapshot().await;
+
+        assert_eq!(
+            snapshot.get_flag("variant-payload"),
+            Some(FlagValue::String("test".to_string()))
+        );
+        assert_eq!(
+            snapshot.get_flag_payload("variant-payload"),
+            Some(json!({"tier": 2}))
+        );
+    }
+
+    #[tokio::test]
+    async fn local_payload_is_absent_without_a_matching_payload() {
+        let snapshot = snapshot().await;
+
+        assert_eq!(snapshot.get_flag_payload("no-payload"), None);
+        assert_eq!(snapshot.get_flag_payload("not-a-flag"), None);
+
+        // A missing key also yields `None`, so pin the flag down first:
+        // it was evaluated, it evaluated false, and its "true" payload
+        // stayed behind.
+        assert_eq!(
+            snapshot.get_flag("disabled-with-payload"),
+            Some(FlagValue::Boolean(false))
+        );
+        assert_eq!(snapshot.get_flag_payload("disabled-with-payload"), None);
     }
 }

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1032,7 +1032,7 @@ impl Client {
                 .or_insert_with(|| json!(distinct_id.clone()));
             let groups_owned = options.groups.clone().unwrap_or_default();
             let group_props_owned = options.group_properties.clone().unwrap_or_default();
-            let local_results = evaluator.evaluate_all_flags(
+            let local_results = evaluator.evaluate_all_flags_with_details(
                 &distinct_id,
                 &person_props_owned,
                 &groups_owned,
@@ -1048,12 +1048,15 @@ impl Client {
                         continue;
                     }
                 }
-                if let Ok(value) = result {
-                    let has_experiment = evaluator.cache().has_experiment(&key);
-                    let payload = evaluator.cache().flag_payload(&key, &value);
+                if let Ok(value) = result.result {
                     records.insert(
                         key.clone(),
-                        local_record(value, payload, has_experiment, local_minimal_gate),
+                        local_record(
+                            value,
+                            result.payload,
+                            result.has_experiment,
+                            local_minimal_gate,
+                        ),
                     );
                     locally_evaluated_keys.insert(key);
                 }

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1050,9 +1050,10 @@ impl Client {
                 }
                 if let Ok(value) = result {
                     let has_experiment = evaluator.cache().has_experiment(&key);
+                    let payload = evaluator.cache().flag_payload(&key, &value);
                     records.insert(
                         key.clone(),
-                        local_record(value, has_experiment, local_minimal_gate),
+                        local_record(value, payload, has_experiment, local_minimal_gate),
                     );
                     locally_evaluated_keys.insert(key);
                 }
@@ -1375,5 +1376,97 @@ mod minimal_gate_tests {
             Some(&serde_json::json!(false))
         );
         assert!(captured[0].minimal);
+    }
+}
+
+#[cfg(test)]
+mod local_payload_tests {
+    use super::*;
+    use crate::client::local_payload_test_support::payload_definitions;
+    use crate::client::minimal_gate_test_support::RecordingHost;
+    use serde_json::json;
+
+    fn snapshot() -> FeatureFlagEvaluations {
+        let cache = FlagCache::new();
+        cache.update(payload_definitions());
+        let options = ClientOptions::from(("phc_test", "http://localhost:0"));
+        let client = Client {
+            options,
+            client: HttpClient::builder().build().unwrap(),
+            local_evaluator: Some(LocalEvaluator::new(cache)),
+            _flag_poller: None,
+            flag_event_host: OnceLock::new(),
+            transport: None,
+        };
+        client
+            .flag_event_host
+            .set(Arc::new(RecordingHost::default()) as _)
+            .unwrap_or_else(|_| panic!("host already set"));
+        client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    only_evaluate_locally: true,
+                    ..Default::default()
+                },
+            )
+            .expect("local evaluate_flags")
+    }
+
+    /// Payloads live in the definitions manifest, so local evaluation must
+    /// surface them the same way `/flags` does — including the JSON decoding,
+    /// or the same flag would yield different payloads depending on which path
+    /// evaluated it.
+    #[test]
+    fn local_evaluation_surfaces_payloads_matching_the_remote_shape() {
+        let snapshot = snapshot();
+
+        assert_eq!(
+            snapshot.get_flag_payload("json-string-payload"),
+            Some(json!({"color": "blue"}))
+        );
+        assert_eq!(
+            snapshot.get_flag_payload("parsed-payload"),
+            Some(json!({"color": "blue"}))
+        );
+        assert_eq!(
+            snapshot.get_flag_payload("quoted-string-payload"),
+            Some(json!("just text"))
+        );
+        assert_eq!(
+            snapshot.get_flag_payload("undecodable-payload"),
+            Some(json!("not json"))
+        );
+    }
+
+    #[test]
+    fn local_payload_is_keyed_by_the_matched_variant() {
+        let snapshot = snapshot();
+
+        assert_eq!(
+            snapshot.get_flag("variant-payload"),
+            Some(FlagValue::String("test".to_string()))
+        );
+        assert_eq!(
+            snapshot.get_flag_payload("variant-payload"),
+            Some(json!({"tier": 2}))
+        );
+    }
+
+    #[test]
+    fn local_payload_is_absent_without_a_matching_payload() {
+        let snapshot = snapshot();
+
+        assert_eq!(snapshot.get_flag_payload("no-payload"), None);
+        assert_eq!(snapshot.get_flag_payload("not-a-flag"), None);
+
+        // A missing key also yields `None`, so pin the flag down first:
+        // it was evaluated, it evaluated false, and its "true" payload
+        // stayed behind.
+        assert_eq!(
+            snapshot.get_flag("disabled-with-payload"),
+            Some(FlagValue::Boolean(false))
+        );
+        assert_eq!(snapshot.get_flag_payload("disabled-with-payload"), None);
     }
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -274,6 +274,7 @@ pub(super) fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFl
 
 pub(super) fn local_record(
     value: FlagValue,
+    payload: Option<serde_json::Value>,
     has_experiment: Option<bool>,
     minimal_flag_called_events: bool,
 ) -> EvaluatedFlagRecord {
@@ -284,8 +285,9 @@ pub(super) fn local_record(
     EvaluatedFlagRecord {
         enabled,
         variant,
-        // Local definitions do not surface a payload through the poller today.
-        payload: None,
+        // The definitions manifest stores payloads the same way `/flags`
+        // returns them, so they go through the same normalisation.
+        payload: payload.map(normalize_payload),
         id: None,
         version: None,
         reason: Some("Evaluated locally".to_string()),

--- a/src/client/local_payload_test_support.rs
+++ b/src/client/local_payload_test_support.rs
@@ -1,0 +1,114 @@
+//! Shared fixtures for the local-evaluation payload tests in `async_client`
+//! and `blocking`. Those two modules are mutually exclusive under the
+//! `async-client` feature, so this lives outside both to avoid two copies
+//! drifting out of sync.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+
+use crate::feature_flags::{
+    FeatureFlag, FeatureFlagCondition, FeatureFlagFilters, MultivariateFilter, MultivariateVariant,
+};
+use crate::local_evaluation::LocalEvaluationResponse;
+
+fn flag(
+    key: &str,
+    rollout_percentage: f64,
+    multivariate: Option<MultivariateFilter>,
+    payloads: &[(&str, serde_json::Value)],
+) -> FeatureFlag {
+    FeatureFlag {
+        key: key.into(),
+        active: true,
+        has_experiment: None,
+        filters: FeatureFlagFilters {
+            groups: vec![FeatureFlagCondition {
+                properties: vec![],
+                rollout_percentage: Some(rollout_percentage),
+                variant: None,
+                aggregation_group_type_index: None,
+            }],
+            multivariate,
+            payloads: payloads
+                .iter()
+                .map(|(key, payload)| ((*key).to_string(), payload.clone()))
+                .collect(),
+            aggregation_group_type_index: None,
+            early_exit: false,
+        },
+    }
+}
+
+/// Definitions covering every shape a payload can take in the manifest, all
+/// evaluable without person properties.
+pub(super) fn payload_definitions() -> LocalEvaluationResponse {
+    let variants = MultivariateFilter {
+        variants: vec![
+            MultivariateVariant {
+                key: "test".into(),
+                rollout_percentage: 100.0,
+            },
+            MultivariateVariant {
+                key: "control".into(),
+                rollout_percentage: 0.0,
+            },
+        ],
+    };
+
+    LocalEvaluationResponse {
+        flags: vec![
+            // The definitions endpoint JSON-encodes payloads, so the common
+            // case is an object stored as a string.
+            flag(
+                "json-string-payload",
+                100.0,
+                None,
+                &[("true", json!("{\"color\": \"blue\"}"))],
+            ),
+            // Definitions written before payloads were normalised server-side
+            // can still carry an already-parsed value.
+            flag(
+                "parsed-payload",
+                100.0,
+                None,
+                &[("true", json!({"color": "blue"}))],
+            ),
+            // A string payload is stored double-encoded.
+            flag(
+                "quoted-string-payload",
+                100.0,
+                None,
+                &[("true", json!("\"just text\""))],
+            ),
+            // Not valid JSON: the raw string survives rather than erroring.
+            flag(
+                "undecodable-payload",
+                100.0,
+                None,
+                &[("true", json!("not json"))],
+            ),
+            // Keyed by variant, so the wrong variant's payload must not leak.
+            flag(
+                "variant-payload",
+                100.0,
+                Some(variants),
+                &[
+                    ("test", json!("{\"tier\": 2}")),
+                    ("control", json!("{\"tier\": 1}")),
+                ],
+            ),
+            flag("no-payload", 100.0, None, &[]),
+            // Evaluates false, so `/flags` would report no payload either.
+            flag(
+                "disabled-with-payload",
+                0.0,
+                None,
+                &[("true", json!("{\"unreachable\": true}"))],
+            ),
+        ],
+        group_type_mapping: HashMap::new(),
+        cohorts: HashMap::new(),
+        minimal_flag_called_events: false,
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -9,6 +9,8 @@ use tracing::warn;
 
 mod common;
 #[cfg(test)]
+mod local_payload_test_support;
+#[cfg(test)]
 mod minimal_gate_test_support;
 mod on_error;
 mod summary;

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -165,35 +165,6 @@ impl FlagCache {
         self.flags.read().unwrap().get(key).cloned()
     }
 
-    /// Return a flag's `has_experiment` signal without cloning the full
-    /// [`FeatureFlag`] (its filters can hold nested `Vec`s and JSON values).
-    pub(crate) fn has_experiment(&self, key: &str) -> Option<bool> {
-        self.flags
-            .read()
-            .unwrap()
-            .get(key)
-            .and_then(|f| f.has_experiment)
-    }
-
-    /// Return the payload a locally-evaluated flag carries for `value`, keyed
-    /// the way the definitions manifest stores it: `"true"` for a boolean
-    /// match, the variant key for a multivariate one. A flag that evaluated
-    /// false has no payload, matching `/flags`, which only attaches one to a
-    /// matching flag. The value is returned as stored — decoding it is the
-    /// caller's job, so local and remote payloads normalise identically.
-    pub(crate) fn flag_payload(&self, key: &str, value: &FlagValue) -> Option<serde_json::Value> {
-        let payload_key = match value {
-            FlagValue::Boolean(true) => "true",
-            FlagValue::Boolean(false) => return None,
-            FlagValue::String(variant) => variant.as_str(),
-        };
-        self.flags
-            .read()
-            .unwrap()
-            .get(key)
-            .and_then(|flag| flag.filters.payloads.get(payload_key).cloned())
-    }
-
     /// Return all cached feature flag definitions.
     pub fn get_all_flags(&self) -> Vec<FeatureFlag> {
         self.flags.read().unwrap().values().cloned().collect()
@@ -729,6 +700,21 @@ pub struct LocalEvaluator {
     cache: FlagCache,
 }
 
+pub(crate) struct LocalFlagEvaluation {
+    pub(crate) result: Result<FlagValue, InconclusiveMatchError>,
+    pub(crate) payload: Option<serde_json::Value>,
+    pub(crate) has_experiment: Option<bool>,
+}
+
+fn flag_payload(flag: &FeatureFlag, value: &FlagValue) -> Option<serde_json::Value> {
+    let payload_key = match value {
+        FlagValue::Boolean(true) => "true",
+        FlagValue::Boolean(false) => return None,
+        FlagValue::String(variant) => variant.as_str(),
+    };
+    flag.filters.payloads.get(payload_key).cloned()
+}
+
 impl LocalEvaluator {
     /// Create an evaluator backed by a shared [`FlagCache`].
     pub fn new(cache: FlagCache) -> Self {
@@ -860,9 +846,27 @@ impl LocalEvaluator {
         groups: &HashMap<String, String>,
         group_properties: &HashMap<String, HashMap<String, serde_json::Value>>,
     ) -> HashMap<String, Result<FlagValue, InconclusiveMatchError>> {
+        self.evaluate_all_flags_with_details(
+            distinct_id,
+            person_properties,
+            groups,
+            group_properties,
+        )
+        .into_iter()
+        .map(|(key, evaluation)| (key, evaluation.result))
+        .collect()
+    }
+
+    pub(crate) fn evaluate_all_flags_with_details(
+        &self,
+        distinct_id: &str,
+        person_properties: &HashMap<String, serde_json::Value>,
+        groups: &HashMap<String, String>,
+        group_properties: &HashMap<String, HashMap<String, serde_json::Value>>,
+    ) -> HashMap<String, LocalFlagEvaluation> {
         let mut results = HashMap::new();
 
-        // Build evaluation context once for all flags
+        // Build one definitions snapshot for evaluation and its metadata.
         let cohorts = self.cache.get_cohort_definitions();
         let flags = self.cache.get_flags_map();
         let group_type_mapping = self.cache.get_group_type_mapping();
@@ -876,12 +880,77 @@ impl LocalEvaluator {
             group_type_mapping: &group_type_mapping,
         };
 
-        for flag in self.cache.get_all_flags() {
-            let result = match_feature_flag_with_context(&flag, person_properties, &ctx);
-            results.insert(flag.key.clone(), result);
+        for flag in flags.values() {
+            let result = match_feature_flag_with_context(flag, person_properties, &ctx);
+            let payload = result
+                .as_ref()
+                .ok()
+                .and_then(|value| flag_payload(flag, value));
+            results.insert(
+                flag.key.clone(),
+                LocalFlagEvaluation {
+                    result,
+                    payload,
+                    has_experiment: flag.has_experiment,
+                },
+            );
         }
 
         debug!(flag_count = results.len(), "Evaluated all local flags");
         results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feature_flags::{FeatureFlagCondition, FeatureFlagFilters};
+    use serde_json::json;
+
+    fn definitions(
+        active: bool,
+        payload: serde_json::Value,
+        has_experiment: bool,
+    ) -> LocalEvaluationResponse {
+        LocalEvaluationResponse {
+            flags: vec![FeatureFlag {
+                key: "snapshot-flag".to_string(),
+                active,
+                filters: FeatureFlagFilters {
+                    groups: vec![FeatureFlagCondition {
+                        properties: vec![],
+                        rollout_percentage: Some(100.0),
+                        variant: None,
+                        aggregation_group_type_index: None,
+                    }],
+                    payloads: HashMap::from([("true".to_string(), payload)]),
+                    ..Default::default()
+                },
+                has_experiment: Some(has_experiment),
+            }],
+            group_type_mapping: HashMap::new(),
+            cohorts: HashMap::new(),
+            minimal_flag_called_events: false,
+        }
+    }
+
+    #[test]
+    fn evaluated_details_survive_a_cache_refresh() {
+        let cache = FlagCache::new();
+        cache.update(definitions(true, json!({"snapshot": "old"}), true));
+        let evaluator = LocalEvaluator::new(cache.clone());
+
+        let evaluations = evaluator.evaluate_all_flags_with_details(
+            "user-1",
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        cache.update(definitions(false, json!({"snapshot": "new"}), false));
+
+        let evaluation = evaluations.get("snapshot-flag").unwrap();
+        assert!(matches!(evaluation.result, Ok(FlagValue::Boolean(true))));
+        assert_eq!(evaluation.payload, Some(json!({"snapshot": "old"})));
+        assert_eq!(evaluation.has_experiment, Some(true));
     }
 }

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -175,6 +175,25 @@ impl FlagCache {
             .and_then(|f| f.has_experiment)
     }
 
+    /// Return the payload a locally-evaluated flag carries for `value`, keyed
+    /// the way the definitions manifest stores it: `"true"` for a boolean
+    /// match, the variant key for a multivariate one. A flag that evaluated
+    /// false has no payload, matching `/flags`, which only attaches one to a
+    /// matching flag. The value is returned as stored — decoding it is the
+    /// caller's job, so local and remote payloads normalise identically.
+    pub(crate) fn flag_payload(&self, key: &str, value: &FlagValue) -> Option<serde_json::Value> {
+        let payload_key = match value {
+            FlagValue::Boolean(true) => "true",
+            FlagValue::Boolean(false) => return None,
+            FlagValue::String(variant) => variant.as_str(),
+        };
+        self.flags
+            .read()
+            .unwrap()
+            .get(key)
+            .and_then(|flag| flag.filters.payloads.get(payload_key).cloned())
+    }
+
     /// Return all cached feature flag definitions.
     pub fn get_all_flags(&self) -> Vec<FeatureFlag> {
         self.flags.read().unwrap().values().cloned().collect()

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -8,7 +8,7 @@ mod common;
 use common::default_user_agent;
 use httpmock::prelude::*;
 #[cfg(feature = "async-client")]
-use posthog_rs::{AsyncFlagPoller, ClientOptionsBuilder};
+use posthog_rs::{AsyncFlagPoller, ClientOptionsBuilder, EvaluateFlagsOptions};
 use posthog_rs::{
     FeatureFlag, FeatureFlagCondition, FeatureFlagFilters, FlagCache, FlagPoller, FlagValue,
     LocalEvaluationConfig, LocalEvaluationResponse, LocalEvaluator, Property,
@@ -381,6 +381,119 @@ async fn test_client_adds_distinct_id_for_local_evaluation_only() {
         .await;
 
     assert_eq!(result.unwrap(), Some(FlagValue::Boolean(true)));
+    eval_mock.assert();
+    flags_mock.assert_hits(0);
+}
+
+/// Payloads ride along in the definitions manifest, so a snapshot that never
+/// touches `/flags` must still expose them. This is the path where they were
+/// most thoroughly lost: with `flag_keys` fully covered locally there is no
+/// remote round trip left to recover a payload from.
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn test_local_evaluation_returns_payloads_without_calling_flags() {
+    let server = MockServer::start();
+
+    // Payloads arrive JSON-encoded from `/flags/definitions/`, the same shape
+    // `/flags` returns them in.
+    let mock_flags = json!({
+        "flags": [
+            {
+                "key": "bool-flag",
+                "active": true,
+                "filters": {
+                    "groups": [
+                        { "properties": [], "rollout_percentage": 100.0, "variant": null }
+                    ],
+                    "multivariate": null,
+                    "payloads": { "true": "{\"color\": \"blue\"}" }
+                }
+            },
+            {
+                "key": "variant-flag",
+                "active": true,
+                "filters": {
+                    "groups": [
+                        { "properties": [], "rollout_percentage": 100.0, "variant": null }
+                    ],
+                    "multivariate": {
+                        "variants": [
+                            { "key": "test", "rollout_percentage": 100.0 },
+                            { "key": "control", "rollout_percentage": 0.0 }
+                        ]
+                    },
+                    "payloads": { "test": "{\"tier\": 2}", "control": "{\"tier\": 1}" }
+                }
+            },
+            {
+                "key": "no-payload-flag",
+                "active": true,
+                "filters": {
+                    "groups": [
+                        { "properties": [], "rollout_percentage": 100.0, "variant": null }
+                    ],
+                    "multivariate": null,
+                    "payloads": {}
+                }
+            }
+        ],
+        "group_type_mapping": {},
+        "cohorts": {}
+    });
+
+    let eval_mock = server.mock(|when, then| {
+        when.method(GET).path("/flags/definitions/");
+        then.status(200).json_body(mock_flags);
+    });
+    let flags_mock = server.mock(|when, then| {
+        when.method(POST).path("/flags/");
+        then.status(200).json_body(json!({
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        }));
+    });
+
+    let options = ClientOptionsBuilder::default()
+        .host(server.base_url())
+        .api_key("test_project_key".to_string())
+        .personal_api_key("test_personal_key".to_string())
+        .enable_local_evaluation(true)
+        .poll_interval_seconds(60)
+        .build()
+        .unwrap();
+
+    let client = posthog_rs::client(options).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let snapshot = client
+        .evaluate_flags(
+            "user-123",
+            EvaluateFlagsOptions {
+                flag_keys: Some(vec![
+                    "bool-flag".to_string(),
+                    "variant-flag".to_string(),
+                    "no-payload-flag".to_string(),
+                ]),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("evaluate_flags");
+
+    assert_eq!(
+        snapshot.get_flag_payload("bool-flag"),
+        Some(json!({ "color": "blue" }))
+    );
+    assert_eq!(
+        snapshot.get_flag("variant-flag"),
+        Some(FlagValue::String("test".to_string()))
+    );
+    assert_eq!(
+        snapshot.get_flag_payload("variant-flag"),
+        Some(json!({ "tier": 2 }))
+    );
+    assert_eq!(snapshot.get_flag_payload("no-payload-flag"), None);
+
     eval_mock.assert();
     flags_mock.assert_hits(0);
 }


### PR DESCRIPTION
## Problem

Local flag evaluation never surfaced feature flag payloads, even though the payloads ship in the definitions manifest and were already deserialized into the cache (`FeatureFlagFilters.payloads`). `local_record()` hardcoded `payload: None`, so `FeatureFlagEvaluations::get_flag_payload()` returned `None` for every locally-evaluated flag, silently.

It is worse than a missing feature: turning local evaluation **on** removes payload access that remote-only callers have. In `evaluate_flags`, the `/flags` round trip is skipped entirely when the caller passed `flag_keys` and local evaluation covered all of them, and even when `/flags` is called, locally-evaluated keys are skipped when merging the remote records. Either path loses the payload. The only thing that still worked was the deprecated `get_feature_flag_payload()`, which posts straight to `/flags` and costs a billed request per call.

Rust was the only PostHog server SDK with local evaluation that did not resolve payloads locally. Python, Go, and Node all do.

Reported by a customer using server-side local evaluation.

## What changed

(See also #200 )

Wiring only. No public API change, no new types, no signature changes to the public evaluator methods (`api/public-api.txt` regenerates clean).

- `FlagCache::flag_payload(key, value)` (`src/local_evaluation.rs`) looks the payload up by the matched value: `"true"` for a boolean match, the variant key for a multivariate one. It mirrors the existing `has_experiment` accessor, so it reads one field under the read lock instead of cloning the whole `FeatureFlag`.
- `local_record()` (`src/client/common.rs`) takes the resolved payload and runs it through the **pre-existing** `normalize_payload()`, the same helper the remote path already uses.
- Both callers (`blocking.rs` and `async_client.rs`) pass it through.

### On the double-encoding trap

Payloads arrive JSON-encoded from both endpoints: `filters.payloads[key]` in the definitions manifest and `metadata.payload` in `/flags?v=2` are literally the same stored value, and the flags service does not decode either one. So the correctness requirement is to apply the *same* decode on both paths, which `normalize_payload` already does for remote (parse a `Value::String`, fall back to the raw string when it does not parse). Reusing it means the same flag returns the same payload whichever path evaluated it. Tests cover all four shapes: JSON-encoded object, already-parsed object, double-encoded string, and an undecodable string that falls back raw.

### A flag that evaluated false gets no payload

Deliberate, for parity with `/flags`: the flags service only computes `get_matching_payload` on a matching flag, so a disabled flag has no payload remotely either. Worth flagging that posthog-go and posthog-python do an unconditional `"false"` key lookup here, while posthog-js guards it out the way this PR does. Since PostHog never stores a `"false"` payload and the server never returns one, matching our own remote path seemed more important than matching Go's lookup shape. Happy to flip it if you disagree.

## Data shape change, please read

Once the payload is populated, `build_called_event_properties` starts attaching `$feature_flag_payload` to `$feature_flag_called` events for locally-evaluated flags, where today it does not. That is the intended parity with remote evaluation, and the event-minimization allowlist strips the property when the gate is on (existing tests in `v0_capture.rs` / `v1_capture.rs` assert this and still pass). But the gate defaults to off, so for customers who have not opted into minimization this is an observable change to their own event data with a small ingestion cost attached. Calling it out rather than leaving it to be discovered.

A security review specifically checked where a payload can now travel: only into `$feature_flag_called` properties, which is the customer's own project. It does not reach logs, error hooks, panic messages, or exception capture, and the per-variant lookup cannot return another flag's or another variant's payload.

## Tests

The bug shipped because of a test blind spot: every fixture in the repo built `payloads: HashMap::new()`, so the non-empty payload path had never been exercised (the same shape of gap that hid the cohort bug in #187, where every fixture used `"cohorts": {}`). New fixtures use a real non-empty payloads map:

- boolean flag, payload under the `"true"` key
- multivariate flag, payload keyed by variant, with a different payload on the other variant so reading the wrong one fails
- JSON-encoded-string payload, asserting the decoded value
- undecodable string payload, asserting the raw-string fallback
- already-parsed payload, asserting passthrough
- no payload at all, asserting `None`
- a flag that evaluates false while carrying a `"true"` payload, asserting both that the flag is present as `Boolean(false)` and that its payload is `None`
- end to end through `evaluate_flags` with `flag_keys` set so `local_covers_request` is true, asserting `/flags` is never called

Unit tests run against both the blocking and async clients, since the two duplicate this call site.

## Not in this PR

The deprecated `get_feature_flag_payload()` still posts to `/flags` unconditionally instead of trying local first (which is what Go does). It is a real win, since it would stop charging people for payload lookups they could resolve locally, but it touches deprecated surface and is a separate behavior change. Happy to do it as a follow-up.

## Base

Branched from #187 (cohort deserialization), which is open and touches the same files. Review that one first. This PR does not touch the cohort work.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*