### PR TITLE
fix: avoid self-joining the transport worker

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -918,22 +918,60 @@ impl Drop for Client {
     /// `shutdown` can't run in a destructor), so dropping a `Client` inside an
     /// async task blocks that executor thread until the drain completes (up to
     /// `shutdown_timeout_ms` plus any in-flight request) — prefer an explicit
-    /// `shutdown().await` first, which makes this a no-op.
+    /// `shutdown().await` first, which makes this a no-op. A drop from a transport
+    /// callback instead queues shutdown without waiting for or joining the current
+    /// worker thread.
     fn drop(&mut self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race or its
-        // shutdown wait was cancelled — so every shutdown/drop path waits for the
-        // worker and the flush stays durable. The winner has already sent the
-        // Shutdown (synchronously, before any await), so the worker will exit.
-        transport.join();
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::*;
+    use std::sync::{mpsc, Mutex};
+
+    #[tokio::test]
+    async fn drop_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Client>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (dropped_tx, dropped_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = callback_slot
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .take()
+                    .expect("client installed before capture");
+                drop(client);
+                dropped_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = client(options).await;
+        let transport = Arc::clone(client.transport.as_ref().unwrap());
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(client);
+
+        client_slot
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .unwrap()
+            .capture(Event::new("drop-in-callback", "user-1"));
+        dropped_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client drop blocked its transport worker");
+
+        // Reap the worker from an external thread and verify repeated close is safe.
+        transport.close_blocking();
+        transport.close_blocking();
+        assert!(transport.is_closed());
     }
 }
 

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -305,22 +305,26 @@ impl Client {
 
     /// Flush, stop the background worker, and join it. Idempotent: subsequent
     /// calls are no-ops. After shutdown, `capture` drops events. A no-op for
-    /// disabled clients.
+    /// disabled clients. When called from a transport callback, queues shutdown
+    /// without waiting for or joining the current worker thread.
     pub async fn shutdown(&self) {
         let Some(transport) = &self.transport else {
             return;
         };
+        let on_worker = transport.on_worker_thread();
         if transport.begin_close() {
             let (tx, rx) = tokio::sync::oneshot::channel();
-            if transport.send_control(Control::Shutdown(Completion::Async(tx))) {
+            if transport.send_control(Control::Shutdown(Completion::Async(tx))) && !on_worker {
                 let _ = rx.await;
             }
         }
-        // Always join — even if this caller lost the `begin_close` race or its
-        // shutdown wait was cancelled — so every shutdown/drop path waits for the
-        // worker and the flush stays durable. The winner has already sent the
-        // Shutdown (synchronously, before any await), so the worker will exit.
-        transport.join();
+        // Always join for external callers — even if this caller lost the
+        // `begin_close` race or its shutdown wait was cancelled — so every
+        // external shutdown/drop path waits for the worker and the flush stays
+        // durable. Joining from the worker itself would deadlock.
+        if !on_worker {
+            transport.join();
+        }
     }
 
     /// Capture a Rust error personlessly, sending it to PostHog Error Tracking.
@@ -932,6 +936,44 @@ impl Drop for Client {
 mod teardown_tests {
     use super::*;
     use std::sync::{mpsc, Mutex};
+
+    #[tokio::test]
+    async fn shutdown_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Arc<Client>>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = Arc::clone(
+                    callback_slot
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .as_ref()
+                        .expect("client installed before capture"),
+                );
+                futures::executor::block_on(client.shutdown());
+                shutdown_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = Arc::new(client(options).await);
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(Arc::clone(&client));
+
+        client.capture(Event::new("shutdown-in-callback", "user-1"));
+        shutdown_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client shutdown blocked its transport worker");
+        client_slot.lock().unwrap_or_else(|p| p.into_inner()).take();
+
+        // Reap the worker externally and verify repeated shutdown is safe.
+        client.shutdown().await;
+        client.shutdown().await;
+        assert!(client.transport.as_ref().unwrap().is_closed());
+    }
 
     #[tokio::test]
     async fn drop_from_worker_callback_closes_without_blocking() {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -309,19 +309,9 @@ impl Client {
     /// calls are no-ops. After shutdown, `capture` drops events. A no-op for
     /// disabled clients.
     pub fn shutdown(&self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race — so every
-        // shutdown/drop path waits for the worker and the flush stays durable. The
-        // winner has already sent the Shutdown, so the worker will exit.
-        transport.join();
     }
 
     /// Capture a Rust error personlessly, sending it to PostHog Error Tracking.
@@ -909,21 +899,59 @@ impl Client {
 
 impl Drop for Client {
     /// Best-effort flush and worker join on drop. An explicit `shutdown()`
-    /// beforehand makes this a no-op.
+    /// beforehand makes this a no-op. A drop from a transport callback queues
+    /// shutdown without waiting for or joining the current worker thread.
     fn drop(&mut self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race — so every
-        // shutdown/drop path waits for the worker and the flush stays durable. The
-        // winner has already sent the Shutdown, so the worker will exit.
-        transport.join();
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::*;
+    use std::sync::{mpsc, Mutex};
+
+    #[test]
+    fn drop_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Client>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (dropped_tx, dropped_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = callback_slot
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .take()
+                    .expect("client installed before capture");
+                drop(client);
+                dropped_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = client(options);
+        let transport = Arc::clone(client.transport.as_ref().unwrap());
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(client);
+
+        client_slot
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .unwrap()
+            .capture(Event::new("drop-in-callback", "user-1"));
+        dropped_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client drop blocked its transport worker");
+
+        // Reap the worker externally and verify repeated close remains a no-op.
+        transport.close_blocking();
+        transport.close_blocking();
+        assert!(transport.is_closed());
     }
 }
 

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -113,9 +113,8 @@ pub(crate) struct TransportHandle {
     max_queue_size: usize,
     /// Shares the worker's clock; used to stamp capture (enqueue) time.
     clock: Arc<dyn Clock>,
-    /// The worker thread's id, so the panic hook can tell when it is running on
-    /// this client's own worker — where capturing would deadlock or recurse.
-    #[cfg_attr(not(feature = "error-tracking"), allow(dead_code))]
+    /// The worker thread's id, so teardown and the panic hook can avoid waiting
+    /// for or joining this client's own worker.
     worker_id: Option<std::thread::ThreadId>,
 }
 
@@ -252,6 +251,23 @@ impl TransportHandle {
         !self.closed.swap(true, Ordering::AcqRel)
     }
 
+    /// Synchronously close and join the worker for external callers. When called
+    /// from the worker itself (for example, when a callback drops its client),
+    /// only queue the shutdown: waiting for its completion or joining here would
+    /// deadlock the worker inside its own callback.
+    pub(crate) fn close_blocking(&self) {
+        let on_worker = self.on_worker_thread();
+        if self.begin_close() {
+            let (tx, rx) = mpsc::channel();
+            if self.send_control(Control::Shutdown(Completion::Blocking(tx))) && !on_worker {
+                let _ = rx.recv();
+            }
+        }
+        if !on_worker {
+            self.join();
+        }
+    }
+
     /// Join the worker thread. Safe to call repeatedly.
     pub(crate) fn join(&self) {
         if let Some(handle) = self.worker.lock().unwrap_or_else(|p| p.into_inner()).take() {
@@ -294,11 +310,9 @@ impl TransportHandle {
         }
     }
 
-    /// True when the calling thread is this transport's worker thread. The panic
-    /// hook skips capturing there: a synchronous self-flush would deadlock the
-    /// worker, and routing the `$exception` back through `before_send` would
-    /// recurse if a `before_send` hook panicked.
-    #[cfg(feature = "error-tracking")]
+    /// True when the calling thread is this transport's worker thread. Teardown
+    /// must not synchronously wait there; the panic hook also skips capturing to
+    /// avoid a self-flush deadlock or recursive `before_send` panic.
     pub(crate) fn on_worker_thread(&self) -> bool {
         self.worker_id == Some(std::thread::current().id())
     }
@@ -306,14 +320,7 @@ impl TransportHandle {
     /// Test helper: flush + stop + join, mirroring the client's shutdown.
     #[cfg(test)]
     fn shutdown_blocking(&self) {
-        if !self.begin_close() {
-            return;
-        }
-        let (tx, rx) = mpsc::channel();
-        if self.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-            let _ = rx.recv();
-        }
-        self.join();
+        self.close_blocking();
     }
 }
 
@@ -1093,6 +1100,91 @@ mod tests {
             0,
             "dropped events left counted as pending"
         );
+    }
+
+    #[test]
+    fn close_from_worker_callback_does_not_wait_or_self_join() {
+        let handle_slot = Arc::new(Mutex::new(None::<Arc<TransportHandle>>));
+        let callback_slot = Arc::clone(&handle_slot);
+        let (returned_tx, returned_rx) = mpsc::channel();
+        let handle = Arc::new(TransportHandle::spawn(
+            options("http://localhost:0".to_string())
+                .flush_at(1usize)
+                .before_send(move |_| {
+                    let callback_handle = callback_slot
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .take()
+                        .expect("transport installed before capture");
+                    assert!(callback_handle.on_worker_thread());
+                    callback_handle.close_blocking();
+                    returned_tx.send(()).unwrap();
+                    None
+                })
+                .build()
+                .unwrap(),
+        ));
+        *handle_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(Arc::clone(&handle));
+
+        handle.enqueue(Event::new("close-in-callback", "user-1"));
+        returned_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("worker-thread close blocked");
+
+        // An external caller still performs the durable join, and repeats are no-ops.
+        handle.close_blocking();
+        handle.close_blocking();
+        assert!(handle.is_closed());
+        assert_eq!(handle.pending(), 0);
+    }
+
+    #[test]
+    fn concurrent_external_close_is_idempotent_and_durable() {
+        let server = MockServer::start();
+        let mock = ok_mock(&server);
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let handle = Arc::new(TransportHandle::spawn(
+            options(server.base_url())
+                .flush_at(1usize)
+                .before_send(move |event| {
+                    entered_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    Some(event)
+                })
+                .build()
+                .unwrap(),
+        ));
+        handle.enqueue(Event::new("close-race", "user-1"));
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("worker did not enter callback");
+
+        let start = Arc::new(std::sync::Barrier::new(3));
+        let closers: Vec<_> = (0..2)
+            .map(|_| {
+                let handle = Arc::clone(&handle);
+                let start = Arc::clone(&start);
+                thread::spawn(move || {
+                    start.wait();
+                    handle.close_blocking();
+                })
+            })
+            .collect();
+        start.wait();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !handle.is_closed() && Instant::now() < deadline {
+            thread::yield_now();
+        }
+        assert!(handle.is_closed(), "neither close caller won the race");
+        release_tx.send(()).unwrap();
+        for closer in closers {
+            closer.join().unwrap();
+        }
+
+        handle.close_blocking();
+        mock.assert_calls(1);
+        assert_eq!(handle.pending(), 0);
     }
 
     // -- virtual-clock worker tests (no real sleeps) -------------------------


### PR DESCRIPTION
## :bulb: Motivation and Context

Dropping a client or calling async `shutdown()` from a transport callback can run teardown on the transport worker itself. Waiting for shutdown completion or joining that same thread deadlocks.

## Changes

Centralize blocking transport teardown and guard async shutdown with the same worker-thread check. Worker-thread callers queue shutdown without waiting or joining, while external callers keep the existing durable close and join behavior.

## :green_heart: How did you test it?

Focused callback tests cover both `Drop` and async `shutdown()`, repeated teardown, and concurrent close behavior. The full library test suite passes with 257 tests. Blocking teardown was also checked with `--no-default-features --features error-tracking`.

Autoreview completed for commit `613aba1` against `origin/v1` with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
