### PR TITLE
refactor: share feature flag evaluation state

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -918,22 +918,60 @@ impl Drop for Client {
     /// `shutdown` can't run in a destructor), so dropping a `Client` inside an
     /// async task blocks that executor thread until the drain completes (up to
     /// `shutdown_timeout_ms` plus any in-flight request) — prefer an explicit
-    /// `shutdown().await` first, which makes this a no-op.
+    /// `shutdown().await` first, which makes this a no-op. A drop from a transport
+    /// callback instead queues shutdown without waiting for or joining the current
+    /// worker thread.
     fn drop(&mut self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race or its
-        // shutdown wait was cancelled — so every shutdown/drop path waits for the
-        // worker and the flush stays durable. The winner has already sent the
-        // Shutdown (synchronously, before any await), so the worker will exit.
-        transport.join();
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::*;
+    use std::sync::{mpsc, Mutex};
+
+    #[tokio::test]
+    async fn drop_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Client>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (dropped_tx, dropped_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = callback_slot
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .take()
+                    .expect("client installed before capture");
+                drop(client);
+                dropped_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = client(options).await;
+        let transport = Arc::clone(client.transport.as_ref().unwrap());
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(client);
+
+        client_slot
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .unwrap()
+            .capture(Event::new("drop-in-callback", "user-1"));
+        dropped_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client drop blocked its transport worker");
+
+        // Reap the worker from an external thread and verify repeated close is safe.
+        transport.close_blocking();
+        transport.close_blocking();
+        assert!(transport.is_closed());
     }
 }
 

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -305,22 +305,26 @@ impl Client {
 
     /// Flush, stop the background worker, and join it. Idempotent: subsequent
     /// calls are no-ops. After shutdown, `capture` drops events. A no-op for
-    /// disabled clients.
+    /// disabled clients. When called from a transport callback, queues shutdown
+    /// without waiting for or joining the current worker thread.
     pub async fn shutdown(&self) {
         let Some(transport) = &self.transport else {
             return;
         };
+        let on_worker = transport.on_worker_thread();
         if transport.begin_close() {
             let (tx, rx) = tokio::sync::oneshot::channel();
-            if transport.send_control(Control::Shutdown(Completion::Async(tx))) {
+            if transport.send_control(Control::Shutdown(Completion::Async(tx))) && !on_worker {
                 let _ = rx.await;
             }
         }
-        // Always join — even if this caller lost the `begin_close` race or its
-        // shutdown wait was cancelled — so every shutdown/drop path waits for the
-        // worker and the flush stays durable. The winner has already sent the
-        // Shutdown (synchronously, before any await), so the worker will exit.
-        transport.join();
+        // Always join for external callers — even if this caller lost the
+        // `begin_close` race or its shutdown wait was cancelled — so every
+        // external shutdown/drop path waits for the worker and the flush stays
+        // durable. Joining from the worker itself would deadlock.
+        if !on_worker {
+            transport.join();
+        }
     }
 
     /// Capture a Rust error personlessly, sending it to PostHog Error Tracking.
@@ -932,6 +936,44 @@ impl Drop for Client {
 mod teardown_tests {
     use super::*;
     use std::sync::{mpsc, Mutex};
+
+    #[tokio::test]
+    async fn shutdown_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Arc<Client>>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = Arc::clone(
+                    callback_slot
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .as_ref()
+                        .expect("client installed before capture"),
+                );
+                futures::executor::block_on(client.shutdown());
+                shutdown_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = Arc::new(client(options).await);
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(Arc::clone(&client));
+
+        client.capture(Event::new("shutdown-in-callback", "user-1"));
+        shutdown_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client shutdown blocked its transport worker");
+        client_slot.lock().unwrap_or_else(|p| p.into_inner()).take();
+
+        // Reap the worker externally and verify repeated shutdown is safe.
+        client.shutdown().await;
+        client.shutdown().await;
+        assert!(client.transport.as_ref().unwrap().is_closed());
+    }
 
     #[tokio::test]
     async fn drop_from_worker_callback_closes_without_blocking() {

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -22,29 +22,6 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
-fn is_retryable_feature_flags_error(err: &reqwest::Error) -> bool {
-    if err.is_timeout() {
-        return true;
-    }
-
-    let mut source = std::error::Error::source(err);
-    while let Some(error) = source {
-        if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
-            return matches!(
-                io_error.kind(),
-                std::io::ErrorKind::ConnectionReset
-                    | std::io::ErrorKind::TimedOut
-                    | std::io::ErrorKind::UnexpectedEof
-            );
-        }
-        source = std::error::Error::source(error);
-    }
-
-    !err.to_string()
-        .to_lowercase()
-        .contains("connection refused")
-}
-
 use super::common::{
     already_reported, build_dedup_key, extract_flag_details, flag_called_event,
     flag_event_dedup_cache, local_record, remote_record_from_detail, report_flags_error,
@@ -822,7 +799,7 @@ impl Client {
                     match super::retry::feature_flags_after_transport_error(
                         &self.options,
                         attempt,
-                        is_retryable_feature_flags_error(&e),
+                        super::retry::is_retryable_feature_flags_error(&e),
                         err_msg,
                     ) {
                         super::retry::FeatureFlagsTransportStep::Backoff(delay) => {

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -16,16 +16,14 @@ use crate::endpoints::Endpoint;
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
-    FlagCalledEventParams,
 };
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
 use super::common::{
-    already_reported, build_dedup_key, extract_flag_details, flag_called_event,
-    flag_event_dedup_cache, local_record, remote_record_from_detail, report_flags_error,
-    DetailedFlagsResponse, FlagEventDedupCache,
+    extract_flag_details, local_record, remote_record_from_detail, report_flags_error,
+    DetailedFlagsResponse, FlagEventHost,
 };
 use super::transport::{Completion, Control, TransportHandle};
 use super::{CaptureSummary, ClientOptions};
@@ -39,52 +37,6 @@ pub struct Client {
     flag_event_host: OnceLock<Arc<dyn FeatureFlagEvaluationsHost>>,
     /// Background event transport. `None` for disabled clients.
     transport: Option<Arc<TransportHandle>>,
-}
-
-/// Implementation of [`FeatureFlagEvaluationsHost`] that emits dedup-aware
-/// `$feature_flag_called` events through the same background capture transport
-/// as any other event.
-struct AsyncFlagEventHost {
-    options: ClientOptions,
-    transport: Option<Arc<TransportHandle>>,
-    dedup_cache: FlagEventDedupCache,
-}
-
-impl AsyncFlagEventHost {
-    fn from_options(options: &ClientOptions, transport: Option<Arc<TransportHandle>>) -> Self {
-        Self {
-            options: options.clone(),
-            transport,
-            dedup_cache: flag_event_dedup_cache(),
-        }
-    }
-
-    fn enqueue(&self, event: Event) {
-        if let Some(transport) = &self.transport {
-            transport.enqueue(event);
-        }
-    }
-}
-
-impl FeatureFlagEvaluationsHost for AsyncFlagEventHost {
-    fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
-        let dedup_key = build_dedup_key(&params.key, params.response.as_ref(), &params.groups);
-        if already_reported(&self.dedup_cache, &params.distinct_id, &dedup_key) {
-            return;
-        }
-
-        if let Some(event) =
-            flag_called_event(params, self.options.disable_geoip, self.options.is_server)
-        {
-            self.enqueue(event);
-        }
-    }
-
-    fn log_warning(&self, message: &str) {
-        // Surface filter-helper misuse via tracing — users can silence these
-        // with their tracing-subscriber level filter (e.g. `posthog_rs=error`).
-        warn!("{message}");
-    }
 }
 
 /// Construct an async PostHog client from an API key or [`ClientOptions`].
@@ -746,8 +698,8 @@ impl Client {
     fn flag_event_host(&self) -> Arc<dyn FeatureFlagEvaluationsHost> {
         self.flag_event_host
             .get_or_init(|| {
-                Arc::new(AsyncFlagEventHost::from_options(
-                    &self.options,
+                Arc::new(FlagEventHost::new(
+                    self.options.capture_defaults(),
                     self.transport.clone(),
                 )) as Arc<dyn FeatureFlagEvaluationsHost>
             })

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 #[cfg(feature = "error-tracking")]
 use std::error::Error as StdError;
 use std::sync::{Arc, OnceLock};
@@ -8,22 +8,21 @@ use reqwest::{header::CONTENT_TYPE, header::USER_AGENT, Client as HttpClient};
 use serde_json::json;
 #[cfg(feature = "error-tracking")]
 use tracing::trace;
-use tracing::{debug, instrument, warn};
+use tracing::{instrument, warn};
 
 use super::get_default_user_agent;
 use crate::endpoints::Endpoint;
 #[cfg(feature = "error-tracking")]
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
 use crate::feature_flag_evaluations::{
-    EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
+    EvaluateFlagsOptions, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
 };
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{AsyncFlagPoller, FlagCache, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
 use super::common::{
-    extract_flag_details, local_record, remote_record_from_detail, report_flags_error,
-    DetailedFlagsResponse, FlagEventHost,
+    extract_flag_details, report_flags_error, DetailedFlagsResponse, EvaluationState, FlagEventHost,
 };
 use super::transport::{Completion, Control, TransportHandle};
 use super::{CaptureSummary, ClientOptions};
@@ -587,112 +586,15 @@ impl Client {
             return Ok(FeatureFlagEvaluations::empty(host));
         }
 
-        let mut options = options;
-        options.groups.get_or_insert_with(HashMap::new);
-        options.group_properties.get_or_insert_with(HashMap::new);
-
-        let mut records: HashMap<String, EvaluatedFlagRecord> = HashMap::new();
-        let mut locally_evaluated_keys: HashSet<String> = HashSet::new();
-
-        if let Some(evaluator) = &self.local_evaluator {
-            let mut person_props_owned = options.person_properties.clone().unwrap_or_default();
-            person_props_owned
-                .entry("distinct_id".to_string())
-                .or_insert_with(|| json!(distinct_id.clone()));
-            let groups_owned = options.groups.clone().unwrap_or_default();
-            let group_props_owned = options.group_properties.clone().unwrap_or_default();
-            let local_results = evaluator.evaluate_all_flags_with_details(
-                &distinct_id,
-                &person_props_owned,
-                &groups_owned,
-                &group_props_owned,
-            );
-            // Pin the gate from the poller's current definitions snapshot at the
-            // point local evaluation succeeded, so it travels with these records
-            // rather than being re-read from shared state at event time.
-            let local_minimal_gate = evaluator.cache().minimal_flag_called_events();
-            for (key, result) in local_results {
-                if let Some(filter) = &options.flag_keys {
-                    if !filter.iter().any(|k| k == &key) {
-                        continue;
-                    }
-                }
-                if let Ok(value) = result.result {
-                    records.insert(
-                        key.clone(),
-                        local_record(
-                            value,
-                            result.payload,
-                            result.has_experiment,
-                            local_minimal_gate,
-                        ),
-                    );
-                    locally_evaluated_keys.insert(key);
-                }
-            }
+        let mut state = EvaluationState::new(distinct_id, options, self.local_evaluator.as_ref());
+        if state.should_fetch_remote(self.options.local_evaluation_only) {
+            let response = self
+                .fetch_flag_details(state.distinct_id(), state.options())
+                .await;
+            state.apply_remote_result(response)?;
         }
 
-        let mut request_id: Option<String> = None;
-        let mut errors_while_computing = false;
-        let mut quota_limited = false;
-
-        // Skip the remote round-trip when local evaluation has already covered
-        // every requested flag. Without `flag_keys` we have to assume the caller
-        // wants every flag the project has and still hit `/flags` to discover
-        // any not loaded by the poller.
-        let local_covers_request = options
-            .flag_keys
-            .as_ref()
-            .is_some_and(|keys| keys.iter().all(|k| locally_evaluated_keys.contains(k)));
-
-        if !options.only_evaluate_locally
-            && !self.options.local_evaluation_only
-            && !local_covers_request
-        {
-            // Don't lose successful local evaluations if `/flags` fails — degrade
-            // to a snapshot built from the local results we already have. The
-            // alternative (returning Err) wastes useful data and surprises
-            // callers who would otherwise get partial coverage.
-            match self.fetch_flag_details(&distinct_id, &options).await {
-                Ok(response) => {
-                    request_id = response.request_id;
-                    errors_while_computing = response.errors_while_computing_flags;
-                    quota_limited = response.quota_limited;
-                    // The remote response is the source of these flags' values,
-                    // so it is also the source of their minimization gate.
-                    let remote_minimal_gate = response.minimal_flag_called_events;
-                    for (key, detail) in response.flags {
-                        if locally_evaluated_keys.contains(&key) {
-                            continue;
-                        }
-                        records.insert(key, remote_record_from_detail(detail, remote_minimal_gate));
-                    }
-                }
-                Err(e) => {
-                    if records.is_empty() {
-                        return Err(e);
-                    }
-                    debug!(
-                        error = e.to_string(),
-                        local_count = records.len(),
-                        "/flags fetch failed; returning snapshot from local results only"
-                    );
-                    errors_while_computing = true;
-                }
-            }
-        }
-
-        Ok(FeatureFlagEvaluations::new(
-            host,
-            distinct_id,
-            records,
-            options.groups.unwrap_or_default(),
-            options.disable_geoip,
-            request_id,
-            None,
-            errors_while_computing,
-            quota_limited,
-        ))
+        Ok(state.into_evaluations(host))
     }
 
     fn flag_event_host(&self) -> Arc<dyn FeatureFlagEvaluationsHost> {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -25,29 +25,6 @@ use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
-fn is_retryable_feature_flags_error(err: &reqwest::Error) -> bool {
-    if err.is_timeout() {
-        return true;
-    }
-
-    let mut source = std::error::Error::source(err);
-    while let Some(error) = source {
-        if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
-            return matches!(
-                io_error.kind(),
-                std::io::ErrorKind::ConnectionReset
-                    | std::io::ErrorKind::TimedOut
-                    | std::io::ErrorKind::UnexpectedEof
-            );
-        }
-        source = std::error::Error::source(error);
-    }
-
-    !err.to_string()
-        .to_lowercase()
-        .contains("connection refused")
-}
-
 use super::common::{
     already_reported, build_dedup_key, extract_flag_details, flag_called_event,
     flag_event_dedup_cache, local_record, remote_record_from_detail, report_flags_error,
@@ -809,7 +786,7 @@ impl Client {
                     match super::retry::feature_flags_after_transport_error(
                         &self.options,
                         attempt,
-                        is_retryable_feature_flags_error(&e),
+                        super::retry::is_retryable_feature_flags_error(&e),
                         err_msg,
                     ) {
                         super::retry::FeatureFlagsTransportStep::Backoff(delay) => {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 #[cfg(feature = "error-tracking")]
 use std::error::Error as StdError;
 use std::sync::{Arc, OnceLock};
@@ -11,22 +11,21 @@ use reqwest::{
 use serde_json::json;
 #[cfg(feature = "error-tracking")]
 use tracing::trace;
-use tracing::{debug, instrument, warn};
+use tracing::{instrument, warn};
 
 use super::get_default_user_agent;
 use crate::endpoints::Endpoint;
 #[cfg(feature = "error-tracking")]
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
 use crate::feature_flag_evaluations::{
-    EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
+    EvaluateFlagsOptions, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
 };
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
 use super::common::{
-    extract_flag_details, local_record, remote_record_from_detail, report_flags_error,
-    DetailedFlagsResponse, FlagEventHost,
+    extract_flag_details, report_flags_error, DetailedFlagsResponse, EvaluationState, FlagEventHost,
 };
 use super::transport::{Completion, Control, TransportHandle};
 use super::{CaptureSummary, ClientOptions};
@@ -573,112 +572,13 @@ impl Client {
             return Ok(FeatureFlagEvaluations::empty(host));
         }
 
-        let mut options = options;
-        options.groups.get_or_insert_with(HashMap::new);
-        options.group_properties.get_or_insert_with(HashMap::new);
-
-        let mut records: HashMap<String, EvaluatedFlagRecord> = HashMap::new();
-        let mut locally_evaluated_keys: HashSet<String> = HashSet::new();
-
-        if let Some(evaluator) = &self.local_evaluator {
-            let mut person_props_owned = options.person_properties.clone().unwrap_or_default();
-            person_props_owned
-                .entry("distinct_id".to_string())
-                .or_insert_with(|| json!(distinct_id.clone()));
-            let groups_owned = options.groups.clone().unwrap_or_default();
-            let group_props_owned = options.group_properties.clone().unwrap_or_default();
-            let local_results = evaluator.evaluate_all_flags_with_details(
-                &distinct_id,
-                &person_props_owned,
-                &groups_owned,
-                &group_props_owned,
-            );
-            // Pin the gate from the poller's current definitions snapshot at the
-            // point local evaluation succeeded, so it travels with these records
-            // rather than being re-read from shared state at event time.
-            let local_minimal_gate = evaluator.cache().minimal_flag_called_events();
-            for (key, result) in local_results {
-                if let Some(filter) = &options.flag_keys {
-                    if !filter.iter().any(|k| k == &key) {
-                        continue;
-                    }
-                }
-                if let Ok(value) = result.result {
-                    records.insert(
-                        key.clone(),
-                        local_record(
-                            value,
-                            result.payload,
-                            result.has_experiment,
-                            local_minimal_gate,
-                        ),
-                    );
-                    locally_evaluated_keys.insert(key);
-                }
-            }
+        let mut state = EvaluationState::new(distinct_id, options, self.local_evaluator.as_ref());
+        if state.should_fetch_remote(self.options.local_evaluation_only) {
+            let response = self.fetch_flag_details(state.distinct_id(), state.options());
+            state.apply_remote_result(response)?;
         }
 
-        let mut request_id: Option<String> = None;
-        let mut errors_while_computing = false;
-        let mut quota_limited = false;
-
-        // Skip the remote round-trip when local evaluation has already covered
-        // every requested flag. Without `flag_keys` we have to assume the caller
-        // wants every flag the project has and still hit `/flags` to discover
-        // any not loaded by the poller.
-        let local_covers_request = options
-            .flag_keys
-            .as_ref()
-            .is_some_and(|keys| keys.iter().all(|k| locally_evaluated_keys.contains(k)));
-
-        if !options.only_evaluate_locally
-            && !self.options.local_evaluation_only
-            && !local_covers_request
-        {
-            // Don't lose successful local evaluations if `/flags` fails — degrade
-            // to a snapshot built from the local results we already have. The
-            // alternative (returning Err) wastes useful data and surprises
-            // callers who would otherwise get partial coverage.
-            match self.fetch_flag_details(&distinct_id, &options) {
-                Ok(response) => {
-                    request_id = response.request_id;
-                    errors_while_computing = response.errors_while_computing_flags;
-                    quota_limited = response.quota_limited;
-                    // The remote response is the source of these flags' values,
-                    // so it is also the source of their minimization gate.
-                    let remote_minimal_gate = response.minimal_flag_called_events;
-                    for (key, detail) in response.flags {
-                        if locally_evaluated_keys.contains(&key) {
-                            continue;
-                        }
-                        records.insert(key, remote_record_from_detail(detail, remote_minimal_gate));
-                    }
-                }
-                Err(e) => {
-                    if records.is_empty() {
-                        return Err(e);
-                    }
-                    debug!(
-                        error = e.to_string(),
-                        local_count = records.len(),
-                        "/flags fetch failed; returning snapshot from local results only"
-                    );
-                    errors_while_computing = true;
-                }
-            }
-        }
-
-        Ok(FeatureFlagEvaluations::new(
-            host,
-            distinct_id,
-            records,
-            options.groups.unwrap_or_default(),
-            options.disable_geoip,
-            request_id,
-            None,
-            errors_while_computing,
-            quota_limited,
-        ))
+        Ok(state.into_evaluations(host))
     }
 
     fn flag_event_host(&self) -> Arc<dyn FeatureFlagEvaluationsHost> {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -19,16 +19,14 @@ use crate::endpoints::Endpoint;
 use crate::error_tracking::{build_exception_event, CaptureExceptionOptions};
 use crate::feature_flag_evaluations::{
     EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
-    FlagCalledEventParams,
 };
 use crate::feature_flags::{match_feature_flag, FeatureFlag, FeatureFlagsResponse, FlagValue};
 use crate::local_evaluation::{FlagCache, FlagPoller, LocalEvaluationConfig, LocalEvaluator};
 use crate::{Error, Event};
 
 use super::common::{
-    already_reported, build_dedup_key, extract_flag_details, flag_called_event,
-    flag_event_dedup_cache, local_record, remote_record_from_detail, report_flags_error,
-    DetailedFlagsResponse, FlagEventDedupCache,
+    extract_flag_details, local_record, remote_record_from_detail, report_flags_error,
+    DetailedFlagsResponse, FlagEventHost,
 };
 use super::transport::{Completion, Control, TransportHandle};
 use super::{CaptureSummary, ClientOptions};
@@ -42,53 +40,6 @@ pub struct Client {
     flag_event_host: OnceLock<Arc<dyn FeatureFlagEvaluationsHost>>,
     /// Background event transport. `None` for disabled clients.
     transport: Option<Arc<TransportHandle>>,
-}
-
-/// Implementation of [`FeatureFlagEvaluationsHost`] that emits dedup-aware
-/// `$feature_flag_called` events through the same background capture transport
-/// as any other event. Constructed lazily and cached on the [`Client`] so all
-/// snapshots share a single dedup cache.
-struct BlockingFlagEventHost {
-    options: ClientOptions,
-    transport: Option<Arc<TransportHandle>>,
-    dedup_cache: FlagEventDedupCache,
-}
-
-impl BlockingFlagEventHost {
-    fn from_options(options: &ClientOptions, transport: Option<Arc<TransportHandle>>) -> Self {
-        Self {
-            options: options.clone(),
-            transport,
-            dedup_cache: flag_event_dedup_cache(),
-        }
-    }
-
-    fn enqueue(&self, event: Event) {
-        if let Some(transport) = &self.transport {
-            transport.enqueue(event);
-        }
-    }
-}
-
-impl FeatureFlagEvaluationsHost for BlockingFlagEventHost {
-    fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
-        let dedup_key = build_dedup_key(&params.key, params.response.as_ref(), &params.groups);
-        if already_reported(&self.dedup_cache, &params.distinct_id, &dedup_key) {
-            return;
-        }
-
-        if let Some(event) =
-            flag_called_event(params, self.options.disable_geoip, self.options.is_server)
-        {
-            self.enqueue(event);
-        }
-    }
-
-    fn log_warning(&self, message: &str) {
-        // Surface filter-helper misuse via tracing — users can silence these
-        // with their tracing-subscriber level filter (e.g. `posthog_rs=error`).
-        warn!("{message}");
-    }
 }
 
 /// Construct a blocking PostHog client from an API key or [`ClientOptions`].
@@ -733,8 +684,8 @@ impl Client {
     fn flag_event_host(&self) -> Arc<dyn FeatureFlagEvaluationsHost> {
         self.flag_event_host
             .get_or_init(|| {
-                Arc::new(BlockingFlagEventHost::from_options(
-                    &self.options,
+                Arc::new(FlagEventHost::new(
+                    self.options.capture_defaults(),
                     self.transport.clone(),
                 )) as Arc<dyn FeatureFlagEvaluationsHost>
             })

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -309,19 +309,9 @@ impl Client {
     /// calls are no-ops. After shutdown, `capture` drops events. A no-op for
     /// disabled clients.
     pub fn shutdown(&self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race — so every
-        // shutdown/drop path waits for the worker and the flush stays durable. The
-        // winner has already sent the Shutdown, so the worker will exit.
-        transport.join();
     }
 
     /// Capture a Rust error personlessly, sending it to PostHog Error Tracking.
@@ -909,21 +899,59 @@ impl Client {
 
 impl Drop for Client {
     /// Best-effort flush and worker join on drop. An explicit `shutdown()`
-    /// beforehand makes this a no-op.
+    /// beforehand makes this a no-op. A drop from a transport callback queues
+    /// shutdown without waiting for or joining the current worker thread.
     fn drop(&mut self) {
-        let Some(transport) = &self.transport else {
-            return;
-        };
-        if transport.begin_close() {
-            let (tx, rx) = std::sync::mpsc::channel();
-            if transport.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-                let _ = rx.recv();
-            }
+        if let Some(transport) = &self.transport {
+            transport.close_blocking();
         }
-        // Always join — even if this caller lost the `begin_close` race — so every
-        // shutdown/drop path waits for the worker and the flush stays durable. The
-        // winner has already sent the Shutdown, so the worker will exit.
-        transport.join();
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::*;
+    use std::sync::{mpsc, Mutex};
+
+    #[test]
+    fn drop_from_worker_callback_closes_without_blocking() {
+        let client_slot = Arc::new(Mutex::new(None::<Client>));
+        let callback_slot = Arc::clone(&client_slot);
+        let (dropped_tx, dropped_rx) = mpsc::channel();
+        let options = crate::ClientOptionsBuilder::default()
+            .api_key("phc_test".to_string())
+            .host("http://localhost:0".to_string())
+            .flush_at(1usize)
+            .before_send(move |_| {
+                let client = callback_slot
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .take()
+                    .expect("client installed before capture");
+                drop(client);
+                dropped_tx.send(()).unwrap();
+                None
+            })
+            .build()
+            .unwrap();
+        let client = client(options);
+        let transport = Arc::clone(client.transport.as_ref().unwrap());
+        *client_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(client);
+
+        client_slot
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .unwrap()
+            .capture(Event::new("drop-in-callback", "user-1"));
+        dropped_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("client drop blocked its transport worker");
+
+        // Reap the worker externally and verify repeated close remains a no-op.
+        transport.close_blocking();
+        transport.close_blocking();
+        assert!(transport.is_closed());
     }
 }
 

--- a/src/client/capture.rs
+++ b/src/client/capture.rs
@@ -13,7 +13,7 @@ use super::retry::{backoff_duration, is_retryable_status};
 // `capture::parse_retry_after` / `capture::Step`.
 pub(crate) use super::retry::{parse_retry_after, Step};
 use super::{
-    common::{apply_before_send_hooks, apply_capture_defaults, apply_runtime_context},
+    common::{apply_runtime_context, preprocess_capture_event},
     CaptureCompression, CaptureDefaults, ClientOptions,
 };
 use crate::capture_event::{
@@ -166,10 +166,7 @@ pub(crate) fn prepare_immediate(
     let defaults = opts.capture_defaults();
     let events: Vec<Event> = events
         .into_iter()
-        .filter_map(|mut event| {
-            apply_capture_defaults(&mut event, &defaults);
-            apply_before_send_hooks(&opts.before_send, event)
-        })
+        .filter_map(|event| preprocess_capture_event(event, &defaults, &opts.before_send))
         .collect();
     if events.is_empty() {
         return None;

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -48,7 +48,7 @@ pub(super) fn flag_event_dedup_cache() -> FlagEventDedupCache {
     Mutex::new(HashMap::new())
 }
 
-pub(super) fn apply_capture_defaults(event: &mut Event, defaults: &CaptureDefaults) {
+fn apply_capture_defaults(event: &mut Event, defaults: &CaptureDefaults) {
     if defaults.disable_geoip {
         event.insert_prop_default("$geoip_disable", serde_json::Value::Bool(true));
     }
@@ -57,7 +57,16 @@ pub(super) fn apply_capture_defaults(event: &mut Event, defaults: &CaptureDefaul
     }
 }
 
-pub(super) fn apply_before_send_hooks(hooks: &[BeforeSendHook], event: Event) -> Option<Event> {
+pub(super) fn preprocess_capture_event(
+    mut event: Event,
+    defaults: &CaptureDefaults,
+    hooks: &[BeforeSendHook],
+) -> Option<Event> {
+    apply_capture_defaults(&mut event, defaults);
+    apply_before_send_hooks(hooks, event)
+}
+
+fn apply_before_send_hooks(hooks: &[BeforeSendHook], event: Event) -> Option<Event> {
     let mut current = Some(event);
 
     for hook in hooks {

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,22 +1,26 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::client::BeforeSendHook;
 use crate::client::CaptureDefaults;
 use crate::client::FlagsFailure;
 use crate::client::OnErrorHook;
 use crate::client::PostHogError;
-use crate::feature_flag_evaluations::{EvaluatedFlagRecord, FlagCalledEventParams};
+use crate::feature_flag_evaluations::{
+    EvaluatedFlagRecord, FeatureFlagEvaluationsHost, FlagCalledEventParams,
+};
 use crate::feature_flags::{FeatureFlagsResponse, FlagDetail, FlagMetadata, FlagValue};
 use crate::Error;
 use crate::Event;
-use tracing::error;
+use tracing::{error, warn};
+
+use super::transport::TransportHandle;
 
 /// Cap on the number of `distinct_id` entries in the `$feature_flag_called`
 /// dedup cache. On overflow the entire map is reset (matches the JS SDK).
-pub(super) const MAX_FLAG_CALLED_CACHE_SIZE: usize = 50_000;
+const MAX_FLAG_CALLED_CACHE_SIZE: usize = 50_000;
 
-pub(super) type FlagEventDedupCache = Mutex<HashMap<String, HashSet<String>>>;
+type FlagEventDedupCache = Mutex<HashMap<String, HashSet<String>>>;
 
 struct RuntimeContext {
     os: String,
@@ -44,8 +48,49 @@ pub(super) fn apply_runtime_context(event: &mut Event) {
     );
 }
 
-pub(super) fn flag_event_dedup_cache() -> FlagEventDedupCache {
+fn flag_event_dedup_cache() -> FlagEventDedupCache {
     Mutex::new(HashMap::new())
+}
+
+/// Runtime-neutral host for deduplicating and enqueueing
+/// `$feature_flag_called` events. Each client lazily constructs its own host so
+/// snapshots from that client share one dedup cache without sharing across
+/// clients.
+pub(super) struct FlagEventHost {
+    defaults: CaptureDefaults,
+    transport: Option<Arc<TransportHandle>>,
+    dedup_cache: FlagEventDedupCache,
+}
+
+impl FlagEventHost {
+    pub(super) fn new(defaults: CaptureDefaults, transport: Option<Arc<TransportHandle>>) -> Self {
+        Self {
+            defaults,
+            transport,
+            dedup_cache: flag_event_dedup_cache(),
+        }
+    }
+}
+
+impl FeatureFlagEvaluationsHost for FlagEventHost {
+    fn capture_flag_called_event_if_needed(&self, params: FlagCalledEventParams) {
+        let dedup_key = build_dedup_key(&params.key, params.response.as_ref(), &params.groups);
+        if already_reported(&self.dedup_cache, &params.distinct_id, &dedup_key) {
+            return;
+        }
+
+        if let (Some(transport), Some(event)) =
+            (&self.transport, flag_called_event(params, &self.defaults))
+        {
+            transport.enqueue(event);
+        }
+    }
+
+    fn log_warning(&self, message: &str) {
+        // Surface filter-helper misuse via tracing — users can silence these
+        // with their tracing-subscriber level filter (e.g. `posthog_rs=error`).
+        warn!("{message}");
+    }
 }
 
 fn apply_capture_defaults(event: &mut Event, defaults: &CaptureDefaults) {
@@ -127,11 +172,7 @@ pub(crate) fn report_flags_error(
 
 /// Returns `true` when the helper has already shipped this
 /// `(distinct_id, key, response)` combination and the caller should skip.
-pub(super) fn already_reported(
-    cache: &FlagEventDedupCache,
-    distinct_id: &str,
-    dedup_key: &str,
-) -> bool {
+fn already_reported(cache: &FlagEventDedupCache, distinct_id: &str, dedup_key: &str) -> bool {
     let mut cache = cache.lock().unwrap_or_else(|p| p.into_inner());
     if let Some(seen) = cache.get(distinct_id) {
         if seen.contains(dedup_key) {
@@ -148,7 +189,7 @@ pub(super) fn already_reported(
     false
 }
 
-pub(super) fn build_dedup_key(
+fn build_dedup_key(
     flag_key: &str,
     response: Option<&FlagValue>,
     groups: &HashMap<String, String>,
@@ -182,11 +223,7 @@ fn pct(s: &str) -> String {
         .replace(';', "%3B")
 }
 
-pub(super) fn flag_called_event(
-    params: FlagCalledEventParams,
-    client_disable_geoip: bool,
-    is_server: bool,
-) -> Option<Event> {
+fn flag_called_event(params: FlagCalledEventParams, defaults: &CaptureDefaults) -> Option<Event> {
     let mut event = Event::new("$feature_flag_called".to_string(), params.distinct_id);
     if params.minimal {
         // Marks the event so the capture pipeline trims it to the minimal
@@ -202,10 +239,10 @@ pub(super) fn flag_called_event(
     for (group_name, group_id) in &params.groups {
         event.add_group(group_name, group_id);
     }
-    if params.disable_geoip.unwrap_or(client_disable_geoip) {
+    if params.disable_geoip.unwrap_or(defaults.disable_geoip) {
         event.insert_prop_default("$geoip_disable", serde_json::Value::Bool(true));
     }
-    if is_server {
+    if defaults.is_server {
         event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
     }
     Some(event)
@@ -357,6 +394,13 @@ mod tests {
             .collect()
     }
 
+    fn defaults(disable_geoip: bool, is_server: bool) -> CaptureDefaults {
+        CaptureDefaults {
+            disable_geoip,
+            is_server,
+        }
+    }
+
     fn flag_params(
         properties: HashMap<String, serde_json::Value>,
         groups: HashMap<String, String>,
@@ -408,8 +452,7 @@ mod tests {
 
         let event = flag_called_event(
             flag_params(properties, groups(&[("organization", "org-a")]), Some(true)),
-            true,
-            true,
+            &defaults(true, true),
         )
         .expect("valid flag-called event");
 
@@ -428,13 +471,38 @@ mod tests {
     fn flag_called_event_adds_defaults_when_missing() {
         let event = flag_called_event(
             flag_params(HashMap::new(), HashMap::new(), None),
-            true,
-            true,
+            &defaults(true, true),
         )
         .expect("valid flag-called event");
 
         assert_eq!(event.properties().get("$is_server"), Some(&json!(true)));
         assert_eq!(event.properties().get("$geoip_disable"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn flag_event_hosts_keep_dedup_state_separate() {
+        let first = FlagEventHost::new(defaults(false, true), None);
+        let second = FlagEventHost::new(defaults(false, true), None);
+        let params = flag_params(HashMap::new(), HashMap::new(), None);
+
+        first.capture_flag_called_event_if_needed(params.clone());
+        first.capture_flag_called_event_if_needed(params.clone());
+
+        let first_cache = first.dedup_cache.lock().unwrap();
+        assert_eq!(first_cache.get("user-1").map(HashSet::len), Some(1));
+        drop(first_cache);
+        assert!(second.dedup_cache.lock().unwrap().is_empty());
+
+        second.capture_flag_called_event_if_needed(params);
+        assert_eq!(
+            second
+                .dedup_cache
+                .lock()
+                .unwrap()
+                .get("user-1")
+                .map(HashSet::len),
+            Some(1)
+        );
     }
 
     #[test]
@@ -453,8 +521,7 @@ mod tests {
     fn flag_called_event_leaves_runtime_context_to_capture_path() {
         let event = flag_called_event(
             flag_params(HashMap::new(), HashMap::new(), None),
-            false,
-            true,
+            &defaults(false, true),
         )
         .expect("valid flag-called event");
 

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -7,12 +7,14 @@ use crate::client::FlagsFailure;
 use crate::client::OnErrorHook;
 use crate::client::PostHogError;
 use crate::feature_flag_evaluations::{
-    EvaluatedFlagRecord, FeatureFlagEvaluationsHost, FlagCalledEventParams,
+    EvaluateFlagsOptions, EvaluatedFlagRecord, FeatureFlagEvaluations, FeatureFlagEvaluationsHost,
+    FlagCalledEventParams,
 };
 use crate::feature_flags::{FeatureFlagsResponse, FlagDetail, FlagMetadata, FlagValue};
+use crate::local_evaluation::LocalEvaluator;
 use crate::Error;
 use crate::Event;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use super::transport::TransportHandle;
 
@@ -318,7 +320,155 @@ pub(super) fn extract_flag_details(response: FeatureFlagsResponse) -> DetailedFl
     }
 }
 
-pub(super) fn local_record(
+/// Shared policy for combining local and remote flag evaluations. The clients
+/// retain their concrete HTTP and async/blocking boundaries; this state owns
+/// only the runtime-neutral decisions on whether to fetch and how to merge.
+pub(super) struct EvaluationState {
+    distinct_id: String,
+    options: EvaluateFlagsOptions,
+    records: HashMap<String, EvaluatedFlagRecord>,
+    request_id: Option<String>,
+    errors_while_computing: bool,
+    quota_limited: bool,
+}
+
+impl EvaluationState {
+    pub(super) fn new(
+        distinct_id: String,
+        mut options: EvaluateFlagsOptions,
+        local_evaluator: Option<&LocalEvaluator>,
+    ) -> Self {
+        options.groups.get_or_insert_with(HashMap::new);
+        options.group_properties.get_or_insert_with(HashMap::new);
+
+        let mut state = Self {
+            distinct_id,
+            options,
+            records: HashMap::new(),
+            request_id: None,
+            errors_while_computing: false,
+            quota_limited: false,
+        };
+        state.evaluate_locally(local_evaluator);
+        state
+    }
+
+    fn evaluate_locally(&mut self, local_evaluator: Option<&LocalEvaluator>) {
+        let Some(evaluator) = local_evaluator else {
+            return;
+        };
+
+        let mut person_properties = self.options.person_properties.clone().unwrap_or_default();
+        person_properties
+            .entry("distinct_id".to_string())
+            .or_insert_with(|| serde_json::json!(self.distinct_id.clone()));
+        let groups = self.options.groups.clone().unwrap_or_default();
+        let group_properties = self.options.group_properties.clone().unwrap_or_default();
+        let local_results = evaluator.evaluate_all_flags_with_details(
+            &self.distinct_id,
+            &person_properties,
+            &groups,
+            &group_properties,
+        );
+
+        // Pin the gate from the definitions snapshot that produced each local
+        // result rather than re-reading shared state when an event is captured.
+        let minimal_flag_called_events = evaluator.cache().minimal_flag_called_events();
+        for (key, result) in local_results {
+            if self
+                .options
+                .flag_keys
+                .as_ref()
+                .is_some_and(|filter| !filter.iter().any(|candidate| candidate == &key))
+            {
+                continue;
+            }
+            if let Ok(value) = result.result {
+                self.records.insert(
+                    key,
+                    local_record(
+                        value,
+                        result.payload,
+                        result.has_experiment,
+                        minimal_flag_called_events,
+                    ),
+                );
+            }
+        }
+    }
+
+    /// Without an explicit key filter, local definitions cannot prove that they
+    /// contain every project flag, so remote discovery remains necessary.
+    pub(super) fn should_fetch_remote(&self, local_evaluation_only: bool) -> bool {
+        let local_covers_request = self
+            .options
+            .flag_keys
+            .as_ref()
+            .is_some_and(|keys| keys.iter().all(|key| self.records.contains_key(key)));
+
+        !self.options.only_evaluate_locally && !local_evaluation_only && !local_covers_request
+    }
+
+    pub(super) fn distinct_id(&self) -> &str {
+        &self.distinct_id
+    }
+
+    pub(super) fn options(&self) -> &EvaluateFlagsOptions {
+        &self.options
+    }
+
+    pub(super) fn apply_remote_result(
+        &mut self,
+        result: Result<DetailedFlagsResponse, Error>,
+    ) -> Result<(), Error> {
+        match result {
+            Ok(response) => {
+                self.request_id = response.request_id;
+                self.errors_while_computing = response.errors_while_computing_flags;
+                self.quota_limited = response.quota_limited;
+                let minimal_flag_called_events = response.minimal_flag_called_events;
+                for (key, detail) in response.flags {
+                    // A successful local evaluation is authoritative. Remote
+                    // evaluation only fills flags that local evaluation could
+                    // not resolve.
+                    self.records.entry(key).or_insert_with(|| {
+                        remote_record_from_detail(detail, minimal_flag_called_events)
+                    });
+                }
+                Ok(())
+            }
+            Err(error) if self.records.is_empty() => Err(error),
+            Err(error) => {
+                debug!(
+                    error = error.to_string(),
+                    local_count = self.records.len(),
+                    "/flags fetch failed; returning snapshot from local results only"
+                );
+                self.errors_while_computing = true;
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn into_evaluations(
+        self,
+        host: Arc<dyn FeatureFlagEvaluationsHost>,
+    ) -> FeatureFlagEvaluations {
+        FeatureFlagEvaluations::new(
+            host,
+            self.distinct_id,
+            self.records,
+            self.options.groups.unwrap_or_default(),
+            self.options.disable_geoip,
+            self.request_id,
+            None,
+            self.errors_while_computing,
+            self.quota_limited,
+        )
+    }
+}
+
+fn local_record(
     value: FlagValue,
     payload: Option<serde_json::Value>,
     has_experiment: Option<bool>,
@@ -343,7 +493,7 @@ pub(super) fn local_record(
     }
 }
 
-pub(super) fn remote_record_from_detail(
+fn remote_record_from_detail(
     detail: FlagDetail,
     minimal_flag_called_events: bool,
 ) -> EvaluatedFlagRecord {
@@ -399,6 +549,155 @@ mod tests {
             disable_geoip,
             is_server,
         }
+    }
+
+    fn local_evaluator() -> LocalEvaluator {
+        use crate::feature_flags::{FeatureFlag, FeatureFlagCondition, FeatureFlagFilters};
+        use crate::local_evaluation::{FlagCache, LocalEvaluationResponse};
+
+        let flag = |key: &str| FeatureFlag {
+            key: key.to_string(),
+            active: true,
+            has_experiment: Some(false),
+            filters: FeatureFlagFilters {
+                groups: vec![FeatureFlagCondition {
+                    properties: Vec::new(),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                    aggregation_group_type_index: None,
+                }],
+                multivariate: None,
+                payloads: HashMap::new(),
+                aggregation_group_type_index: None,
+                early_exit: false,
+            },
+        };
+
+        let cache = FlagCache::new();
+        cache.update(LocalEvaluationResponse {
+            flags: vec![flag("local"), flag("filtered-out")],
+            group_type_mapping: HashMap::new(),
+            cohorts: HashMap::new(),
+            minimal_flag_called_events: true,
+        });
+        LocalEvaluator::new(cache)
+    }
+
+    fn remote_detail(key: &str, enabled: bool, id: u64) -> FlagDetail {
+        FlagDetail {
+            key: key.to_string(),
+            enabled,
+            variant: None,
+            reason: Some(crate::feature_flags::FlagReason {
+                code: "condition_match".to_string(),
+                condition_index: Some(0),
+                description: Some("Matched remotely".to_string()),
+            }),
+            metadata: Some(FlagMetadata {
+                id,
+                version: 7,
+                description: None,
+                payload: Some(json!({"source": "remote"})),
+                has_experiment: Some(true),
+            }),
+        }
+    }
+
+    #[test]
+    fn evaluation_state_filters_local_results_and_preserves_local_wins_merge_metadata() {
+        let evaluator = local_evaluator();
+        let mut options = EvaluateFlagsOptions::default();
+        options.flag_keys = Some(vec!["local".to_string(), "remote".to_string()]);
+        options.groups = Some(groups(&[("organization", "org-a")]));
+
+        let mut state = EvaluationState::new("user-1".to_string(), options, Some(&evaluator));
+        assert_eq!(state.records.len(), 1);
+        assert!(state.records.contains_key("local"));
+        assert!(!state.records.contains_key("filtered-out"));
+        assert!(state.should_fetch_remote(false));
+
+        let local_before_merge = &state.records["local"];
+        assert!(local_before_merge.enabled);
+        assert!(local_before_merge.locally_evaluated);
+        assert!(local_before_merge.minimal_flag_called_events);
+
+        let response = DetailedFlagsResponse {
+            flags: HashMap::from([
+                ("local".to_string(), remote_detail("local", false, 101)),
+                ("remote".to_string(), remote_detail("remote", true, 202)),
+            ]),
+            request_id: Some("req-policy".to_string()),
+            errors_while_computing_flags: true,
+            quota_limited: true,
+            minimal_flag_called_events: false,
+        };
+        state.apply_remote_result(Ok(response)).unwrap();
+
+        let local = &state.records["local"];
+        assert!(local.enabled, "successful local evaluation must win");
+        assert!(local.locally_evaluated);
+        assert_eq!(local.id, None);
+        assert!(local.minimal_flag_called_events);
+
+        let remote = &state.records["remote"];
+        assert!(remote.enabled);
+        assert!(!remote.locally_evaluated);
+        assert_eq!(remote.id, Some(202));
+        assert_eq!(remote.version, Some(7));
+        assert_eq!(remote.reason.as_deref(), Some("Matched remotely"));
+        assert_eq!(remote.payload, Some(json!({"source": "remote"})));
+        assert_eq!(remote.has_experiment, Some(true));
+        assert!(!remote.minimal_flag_called_events);
+
+        assert_eq!(state.request_id.as_deref(), Some("req-policy"));
+        assert!(state.errors_while_computing);
+        assert!(state.quota_limited);
+        assert_eq!(
+            state.options.groups.as_ref().unwrap().get("organization"),
+            Some(&"org-a".to_string())
+        );
+    }
+
+    #[test]
+    fn evaluation_state_characterizes_fetch_gates_and_partial_fallback() {
+        let evaluator = local_evaluator();
+
+        let mut covered_options = EvaluateFlagsOptions::default();
+        covered_options.flag_keys = Some(vec!["local".to_string()]);
+        let covered = EvaluationState::new("user-1".to_string(), covered_options, Some(&evaluator));
+        assert!(!covered.should_fetch_remote(false));
+
+        let mut local_only_options = EvaluateFlagsOptions::default();
+        local_only_options.only_evaluate_locally = true;
+        let local_only =
+            EvaluationState::new("user-1".to_string(), local_only_options, Some(&evaluator));
+        assert!(!local_only.should_fetch_remote(false));
+
+        let project_local_only = EvaluationState::new(
+            "user-1".to_string(),
+            EvaluateFlagsOptions::default(),
+            Some(&evaluator),
+        );
+        assert!(!project_local_only.should_fetch_remote(true));
+
+        let mut partial_options = EvaluateFlagsOptions::default();
+        partial_options.flag_keys = Some(vec!["local".to_string(), "missing".to_string()]);
+        let mut partial =
+            EvaluationState::new("user-1".to_string(), partial_options, Some(&evaluator));
+        partial
+            .apply_remote_result(Err(Error::Connection("remote failed".to_string())))
+            .expect("local results degrade a remote failure to a partial snapshot");
+        assert_eq!(partial.records.len(), 1);
+        assert!(partial.records.contains_key("local"));
+        assert!(partial.errors_while_computing);
+        assert_eq!(partial.request_id, None);
+        assert!(!partial.quota_limited);
+
+        let mut empty =
+            EvaluationState::new("user-1".to_string(), EvaluateFlagsOptions::default(), None);
+        assert!(empty
+            .apply_remote_result(Err(Error::Connection("remote failed".to_string())))
+            .is_err());
     }
 
     fn flag_params(

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -1,4 +1,4 @@
-//! Runtime-agnostic retry primitives shared by the V0 and V1 capture paths.
+//! Runtime-agnostic retry primitives shared by client request paths.
 
 use std::time::{Duration, SystemTime};
 
@@ -34,6 +34,30 @@ pub(crate) enum FeatureFlagsTransportStep {
 /// caller surfaces it without burning the attempt budget.
 pub(crate) fn is_retryable_status(status: u16) -> bool {
     matches!(status, 408 | 500 | 502 | 503 | 504)
+}
+
+/// Classify transport errors from remote feature-flag requests.
+pub(crate) fn is_retryable_feature_flags_error(err: &reqwest::Error) -> bool {
+    if err.is_timeout() {
+        return true;
+    }
+
+    let mut source = std::error::Error::source(err);
+    while let Some(error) = source {
+        if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+            return matches!(
+                io_error.kind(),
+                std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::TimedOut
+                    | std::io::ErrorKind::UnexpectedEof
+            );
+        }
+        source = std::error::Error::source(error);
+    }
+
+    !err.to_string()
+        .to_lowercase()
+        .contains("connection refused")
 }
 
 /// Parse `Retry-After` as either delay-seconds or an HTTP-date.
@@ -140,6 +164,10 @@ pub(crate) fn feature_flags_after_transport_error(
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::{Shutdown, TcpListener};
+    use std::thread;
+
     use reqwest::header::{HeaderMap, HeaderValue};
 
     use super::*;
@@ -153,6 +181,17 @@ mod tests {
             .retry_max_backoff_ms(5000u64)
             .build()
             .unwrap()
+    }
+
+    fn has_io_error_kind(err: &reqwest::Error, expected: std::io::ErrorKind) -> bool {
+        let mut source = std::error::Error::source(err);
+        while let Some(error) = source {
+            if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+                return io_error.kind() == expected;
+            }
+            source = std::error::Error::source(error);
+        }
+        false
     }
 
     #[test]
@@ -175,6 +214,77 @@ mod tests {
                 code
             );
         }
+    }
+
+    #[test]
+    fn feature_flags_timeout_error_is_retryable() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            thread::sleep(Duration::from_millis(100));
+        });
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_millis(20))
+            .build()
+            .unwrap();
+
+        let err = client.get(url).send().unwrap_err();
+
+        assert!(err.is_timeout());
+        assert!(is_retryable_feature_flags_error(&err));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn feature_flags_unexpected_eof_error_is_retryable() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 10\r\n\r\n")
+                .unwrap();
+            let _ = stream.shutdown(Shutdown::Both);
+        });
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap();
+
+        let err = client.get(url).send().unwrap().bytes().unwrap_err();
+
+        assert!(has_io_error_kind(&err, std::io::ErrorKind::UnexpectedEof));
+        assert!(is_retryable_feature_flags_error(&err));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn feature_flags_connection_refused_error_is_not_retryable() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap();
+
+        let err = client.get(url).send().unwrap_err();
+
+        assert!(!is_retryable_feature_flags_error(&err));
+    }
+
+    #[test]
+    fn feature_flags_unknown_error_is_retryable() {
+        let err = reqwest::blocking::Client::new()
+            .get("ftp://example.com")
+            .send()
+            .unwrap_err();
+
+        assert!(is_retryable_feature_flags_error(&err));
     }
 
     #[test]

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -113,9 +113,8 @@ pub(crate) struct TransportHandle {
     max_queue_size: usize,
     /// Shares the worker's clock; used to stamp capture (enqueue) time.
     clock: Arc<dyn Clock>,
-    /// The worker thread's id, so the panic hook can tell when it is running on
-    /// this client's own worker — where capturing would deadlock or recurse.
-    #[cfg_attr(not(feature = "error-tracking"), allow(dead_code))]
+    /// The worker thread's id, so teardown and the panic hook can avoid waiting
+    /// for or joining this client's own worker.
     worker_id: Option<std::thread::ThreadId>,
 }
 
@@ -252,6 +251,23 @@ impl TransportHandle {
         !self.closed.swap(true, Ordering::AcqRel)
     }
 
+    /// Synchronously close and join the worker for external callers. When called
+    /// from the worker itself (for example, when a callback drops its client),
+    /// only queue the shutdown: waiting for its completion or joining here would
+    /// deadlock the worker inside its own callback.
+    pub(crate) fn close_blocking(&self) {
+        let on_worker = self.on_worker_thread();
+        if self.begin_close() {
+            let (tx, rx) = mpsc::channel();
+            if self.send_control(Control::Shutdown(Completion::Blocking(tx))) && !on_worker {
+                let _ = rx.recv();
+            }
+        }
+        if !on_worker {
+            self.join();
+        }
+    }
+
     /// Join the worker thread. Safe to call repeatedly.
     pub(crate) fn join(&self) {
         if let Some(handle) = self.worker.lock().unwrap_or_else(|p| p.into_inner()).take() {
@@ -294,11 +310,9 @@ impl TransportHandle {
         }
     }
 
-    /// True when the calling thread is this transport's worker thread. The panic
-    /// hook skips capturing there: a synchronous self-flush would deadlock the
-    /// worker, and routing the `$exception` back through `before_send` would
-    /// recurse if a `before_send` hook panicked.
-    #[cfg(feature = "error-tracking")]
+    /// True when the calling thread is this transport's worker thread. Teardown
+    /// must not synchronously wait there; the panic hook also skips capturing to
+    /// avoid a self-flush deadlock or recursive `before_send` panic.
     pub(crate) fn on_worker_thread(&self) -> bool {
         self.worker_id == Some(std::thread::current().id())
     }
@@ -306,14 +320,7 @@ impl TransportHandle {
     /// Test helper: flush + stop + join, mirroring the client's shutdown.
     #[cfg(test)]
     fn shutdown_blocking(&self) {
-        if !self.begin_close() {
-            return;
-        }
-        let (tx, rx) = mpsc::channel();
-        if self.send_control(Control::Shutdown(Completion::Blocking(tx))) {
-            let _ = rx.recv();
-        }
-        self.join();
+        self.close_blocking();
     }
 }
 
@@ -1093,6 +1100,91 @@ mod tests {
             0,
             "dropped events left counted as pending"
         );
+    }
+
+    #[test]
+    fn close_from_worker_callback_does_not_wait_or_self_join() {
+        let handle_slot = Arc::new(Mutex::new(None::<Arc<TransportHandle>>));
+        let callback_slot = Arc::clone(&handle_slot);
+        let (returned_tx, returned_rx) = mpsc::channel();
+        let handle = Arc::new(TransportHandle::spawn(
+            options("http://localhost:0".to_string())
+                .flush_at(1usize)
+                .before_send(move |_| {
+                    let callback_handle = callback_slot
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .take()
+                        .expect("transport installed before capture");
+                    assert!(callback_handle.on_worker_thread());
+                    callback_handle.close_blocking();
+                    returned_tx.send(()).unwrap();
+                    None
+                })
+                .build()
+                .unwrap(),
+        ));
+        *handle_slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(Arc::clone(&handle));
+
+        handle.enqueue(Event::new("close-in-callback", "user-1"));
+        returned_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("worker-thread close blocked");
+
+        // An external caller still performs the durable join, and repeats are no-ops.
+        handle.close_blocking();
+        handle.close_blocking();
+        assert!(handle.is_closed());
+        assert_eq!(handle.pending(), 0);
+    }
+
+    #[test]
+    fn concurrent_external_close_is_idempotent_and_durable() {
+        let server = MockServer::start();
+        let mock = ok_mock(&server);
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let handle = Arc::new(TransportHandle::spawn(
+            options(server.base_url())
+                .flush_at(1usize)
+                .before_send(move |event| {
+                    entered_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    Some(event)
+                })
+                .build()
+                .unwrap(),
+        ));
+        handle.enqueue(Event::new("close-race", "user-1"));
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("worker did not enter callback");
+
+        let start = Arc::new(std::sync::Barrier::new(3));
+        let closers: Vec<_> = (0..2)
+            .map(|_| {
+                let handle = Arc::clone(&handle);
+                let start = Arc::clone(&start);
+                thread::spawn(move || {
+                    start.wait();
+                    handle.close_blocking();
+                })
+            })
+            .collect();
+        start.wait();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !handle.is_closed() && Instant::now() < deadline {
+            thread::yield_now();
+        }
+        assert!(handle.is_closed(), "neither close caller won the race");
+        release_tx.send(()).unwrap();
+        for closer in closers {
+            closer.join().unwrap();
+        }
+
+        handle.close_blocking();
+        mock.assert_calls(1);
+        assert_eq!(handle.pending(), 0);
     }
 
     // -- virtual-clock worker tests (no real sleeps) -------------------------

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -724,15 +724,14 @@ impl Pipeline {
         historical_migration: bool,
         deadline: Option<Instant>,
     ) {
-        use super::common::{apply_before_send_hooks, apply_capture_defaults};
+        use super::common::preprocess_capture_event;
 
         let defaults = self.options.capture_defaults();
         let original = events.len();
         let processed: Vec<Event> = events
             .into_iter()
-            .filter_map(|mut event| {
-                apply_capture_defaults(&mut event, &defaults);
-                apply_before_send_hooks(&self.options.before_send, event)
+            .filter_map(|event| {
+                preprocess_capture_event(event, &defaults, &self.options.before_send)
             })
             .collect();
         // Events dropped by before_send are terminal.
@@ -1255,20 +1254,29 @@ mod tests {
     }
 
     #[test]
-    fn before_send_dropped_events_are_not_counted_in_flight() {
+    fn capture_preprocessing_applies_defaults_before_hooks_and_accounts_for_drops() {
         // before_send drops one of two events; a 503 holds the batch for retry.
         // pending() must reflect only the surviving event: the dropped one is
         // terminal at build time, so counting it as in-flight would inflate the
         // bounded-queue depth (and the drop/retry logs) for the batch's lifetime.
         let server = MockServer::start();
         let fail = server.mock(|when, then| {
-            when.method(POST);
+            when.method(POST)
+                .body_includes("\"hook_saw_defaults\":true");
             then.status(503);
         });
         let clock = ManualClock::new();
         let handle = TransportHandle::spawn_with_clock(
             options(server.base_url())
-                .before_send(|event| {
+                .disable_geoip(true)
+                .before_send(|mut event| {
+                    let saw_defaults = event.properties().get("$is_server")
+                        == Some(&serde_json::json!(true))
+                        && event.properties().get("$geoip_disable")
+                            == Some(&serde_json::json!(true));
+                    event
+                        .insert_prop("hook_saw_defaults", saw_defaults)
+                        .unwrap();
                     if event.properties().get("__drop").is_some() {
                         None
                     } else {


### PR DESCRIPTION
## :bulb: Motivation and Context

Async and blocking clients duplicated local evaluation, remote-fetch decisions, result merging, and fallback policy.

## Changes

Move runtime-neutral evaluation and merge policy into a shared state object. Network requests remain in the concrete async and blocking clients. This PR is stacked on `slopo/04-shared-flag-host`.

## :green_heart: How did you test it?

Local and remote merging, filtered keys, local-only behavior, fallback, metadata, quota state, and both client configurations.

Autoreview completed for this exact branch head and base with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
