### PR TITLE
refactor: share feature flag retry classification

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -918,22 +918,60 @@ impl Drop for Client {
     /// `shutdown` can't run in a destructor), so dropping a `Client` inside an
     /// async task blocks that executor thread until the drain completes (up to
     /// `shutdown_timeout_ms` plus any in-flight request) — prefer an explicit
-    /// `shutdown().await` first, which makes this a no-op.
+    /// `shutdown().await` first, which makes this a no-op. A drop from a transport
+    /// callback instead queues shutdown without waiting for or joining the current
+    /// worker thread.
     fn drop(&mut self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race or its
-        // shutdown wait was cancelled — so every shutdown/drop path waits for the
-        // worker and the flush stays durable. The winner has already sent the
-        // Shutdown (synchronously, before any await), so the worker will exit.
-        transport.join();
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::*;
+    use std::sync::{mpsc, Mutex};
+
+    #[tokio::test]
+    async fn drop_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Client>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (dropped_tx, dropped_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = callback_slot
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .take()
+                    .expect("client installed before capture");
+                drop(client);
+                dropped_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = client(options).await;
+        let transport = Arc::clone(client.transport.as_ref().unwrap());
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(client);
+
+        client_slot
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .unwrap()
+            .capture(Event::new("drop-in-callback", "user-1"));
+        dropped_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client drop blocked its transport worker");
+
+        // Reap the worker from an external thread and verify repeated close is safe.
+        transport.close_blocking();
+        transport.close_blocking();
+        assert!(transport.is_closed());
     }
 }
 

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -305,22 +305,26 @@ impl Client {
 
     /// Flush, stop the background worker, and join it. Idempotent: subsequent
     /// calls are no-ops. After shutdown, `capture` drops events. A no-op for
-    /// disabled clients.
+    /// disabled clients. When called from a transport callback, queues shutdown
+    /// without waiting for or joining the current worker thread.
     pub async fn shutdown(&self) {
         let Some(transport) = &self.transport else {
             return;
         };
+        let on_worker = transport.on_worker_thread();
         if transport.begin_close() {
             let (tx, rx) = tokio::sync::oneshot::channel();
-            if transport.send_control(Control::Shutdown(Completion::Async(tx))) {
+            if transport.send_control(Control::Shutdown(Completion::Async(tx))) && !on_worker {
                 let _ = rx.await;
             }
         }
-        // Always join — even if this caller lost the `begin_close` race or its
-        // shutdown wait was cancelled — so every shutdown/drop path waits for the
-        // worker and the flush stays durable. The winner has already sent the
-        // Shutdown (synchronously, before any await), so the worker will exit.
-        transport.join();
+        // Always join for external callers — even if this caller lost the
+        // `begin_close` race or its shutdown wait was cancelled — so every
+        // external shutdown/drop path waits for the worker and the flush stays
+        // durable. Joining from the worker itself would deadlock.
+        if !on_worker {
+            transport.join();
+        }
     }
 
     /// Capture a Rust error personlessly, sending it to PostHog Error Tracking.
@@ -932,6 +936,44 @@ impl Drop for Client {
 mod teardown_tests {
     use super::*;
     use std::sync::{mpsc, Mutex};
+
+    #[tokio::test]
+    async fn shutdown_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Arc<Client>>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = Arc::clone(
+                    callback_slot
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .as_ref()
+                        .expect("client installed before capture"),
+                );
+                futures::executor::block_on(client.shutdown());
+                shutdown_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = Arc::new(client(options).await);
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(Arc::clone(&client));
+
+        client.capture(Event::new("shutdown-in-callback", "user-1"));
+        shutdown_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client shutdown blocked its transport worker");
+        client_slot.lock().unwrap_or_else(|p| p.into_inner()).take();
+
+        // Reap the worker externally and verify repeated shutdown is safe.
+        client.shutdown().await;
+        client.shutdown().await;
+        assert!(client.transport.as_ref().unwrap().is_closed());
+    }
 
     #[tokio::test]
     async fn drop_from_worker_callback_closes_without_blocking() {

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -22,29 +22,6 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
-fn is_retryable_feature_flags_error(err: &reqwest::Error) -> bool {
-    if err.is_timeout() {
-        return true;
-    }
-
-    let mut source = std::error::Error::source(err);
-    while let Some(error) = source {
-        if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
-            return matches!(
-                io_error.kind(),
-                std::io::ErrorKind::ConnectionReset
-                    | std::io::ErrorKind::TimedOut
-                    | std::io::ErrorKind::UnexpectedEof
-            );
-        }
-        source = std::error::Error::source(error);
-    }
-
-    !err.to_string()
-        .to_lowercase()
-        .contains("connection refused")
-}
-
 use super::common::{
     already_reported, build_dedup_key, extract_flag_details, flag_called_event,
     flag_event_dedup_cache, local_record, remote_record_from_detail, report_flags_error,
@@ -822,7 +799,7 @@ impl Client {
                     match super::retry::feature_flags_after_transport_error(
                         &self.options,
                         attempt,
-                        is_retryable_feature_flags_error(&e),
+                        super::retry::is_retryable_feature_flags_error(&e),
                         err_msg,
                     ) {
                         super::retry::FeatureFlagsTransportStep::Backoff(delay) => {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -25,29 +25,6 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
-fn is_retryable_feature_flags_error(err: &reqwest::Error) -> bool {
-    if err.is_timeout() {
-        return true;
-    }
-
-    let mut source = std::error::Error::source(err);
-    while let Some(error) = source {
-        if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
-            return matches!(
-                io_error.kind(),
-                std::io::ErrorKind::ConnectionReset
-                    | std::io::ErrorKind::TimedOut
-                    | std::io::ErrorKind::UnexpectedEof
-            );
-        }
-        source = std::error::Error::source(error);
-    }
-
-    !err.to_string()
-        .to_lowercase()
-        .contains("connection refused")
-}
-
 use super::common::{
     already_reported, build_dedup_key, extract_flag_details, flag_called_event,
     flag_event_dedup_cache, local_record, remote_record_from_detail, report_flags_error,
@@ -809,7 +786,7 @@ impl Client {
                     match super::retry::feature_flags_after_transport_error(
                         &self.options,
                         attempt,
-                        is_retryable_feature_flags_error(&e),
+                        super::retry::is_retryable_feature_flags_error(&e),
                         err_msg,
                     ) {
                         super::retry::FeatureFlagsTransportStep::Backoff(delay) => {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -309,19 +309,9 @@ impl Client {
     /// calls are no-ops. After shutdown, `capture` drops events. A no-op for
     /// disabled clients.
     pub fn shutdown(&self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race — so every
-        // shutdown/drop path waits for the worker and the flush stays durable. The
-        // winner has already sent the Shutdown, so the worker will exit.
-        transport.join();
     }
 
     /// Capture a Rust error personlessly, sending it to PostHog Error Tracking.
@@ -909,21 +899,59 @@ impl Client {
 
 impl Drop for Client {
     /// Best-effort flush and worker join on drop. An explicit `shutdown()`
-    /// beforehand makes this a no-op.
+    /// beforehand makes this a no-op. A drop from a transport callback queues
+    /// shutdown without waiting for or joining the current worker thread.
     fn drop(&mut self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race — so every
-        // shutdown/drop path waits for the worker and the flush stays durable. The
-        // winner has already sent the Shutdown, so the worker will exit.
-        transport.join();
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::*;
+    use std::sync::{mpsc, Mutex};
+
+    #[test]
+    fn drop_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Client>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (dropped_tx, dropped_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = callback_slot
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .take()
+                    .expect("client installed before capture");
+                drop(client);
+                dropped_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = client(options);
+        let transport = Arc::clone(client.transport.as_ref().unwrap());
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(client);
+
+        client_slot
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .unwrap()
+            .capture(Event::new("drop-in-callback", "user-1"));
+        dropped_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client drop blocked its transport worker");
+
+        // Reap the worker externally and verify repeated close remains a no-op.
+        transport.close_blocking();
+        transport.close_blocking();
+        assert!(transport.is_closed());
     }
 }
 

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -1,4 +1,4 @@
-//! Runtime-agnostic retry primitives shared by the V0 and V1 capture paths.
+//! Runtime-agnostic retry primitives shared by client request paths.
 
 use std::time::{Duration, SystemTime};
 
@@ -34,6 +34,30 @@ pub(crate) enum FeatureFlagsTransportStep {
 /// caller surfaces it without burning the attempt budget.
 pub(crate) fn is_retryable_status(status: u16) -> bool {
     matches!(status, 408 | 500 | 502 | 503 | 504)
+}
+
+/// Classify transport errors from remote feature-flag requests.
+pub(crate) fn is_retryable_feature_flags_error(err: &reqwest::Error) -> bool {
+    if err.is_timeout() {
+        return true;
+    }
+
+    let mut source = std::error::Error::source(err);
+    while let Some(error) = source {
+        if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+            return matches!(
+                io_error.kind(),
+                std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::TimedOut
+                    | std::io::ErrorKind::UnexpectedEof
+            );
+        }
+        source = std::error::Error::source(error);
+    }
+
+    !err.to_string()
+        .to_lowercase()
+        .contains("connection refused")
 }
 
 /// Parse `Retry-After` as either delay-seconds or an HTTP-date.
@@ -140,6 +164,10 @@ pub(crate) fn feature_flags_after_transport_error(
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::{Shutdown, TcpListener};
+    use std::thread;
+
     use reqwest::header::{HeaderMap, HeaderValue};
 
     use super::*;
@@ -153,6 +181,17 @@ mod tests {
             .retry_max_backoff_ms(5000u64)
             .build()
             .unwrap()
+    }
+
+    fn has_io_error_kind(err: &reqwest::Error, expected: std::io::ErrorKind) -> bool {
+        let mut source = std::error::Error::source(err);
+        while let Some(error) = source {
+            if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+                return io_error.kind() == expected;
+            }
+            source = std::error::Error::source(error);
+        }
+        false
     }
 
     #[test]
@@ -175,6 +214,77 @@ mod tests {
                 code
             );
         }
+    }
+
+    #[test]
+    fn feature_flags_timeout_error_is_retryable() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            thread::sleep(Duration::from_millis(100));
+        });
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_millis(20))
+            .build()
+            .unwrap();
+
+        let err = client.get(url).send().unwrap_err();
+
+        assert!(err.is_timeout());
+        assert!(is_retryable_feature_flags_error(&err));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn feature_flags_unexpected_eof_error_is_retryable() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 10\r\n\r\n")
+                .unwrap();
+            let _ = stream.shutdown(Shutdown::Both);
+        });
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap();
+
+        let err = client.get(url).send().unwrap().bytes().unwrap_err();
+
+        assert!(has_io_error_kind(&err, std::io::ErrorKind::UnexpectedEof));
+        assert!(is_retryable_feature_flags_error(&err));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn feature_flags_connection_refused_error_is_not_retryable() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap();
+
+        let err = client.get(url).send().unwrap_err();
+
+        assert!(!is_retryable_feature_flags_error(&err));
+    }
+
+    #[test]
+    fn feature_flags_unknown_error_is_retryable() {
+        let err = reqwest::blocking::Client::new()
+            .get("ftp://example.com")
+            .send()
+            .unwrap_err();
+
+        assert!(is_retryable_feature_flags_error(&err));
     }
 
     #[test]

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -113,9 +113,8 @@ pub(crate) struct TransportHandle {
     max_queue_size: usize,
     /// Shares the worker's clock; used to stamp capture (enqueue) time.
     clock: Arc<dyn Clock>,
-    /// The worker thread's id, so the panic hook can tell when it is running on
-    /// this client's own worker — where capturing would deadlock or recurse.
-    #[cfg_attr(not(feature = "error-tracking"), allow(dead_code))]
+    /// The worker thread's id, so teardown and the panic hook can avoid waiting
+    /// for or joining this client's own worker.
     worker_id: Option<std::thread::ThreadId>,
 }
 
@@ -252,6 +251,23 @@ impl TransportHandle {
         !self.closed.swap(true, Ordering::AcqRel)
     }
 
+    /// Synchronously close and join the worker for external callers. When called
+    /// from the worker itself (for example, when a callback drops its client),
+    /// only queue the shutdown: waiting for its completion or joining here would
+    /// deadlock the worker inside its own callback.
+    pub(crate) fn close_blocking(&self) {
+        let on_worker = self.on_worker_thread();
+        if self.begin_close() {
+            let (tx, rx) = mpsc::channel();
+            if self.send_control(Control::Shutdown(Completion::Blocking(tx))) && !on_worker {
+                let _ = rx.recv();
+            }
+        }
+        if !on_worker {
+            self.join();
+        }
+    }
+
     /// Join the worker thread. Safe to call repeatedly.
     pub(crate) fn join(&self) {
         if let Some(handle) = self.worker.lock().unwrap_or_else(|p| p.into_inner()).take() {
@@ -294,11 +310,9 @@ impl TransportHandle {
         }
     }
 
-    /// True when the calling thread is this transport's worker thread. The panic
-    /// hook skips capturing there: a synchronous self-flush would deadlock the
-    /// worker, and routing the `$exception` back through `before_send` would
-    /// recurse if a `before_send` hook panicked.
-    #[cfg(feature = "error-tracking")]
+    /// True when the calling thread is this transport's worker thread. Teardown
+    /// must not synchronously wait there; the panic hook also skips capturing to
+    /// avoid a self-flush deadlock or recursive `before_send` panic.
     pub(crate) fn on_worker_thread(&self) -> bool {
         self.worker_id == Some(std::thread::current().id())
     }
@@ -306,14 +320,7 @@ impl TransportHandle {
     /// Test helper: flush + stop + join, mirroring the client's shutdown.
     #[cfg(test)]
     fn shutdown_blocking(&self) {
-        if !self.begin_close() {
-            return;
-        }
-        let (tx, rx) = mpsc::channel();
-        if self.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-            let _ = rx.recv();
-        }
-        self.join();
+        self.close_blocking();
     }
 }
 
@@ -1093,6 +1100,91 @@ mod tests {
             0,
             "dropped events left counted as pending"
         );
+    }
+
+    #[test]
+    fn close_from_worker_callback_does_not_wait_or_self_join() {
+        let handle_slot = Arc::new(Mutex::new(None::<Arc<TransportHandle>>));
+        let callback_slot = Arc::clone(&handle_slot);
+        let (returned_tx, returned_rx) = mpsc::channel();
+        let handle = Arc::new(TransportHandle::spawn(
+            options("http://localhost:0".to_string())
+                .flush_at(1usize)
+                .before_send(move |_| {
+                    let callback_handle = callback_slot
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .take()
+                        .expect("transport installed before capture");
+                    assert!(callback_handle.on_worker_thread());
+                    callback_handle.close_blocking();
+                    returned_tx.send(()).unwrap();
+                    None
+                })
+                .build()
+                .unwrap(),
+        ));
+        *handle_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(Arc::clone(&handle));
+
+        handle.enqueue(Event::new("close-in-callback", "user-1"));
+        returned_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("worker-thread close blocked");
+
+        // An external caller still performs the durable join, and repeats are no-ops.
+        handle.close_blocking();
+        handle.close_blocking();
+        assert!(handle.is_closed());
+        assert_eq!(handle.pending(), 0);
+    }
+
+    #[test]
+    fn concurrent_external_close_is_idempotent_and_durable() {
+        let server = MockServer::start();
+        let mock = ok_mock(&server);
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let handle = Arc::new(TransportHandle::spawn(
+            options(server.base_url())
+                .flush_at(1usize)
+                .before_send(move |event| {
+                    entered_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    Some(event)
+                })
+                .build()
+                .unwrap(),
+        ));
+        handle.enqueue(Event::new("close-race", "user-1"));
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("worker did not enter callback");
+
+        let start = Arc::new(std::sync::Barrier::new(3));
+        let closers: Vec<_> = (0..2)
+            .map(|_| {
+                let handle = Arc::clone(&handle);
+                let start = Arc::clone(&start);
+                thread::spawn(move || {
+                    start.wait();
+                    handle.close_blocking();
+                })
+            })
+            .collect();
+        start.wait();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !handle.is_closed() && Instant::now() < deadline {
+            thread::yield_now();
+        }
+        assert!(handle.is_closed(), "neither close caller won the race");
+        release_tx.send(()).unwrap();
+        for closer in closers {
+            closer.join().unwrap();
+        }
+
+        handle.close_blocking();
+        mock.assert_calls(1);
+        assert_eq!(handle.pending(), 0);
     }
 
     // -- virtual-clock worker tests (no real sleeps) -------------------------


### PR DESCRIPTION
## :bulb: Motivation and Context

The async and blocking feature flag clients carried identical transport error classification. Keeping two copies makes retry behavior easier to change in only one client mode.

## Changes

Move retry classification into the shared retry module and use it from both clients. The transport teardown fix previously underneath this branch landed on `main` in #233 and has since been merged into `v1`, so this PR now targets `v1` directly.

## :green_heart: How did you test it?

Classifier and feature flag request tests under default and blocking configurations.

Autoreview completed for this exact branch head and base with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

