### PR TITLE
fix: normalize SDK timestamps to UTC

### DIFF
--- a/.sampo/changesets/regal-stormcaller-tuulikki.md
+++ b/.sampo/changesets/regal-stormcaller-tuulikki.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Normalize SDK timestamps to UTC

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -1461,17 +1461,11 @@ mod tests {
         );
     }
 
-    /// Parse either an RFC3339 string (v1 timestamps / v0 `sent_at`) or a naive
-    /// datetime (v0 event timestamps serialize without an offset) as UTC.
+    /// Parse an RFC3339 wire timestamp and normalize it to UTC.
     fn parse_ts(s: &str) -> Option<DateTime<Utc>> {
         DateTime::parse_from_rfc3339(s)
             .map(|d| d.with_timezone(&Utc))
             .ok()
-            .or_else(|| {
-                chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
-                    .map(|n| n.and_utc())
-                    .ok()
-            })
     }
 
     #[test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -180,8 +180,8 @@ impl Event {
     ///
     /// # Parameters
     ///
-    /// - `timestamp`: Timestamp to send with the event. It is converted to UTC
-    ///   before serialization.
+    /// - `timestamp`: Timestamp to send with the event. UTC input is preferred;
+    ///   non-UTC input is converted to the equivalent UTC instant before serialization.
     ///
     /// # Errors
     ///
@@ -381,7 +381,7 @@ pub struct InnerEvent {
     event: String,
     distinct_id: String,
     properties: HashMap<String, serde_json::Value>,
-    timestamp: Option<NaiveDateTime>,
+    timestamp: Option<DateTime<Utc>>,
 }
 
 impl InnerEvent {
@@ -408,7 +408,7 @@ impl InnerEvent {
             event: event.event,
             distinct_id: event.distinct_id,
             properties: event.properties,
-            timestamp: event.timestamp,
+            timestamp: event.timestamp.map(|timestamp| timestamp.and_utc()),
         }
     }
 }
@@ -478,6 +478,19 @@ pub mod tests {
             assert!(event.get("$distinct_id").is_none());
             assert!(event.get("api_key").is_none());
         }
+    }
+
+    #[test]
+    fn v0_serializes_non_utc_timestamp_as_equivalent_utc_instant() {
+        let mut event = Event::new("test", "user1");
+        event
+            .set_timestamp(
+                chrono::DateTime::parse_from_rfc3339("2023-01-01T10:00:00.123+03:00").unwrap(),
+            )
+            .unwrap();
+
+        let json = serde_json::to_value(build_v0(event)).unwrap();
+        assert_eq!(json["timestamp"], "2023-01-01T07:00:00.123Z");
     }
 
     #[test]

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -217,6 +217,17 @@ mod tests {
     }
 
     #[test]
+    fn v1_event_preserves_utc_timestamp_serialization() {
+        let mut event = Event::new("test_event", "user-1");
+        event
+            .set_timestamp(DateTime::parse_from_rfc3339("2023-01-01T10:00:00.123+03:00").unwrap())
+            .unwrap();
+
+        let v1 = V1Event::from_event(&event);
+        assert_eq!(v1.timestamp, "2023-01-01T07:00:00.123Z");
+    }
+
+    #[test]
     fn v1_event_from_event_anon() {
         let event = Event::new_anon("anon_event");
         let v1 = V1Event::from_event(&event);


### PR DESCRIPTION
## :bulb: Motivation and Context

V0 capture payloads serialize event timestamps as naive date-time strings without a UTC offset. This makes the wire timestamp ambiguous even though `Event::set_timestamp` already converts the supplied value to the equivalent UTC instant.

This change stores the V0 wire timestamp as `DateTime<Utc>`, so both single-event and batch capture payloads serialize timestamps as RFC 3339 UTC values with a `Z` suffix. For example, `2023-01-01T10:00:00.123+03:00` is sent as `2023-01-01T07:00:00.123Z`. V1 serialization remains unchanged and continues to send the same UTC instant.

The regression coverage verifies that behavior directly. `v0_serializes_non_utc_timestamp_as_equivalent_utc_instant` checks V0 conversion from `+03:00` to `Z`. `v1_event_preserves_utc_timestamp_serialization` checks the same instant on V1. The existing `event_timestamp_is_capture_time_not_publish_time` transport test now accepts only RFC 3339 timestamps, so its default and `capture-v1` runs also prove both wire formats include a UTC offset while preserving capture-time stamping.

## :green_heart: How did you test it?

- `cargo fmt --check`
- `cargo test --lib` - 224 tests passed.
- `cargo test --lib --features capture-v1` - 262 tests passed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
