### PR TITLE
ci: remove automerge from upgrade workflow

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -110,13 +110,6 @@ jobs:
         run: |
           echo "PostHog pull request for $PACKAGE_NAME version $PACKAGE_VERSION ready: $PR_URL"
 
-      - name: Enable automerge
-        env:
-          GH_TOKEN: ${{ steps.upgrader.outputs.token }}
-          PR_NUMBER: ${{ steps.main-repo-pr.outputs.pull-request-number }}
-        run: |
-          gh pr merge "$PR_NUMBER" --repo PostHog/posthog --auto --squash
-
       - name: Assign reviewers
         env:
           GH_TOKEN: ${{ steps.upgrader.outputs.token }}


### PR DESCRIPTION
## :bulb: Motivation and Context

The organization blocks auto-merge. The SDK upgrade workflow currently tries to enable it on the pull requests it creates in `PostHog/posthog`, so that step cannot succeed.

This removes the auto-merge command. The workflow will continue to create the pull request and assign the SDK reviewer teams.

## :green_heart: How did you test it?

- Ran `actionlint .github/workflows/posthog-upgrade.yml`.
- Ran `git diff --check`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
