### PR TITLE
feat: add alias helper for merging distinct IDs

### DIFF
--- a/.sampo/changesets/add-alias-helper.md
+++ b/.sampo/changesets/add-alias-helper.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Add a `Client::alias` helper that merges two distinct IDs onto the same person, so callers no longer need to hand-build the `$create_alias` event and know that `distinct_id` is written both at the top level and inside `properties`. Available on the async and blocking clients with the same fire-and-forget signature as `capture`. A blank ID on either side cannot describe a merge, so the event is dropped with a warning rather than sent.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -125,6 +125,7 @@ pub fn posthog_rs::CaptureSummary::not_persisted(&self) -> usize
 pub fn posthog_rs::CaptureSummary::submitted(&self) -> usize
 pub struct posthog_rs::Client
 impl posthog_rs::Client
+pub fn posthog_rs::Client::alias<P: core::convert::Into<alloc::string::String>, D: core::convert::Into<alloc::string::String>>(&self, P, D)
 pub fn posthog_rs::Client::capture(&self, posthog_rs::Event)
 pub fn posthog_rs::Client::capture_batch(&self, alloc::vec::Vec<posthog_rs::Event>, bool)
 pub async fn posthog_rs::Client::capture_batch_immediate(&self, alloc::vec::Vec<posthog_rs::Event>, bool) -> core::result::Result<posthog_rs::CaptureSummary, posthog_rs::Error>

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -198,6 +198,38 @@ impl Client {
         }
     }
 
+    /// Merge two distinct IDs onto the same person by sending a `$create_alias`
+    /// event.
+    ///
+    /// See <https://posthog.com/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user>.
+    ///
+    /// # Parameters
+    ///
+    /// - `previous_id`: ID already known to PostHog, such as an anonymous ID.
+    /// - `distinct_id`: ID it should be merged into, such as a logged-in user ID.
+    ///
+    /// # Remarks
+    ///
+    /// Fire-and-forget, like [`Client::capture`]. A blank ID on either side
+    /// cannot describe a merge, so the event is dropped with a warning rather
+    /// than sent.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn example() {
+    /// let client = posthog_rs::client("phc_project_api_key").await;
+    ///
+    /// // The visitor browsed anonymously, then logged in.
+    /// client.alias("anon-abc123", "user-42");
+    /// # }
+    /// ```
+    pub fn alias<P: Into<String>, D: Into<String>>(&self, previous_id: P, distinct_id: D) {
+        if let Some(event) = Event::alias(previous_id.into(), distinct_id.into()) {
+            self.capture(event);
+        }
+    }
+
     /// Flush queued events, returning once the worker has attempted delivery of
     /// everything queued before this call. Transient failures are kept for retry
     /// (the call still returns without error). A no-op for disabled clients.

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -202,6 +202,36 @@ impl Client {
         }
     }
 
+    /// Merge two distinct IDs onto the same person by sending a `$create_alias`
+    /// event.
+    ///
+    /// See <https://posthog.com/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user>.
+    ///
+    /// # Parameters
+    ///
+    /// - `previous_id`: ID already known to PostHog, such as an anonymous ID.
+    /// - `distinct_id`: ID it should be merged into, such as a logged-in user ID.
+    ///
+    /// # Remarks
+    ///
+    /// Fire-and-forget, like [`Client::capture`]. A blank ID on either side
+    /// cannot describe a merge, so the event is dropped with a warning rather
+    /// than sent.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// let client = posthog_rs::client("phc_project_api_key");
+    ///
+    /// // The visitor browsed anonymously, then logged in.
+    /// client.alias("anon-abc123", "user-42");
+    /// ```
+    pub fn alias<P: Into<String>, D: Into<String>>(&self, previous_id: P, distinct_id: D) {
+        if let Some(event) = Event::alias(previous_id.into(), distinct_id.into()) {
+            self.capture(event);
+        }
+    }
+
     /// Flush queued events, blocking until the worker has attempted delivery of
     /// everything queued before this call. Transient failures are kept for retry
     /// (the call still returns). A no-op for disabled clients.

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 use semver::Version;
 use serde::Serialize;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::client::CRATE_VERSION;
@@ -197,6 +198,43 @@ impl Event {
         }
         self.timestamp = Some(timestamp.naive_utc());
         Ok(())
+    }
+
+    /// Build the `$create_alias` event backing [`crate::Client::alias`].
+    ///
+    /// The event is attributed to `previous_id`, which is also mirrored into
+    /// `properties.distinct_id` alongside the merge target in `properties.alias`
+    /// — the shape posthog-python, posthog-js-lite, and posthog-php all send.
+    ///
+    /// Returns `None` when either ID is blank. A merge needs both sides, so a
+    /// blank one can only produce a malformed event; the SDKs above drop it with
+    /// a warning rather than sending it, and so do we.
+    ///
+    /// Properties are built directly rather than through `insert_prop` so
+    /// construction is infallible: both values are strings, which cannot fail to
+    /// serialize, leaving no always-`Ok` `Result` for callers to discard.
+    pub(crate) fn alias(previous_id: String, distinct_id: String) -> Option<Self> {
+        if previous_id.trim().is_empty() || distinct_id.trim().is_empty() {
+            warn!("alias() called with a blank id, dropping the $create_alias event");
+            return None;
+        }
+
+        let mut properties = HashMap::new();
+        properties.insert(
+            "distinct_id".to_string(),
+            serde_json::Value::String(previous_id.clone()),
+        );
+        properties.insert("alias".to_string(), serde_json::Value::String(distinct_id));
+
+        Some(Self {
+            event: "$create_alias".to_string(),
+            distinct_id: previous_id,
+            properties,
+            groups: HashMap::new(),
+            timestamp: None,
+            uuid: Uuid::now_v7(),
+            minimal_flag_called: false,
+        })
     }
 
     /// Stamp the capture (enqueue) time when the caller hasn't set an explicit

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -1,0 +1,335 @@
+//! Coverage for `Client::alias`, the `$create_alias` helper.
+//!
+//! The emitted event is identical on both capture pipelines — nothing in it is
+//! lifted into the V1 `options` object — so a single `CAPTURE_PATH` switch
+//! covers V0 and V1 rather than the split-file treatment error tracking needs.
+//!
+//! Capture is a non-blocking enqueue drained by the background worker, so every
+//! test `flush()`es before asserting.
+
+use httpmock::prelude::*;
+use serde_json::{json, Value};
+
+#[cfg(feature = "capture-v1")]
+const CAPTURE_PATH: &str = "/i/v1/analytics/events";
+#[cfg(not(feature = "capture-v1"))]
+const CAPTURE_PATH: &str = "/batch/";
+
+const PREVIOUS_ID: &str = "anon-abc123";
+const DISTINCT_ID: &str = "user-42";
+
+/// V1 reports per-event status in `results`; an empty map is a clean accept and
+/// keeps the client to a single attempt. V0 ignores the body entirely.
+fn ok_response() -> Value {
+    json!({ "results": {} })
+}
+
+fn alias_event(body: &Value) -> Option<&Value> {
+    body.get("batch")?
+        .as_array()?
+        .iter()
+        .find(|event| event.get("event").and_then(Value::as_str) == Some("$create_alias"))
+}
+
+/// The event is attributed to the *previous* ID at the top level, and that ID is
+/// mirrored into `properties.distinct_id` while the merge target goes to
+/// `properties.alias`. Both property keys are required: posthog-python,
+/// posthog-js-lite, and posthog-php all write the pair, and issue #149's JSON
+/// snippet omits `properties.distinct_id`.
+fn request_has_well_formed_alias_event(req: &HttpMockRequest) -> bool {
+    let Ok(body) = serde_json::from_slice::<Value>(req.body_ref()) else {
+        return false;
+    };
+    let Some(event) = alias_event(&body) else {
+        return false;
+    };
+
+    event.get("distinct_id").and_then(Value::as_str) == Some(PREVIOUS_ID)
+        && event
+            .pointer("/properties/distinct_id")
+            .and_then(Value::as_str)
+            == Some(PREVIOUS_ID)
+        && event.pointer("/properties/alias").and_then(Value::as_str) == Some(DISTINCT_ID)
+}
+
+/// A merge cannot be personless, so the helper must not stamp the opt-out that
+/// `Event::new_anon` sets.
+fn request_does_not_disable_person_processing(req: &HttpMockRequest) -> bool {
+    let Ok(body) = serde_json::from_slice::<Value>(req.body_ref()) else {
+        return false;
+    };
+    let Some(event) = alias_event(&body) else {
+        return false;
+    };
+
+    event
+        .pointer("/properties/$process_person_profile")
+        .and_then(Value::as_bool)
+        != Some(false)
+}
+
+/// PostHog deduplicates on event UUID, so a constructor that reused one would
+/// have every alias after the first silently dropped server-side.
+fn request_has_two_distinct_event_uuids(req: &HttpMockRequest) -> bool {
+    let Ok(body) = serde_json::from_slice::<Value>(req.body_ref()) else {
+        return false;
+    };
+    let Some(batch) = body.get("batch").and_then(Value::as_array) else {
+        return false;
+    };
+    if batch.len() != 2 {
+        return false;
+    }
+
+    let uuid_at = |i: usize| {
+        batch[i]
+            .get("uuid")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+    let (first, second) = (uuid_at(0), uuid_at(1));
+
+    const NIL_UUID: &str = "00000000-0000-0000-0000-000000000000";
+    !first.is_empty() && first != second && first != NIL_UUID && second != NIL_UUID
+}
+
+const BLANK_IDS: [&str; 2] = ["", "   "];
+
+#[cfg(not(feature = "async-client"))]
+mod blocking {
+    use super::*;
+
+    fn create_test_client(base_url: String) -> posthog_rs::Client {
+        let options: posthog_rs::ClientOptions = ("test_api_key", base_url.as_str()).into();
+        posthog_rs::client(options)
+    }
+
+    #[test]
+    fn alias_sends_create_alias_event() {
+        let server = MockServer::start();
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(CAPTURE_PATH)
+                .matches(request_has_well_formed_alias_event)
+                .matches(request_does_not_disable_person_processing);
+            then.status(200).json_body(ok_response());
+        });
+
+        let client = create_test_client(server.base_url());
+        client.alias(PREVIOUS_ID, DISTINCT_ID);
+        client.flush();
+
+        capture_mock.assert();
+    }
+
+    #[test]
+    fn alias_accepts_owned_and_borrowed_ids() {
+        let server = MockServer::start();
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(CAPTURE_PATH)
+                .matches(request_has_well_formed_alias_event);
+            then.status(200).json_body(ok_response());
+        });
+
+        let client = create_test_client(server.base_url());
+        // Mixing `&str` and `String` only compiles with two generic parameters.
+        client.alias(PREVIOUS_ID, String::from(DISTINCT_ID));
+        client.flush();
+
+        capture_mock.assert();
+    }
+
+    #[test]
+    fn repeated_aliases_get_distinct_event_uuids() {
+        let server = MockServer::start();
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(CAPTURE_PATH)
+                .matches(request_has_two_distinct_event_uuids);
+            then.status(200).json_body(ok_response());
+        });
+
+        let client = create_test_client(server.base_url());
+        client.alias(PREVIOUS_ID, DISTINCT_ID);
+        client.alias("anon-def456", "user-99");
+        client.flush();
+
+        capture_mock.assert();
+    }
+
+    #[test]
+    fn alias_with_blank_previous_id_is_dropped() {
+        for blank in BLANK_IDS {
+            let server = MockServer::start();
+            let capture_mock = server.mock(|when, then| {
+                when.method(POST).path(CAPTURE_PATH);
+                then.status(200).json_body(ok_response());
+            });
+
+            let client = create_test_client(server.base_url());
+            client.alias(blank, DISTINCT_ID);
+            client.flush();
+
+            capture_mock.assert_hits(0);
+        }
+    }
+
+    #[test]
+    fn alias_with_blank_distinct_id_is_dropped() {
+        for blank in BLANK_IDS {
+            let server = MockServer::start();
+            let capture_mock = server.mock(|when, then| {
+                when.method(POST).path(CAPTURE_PATH);
+                then.status(200).json_body(ok_response());
+            });
+
+            let client = create_test_client(server.base_url());
+            client.alias(PREVIOUS_ID, blank);
+            client.flush();
+
+            capture_mock.assert_hits(0);
+        }
+    }
+
+    #[test]
+    fn alias_is_noop_for_disabled_client() {
+        let server = MockServer::start();
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST).path(CAPTURE_PATH);
+            then.status(200).json_body(ok_response());
+        });
+
+        let options = posthog_rs::ClientOptionsBuilder::default()
+            .host(server.base_url())
+            .build()
+            .unwrap();
+        assert!(options.is_disabled());
+
+        let client = posthog_rs::client(options);
+        client.alias(PREVIOUS_ID, DISTINCT_ID);
+        client.flush();
+
+        capture_mock.assert_hits(0);
+    }
+}
+
+#[cfg(feature = "async-client")]
+mod async_client {
+    use super::*;
+
+    async fn create_test_client(base_url: String) -> posthog_rs::Client {
+        let options: posthog_rs::ClientOptions = ("test_api_key", base_url.as_str()).into();
+        posthog_rs::client(options).await
+    }
+
+    #[tokio::test]
+    async fn alias_sends_create_alias_event() {
+        let server = MockServer::start();
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(CAPTURE_PATH)
+                .matches(request_has_well_formed_alias_event)
+                .matches(request_does_not_disable_person_processing);
+            then.status(200).json_body(ok_response());
+        });
+
+        let client = create_test_client(server.base_url()).await;
+        client.alias(PREVIOUS_ID, DISTINCT_ID);
+        client.flush().await;
+
+        capture_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn alias_accepts_owned_and_borrowed_ids() {
+        let server = MockServer::start();
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(CAPTURE_PATH)
+                .matches(request_has_well_formed_alias_event);
+            then.status(200).json_body(ok_response());
+        });
+
+        let client = create_test_client(server.base_url()).await;
+        // Mixing `&str` and `String` only compiles with two generic parameters.
+        client.alias(PREVIOUS_ID, String::from(DISTINCT_ID));
+        client.flush().await;
+
+        capture_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn repeated_aliases_get_distinct_event_uuids() {
+        let server = MockServer::start();
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(CAPTURE_PATH)
+                .matches(request_has_two_distinct_event_uuids);
+            then.status(200).json_body(ok_response());
+        });
+
+        let client = create_test_client(server.base_url()).await;
+        client.alias(PREVIOUS_ID, DISTINCT_ID);
+        client.alias("anon-def456", "user-99");
+        client.flush().await;
+
+        capture_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn alias_with_blank_previous_id_is_dropped() {
+        for blank in BLANK_IDS {
+            let server = MockServer::start();
+            let capture_mock = server.mock(|when, then| {
+                when.method(POST).path(CAPTURE_PATH);
+                then.status(200).json_body(ok_response());
+            });
+
+            let client = create_test_client(server.base_url()).await;
+            client.alias(blank, DISTINCT_ID);
+            client.flush().await;
+
+            capture_mock.assert_hits(0);
+        }
+    }
+
+    #[tokio::test]
+    async fn alias_with_blank_distinct_id_is_dropped() {
+        for blank in BLANK_IDS {
+            let server = MockServer::start();
+            let capture_mock = server.mock(|when, then| {
+                when.method(POST).path(CAPTURE_PATH);
+                then.status(200).json_body(ok_response());
+            });
+
+            let client = create_test_client(server.base_url()).await;
+            client.alias(PREVIOUS_ID, blank);
+            client.flush().await;
+
+            capture_mock.assert_hits(0);
+        }
+    }
+
+    #[tokio::test]
+    async fn alias_is_noop_for_disabled_client() {
+        let server = MockServer::start();
+        let capture_mock = server.mock(|when, then| {
+            when.method(POST).path(CAPTURE_PATH);
+            then.status(200).json_body(ok_response());
+        });
+
+        let options = posthog_rs::ClientOptionsBuilder::default()
+            .host(server.base_url())
+            .build()
+            .unwrap();
+        assert!(options.is_disabled());
+
+        let client = posthog_rs::client(options).await;
+        client.alias(PREVIOUS_ID, DISTINCT_ID);
+        client.flush().await;
+
+        capture_mock.assert_hits(0);
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

closes #149. (Left unlinked rather than auto-closing — the issue's last acceptance
criterion is about the docs on posthog.com pointing at the helper, which isn't
this repo. Close it whenever you think it's covered.)

Adds a first-class `alias` helper so users don't hand-build the `$create_alias` event:

```rust
client.alias("anon-abc123", "user-42");
```

Available on both the async and blocking clients with the same signature.

### Two places I deviated from the issue — please sanity-check these

**1. The event carries `distinct_id` inside `properties`, which the issue's JSON snippet omits.**

The issue specifies:

```json
{
  "event": "$create_alias",
  "distinct_id": "frontend_id",
  "properties": { "alias": "backend_id" }
}
```

Every other PostHog SDK also writes `distinct_id` into `properties`:

| SDK                                                                                                                  | `properties` keys      |
| -------------------------------------------------------------------------------------------------------------------- | ---------------------- |
| [posthog-python](https://github.com/PostHog/posthog-python/blob/master/posthog/client.py)                            | `distinct_id`, `alias` |
| [posthog-js-lite](https://github.com/PostHog/posthog-js-lite/blob/main/posthog-core/src/index.ts) (`aliasStateless`) | `distinct_id`, `alias` |
| [posthog-php](https://github.com/PostHog/posthog-php/blob/master/lib/Client.php)                                     | `distinct_id`, `alias` |

I followed the SDKs rather than the snippet, so Rust doesn't emit an event missing a field the other libraries all send. Happy to switch if the snippet is authoritative and the others are carrying legacy baggage.

**2. The signature is sync and infallible, not `async` + `Result`.**

The issue proposes `client.alias(a, b).await?`. This crate's `capture()` is sync and returns nothing even on the async client — fire-and-forget is the core model, and delivery failures surface through the `on_error` hook. Building an alias event cannot fail (two strings into a map), so a `Result` would always be `Ok` and every caller would have to `?` or discard it, and there is nothing to `.await`.

Following `capture()` also means the async and blocking call sites are character-for-character identical, so docs and snippets are portable between them. Easy to change if you'd rather match the other SDKs' shape.

### Other behavior worth flagging

- **Blank IDs are dropped, not sent.** A blank ID on either side can't describe a merge. posthog-python drops with a warning; this does the same, rejecting `""` and whitespace-only. IDs that pass are sent exactly as given, never trimmed.
- **Person profile processing is left on**, as a merge requires — the helper doesn't stamp the `$process_person_profile: false` that `Event::new_anon` sets.
- **Construction lives in `Event::alias`**, so both clients share one definition of the payload and the guard, and neither can drift.
- **Not added:** a global `posthog_rs::alias()` alongside `global::capture`. #149 asks only for the two clients, and #150/#152 raise the same question — probably better decided once across all three helpers. Say the word and I'll add it here.

## :green_heart: How did you test it?

`tests/test_alias.rs` — 6 tests, mirrored across the blocking and async client modules. Verified against all five relevant feature combinations (30 test executions):

| Combination                                                   | Result   |
| ------------------------------------------------------------- | -------- |
| default (async + v0)                                          | 6 passed |
| `--features capture-v1` (async + v1)                          | 6 passed |
| `--no-default-features` (blocking + v0)                       | 6 passed |
| `--no-default-features --features error-tracking`             | 6 passed |
| `--no-default-features --features capture-v1` (blocking + v1) | 6 passed |

Coverage: payload shape, `$process_person_profile` not disabled, blank-ID drop on each side, `Into<String>` ergonomics with mixed `&str`/`String`, disabled-client no-op, and distinct event UUIDs across repeated calls.

The emitted event is identical on both capture pipelines — nothing in it is lifted into the V1 `options` object — so one file with a `CAPTURE_PATH` switch covers V0 and V1 rather than the split-file treatment error tracking needs.

I captured the real request body off a socket to confirm the wire format on both pipelines:

```json
{
  "event": "$create_alias",
  "distinct_id": "anon-abc123",
  "properties": {
    "alias": "user-42",
    "distinct_id": "anon-abc123",
    "$is_server": true
  }
}
```

**Mutation testing.** To check the tests actually catch regressions rather than just passing, I wrote 11 deliberately broken versions of `Event::alias` and confirmed each one fails the suite: swapped IDs, dropped `properties.distinct_id`, dropped `properties.alias`, wrong event name, event attributed to the new ID, guard removed, guard ignoring whitespace, guard checking only one side, merge marked personless, and a reused event UUID. All 11 are caught.

The UUID case was a genuine hole on the first pass — nothing asserted uniqueness, so `Uuid::nil()` passed everything. Since PostHog deduplicates on event UUID, that would have silently dropped every alias after the first. `repeated_aliases_get_distinct_event_uuids` closes it.

**Not covered, for transparency:** no run against a live PostHog instance (the `e2e-test` feature needs `POSTHOG_RS_E2E_TEST_API_KEY`, which CI holds), so this verifies the emitted bytes match the other SDKs rather than that the merge lands server-side. Unicode/very long IDs, concurrent `alias` calls, and `before_send` interaction are also untested.

Also run locally and passing: `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test --doc`, `cargo doc --no-deps` (no rustdoc warnings), `cargo publish --dry-run --locked`, and `scripts/check-public-api.sh`.

`api/public-api.txt` is regenerated via `scripts/check-public-api.sh --update`; the diff is one added line.

Two unrelated tests fail on my machine, on `main` as well as on this branch: `error_tracking::tests::from_error_builds_exception_list_with_stacktrace` and `inlined_frames_emit_expanded_groups`, both with `expected hex instruction_addr, got ""`. That's local stack symbolication on NixOS, not anything this branch touches — verified against a clean worktree at `main`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<sub>`sampo` isn't published as a binary I could install locally, so `.sampo/changesets/add-alias-helper.md` is hand-written to the format in RELEASING.md (`cargo/posthog-rs: minor`, matching the changesets from #184 and #186). Happy to regenerate it if the file needs anything else.</sub>

---

<sub>Written with AI assistance (Claude Code). I reviewed every line, ran the full feature matrix locally, and the SDK cross-references and mutation results above are ones I verified rather than took on trust. This is my first contribution here so please let me know if anything doesn't match how you like PRs shaped.</sub>
