### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,17 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot currently opens separate pull requests for each Cargo dependency and GitHub Actions update. Grouping updates reduces the number of maintenance pull requests.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` as YAML.
- Verified that the Cargo group and GitHub Actions group each use the `"*"` pattern.
- Ran `git diff --check`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
