### PR TITLE
fix(flags): handle empty evaluation key scopes

### DIFF
--- a/.sampo/changesets/ancient-wavetamer-kalma.md
+++ b/.sampo/changesets/ancient-wavetamer-kalma.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Return an empty feature flag snapshot without evaluation when feature flag keys are explicitly empty.

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -1118,9 +1118,22 @@ impl Client {
     ) -> Result<FeatureFlagEvaluations, Error> {
         let distinct_id: String = distinct_id.into();
         let host = self.flag_event_host();
-
         if distinct_id.is_empty() || self.options.is_disabled() {
             return Ok(FeatureFlagEvaluations::empty(host));
+        }
+
+        if options.flag_keys.as_ref().is_some_and(Vec::is_empty) {
+            return Ok(FeatureFlagEvaluations::new(
+                host,
+                distinct_id,
+                HashMap::new(),
+                options.groups.unwrap_or_default(),
+                options.disable_geoip,
+                None,
+                None,
+                false,
+                false,
+            ));
         }
 
         let mut options = options;

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1086,9 +1086,22 @@ impl Client {
     ) -> Result<FeatureFlagEvaluations, Error> {
         let distinct_id: String = distinct_id.into();
         let host = self.flag_event_host();
-
         if distinct_id.is_empty() || self.options.is_disabled() {
             return Ok(FeatureFlagEvaluations::empty(host));
+        }
+
+        if options.flag_keys.as_ref().is_some_and(Vec::is_empty) {
+            return Ok(FeatureFlagEvaluations::new(
+                host,
+                distinct_id,
+                HashMap::new(),
+                options.groups.unwrap_or_default(),
+                options.disable_geoip,
+                None,
+                None,
+                false,
+                false,
+            ));
         }
 
         let mut options = options;

--- a/src/feature_flag_evaluations.rs
+++ b/src/feature_flag_evaluations.rs
@@ -91,7 +91,8 @@ pub struct EvaluateFlagsOptions {
     /// Optional list of flag keys. When provided, only these flags are
     /// evaluated — the underlying `/flags` request asks the server for just
     /// this subset, which makes the response smaller and the request cheaper.
-    /// Use this when you only need a handful of flags out of many.
+    /// An explicitly empty list returns an empty snapshot without local or
+    /// remote evaluation; `None` evaluates all flags.
     ///
     /// Distinct from [`FeatureFlagEvaluations::only`]: `flag_keys` trims the
     /// network call, [`only`](FeatureFlagEvaluations::only) trims which flags
@@ -149,7 +150,7 @@ impl FeatureFlagEvaluations {
         }
     }
 
-    /// Construct an empty snapshot used when no `distinct_id` was resolvable.
+    /// Construct an empty snapshot used when evaluation is skipped.
     /// The empty `distinct_id` short-circuits event firing inside
     /// [`record_access`](Self::record_access).
     pub(crate) fn empty(host: Arc<dyn FeatureFlagEvaluationsHost>) -> Self {

--- a/tests/test_evaluate_flags.rs
+++ b/tests/test_evaluate_flags.rs
@@ -85,6 +85,26 @@ fn flags_response_fixture() -> Value {
     })
 }
 
+fn local_definitions_fixture() -> Value {
+    json!({
+        "flags": [{
+            "key": "alpha",
+            "active": true,
+            "filters": {
+                "groups": [{
+                    "properties": [],
+                    "rollout_percentage": 100.0,
+                    "variant": null
+                }],
+                "multivariate": null,
+                "payloads": {}
+            }
+        }],
+        "group_type_mapping": {},
+        "cohorts": {}
+    })
+}
+
 struct FlakyFlagsServer {
     base_url: String,
     attempts: Arc<AtomicUsize>,
@@ -649,6 +669,47 @@ mod blocking {
     }
 
     #[test]
+    fn explicit_empty_flag_keys_skip_local_and_remote_evaluation() {
+        let server = MockServer::start();
+        let definitions_mock = server.mock(|when, then| {
+            when.method(GET).path("/flags/definitions/");
+            then.status(200).json_body(local_definitions_fixture());
+        });
+        let flags_mock = server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let capture_mock = capture_path_mock(&server);
+        let options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key("test_api_key".to_string())
+            .host(server.base_url())
+            .secret_key("test_personal_key".to_string())
+            .enable_local_evaluation(true)
+            .poll_interval_seconds(3600)
+            .build()
+            .unwrap();
+        let client = posthog_rs::client(options);
+        definitions_mock.assert_calls(1);
+
+        let snapshot = client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    flag_keys: Some(Vec::new()),
+                    ..Default::default()
+                },
+            )
+            .expect("empty key scope should be valid");
+
+        assert!(snapshot.keys().is_empty());
+        assert!(!snapshot.is_enabled("alpha"));
+        client.flush();
+        definitions_mock.assert_calls(1);
+        flags_mock.assert_calls(0);
+        capture_mock.assert_calls(1);
+    }
+
+    #[test]
     fn empty_distinct_id_returns_empty_snapshot_without_request_or_events() {
         let server = MockServer::start();
         let flags_mock = server.mock(|when, then| {
@@ -1179,6 +1240,48 @@ mod async_tests {
         };
         let _ = client.evaluate_flags("user-1", opts).await.unwrap();
         flags_mock.assert_hits(1);
+    }
+
+    #[tokio::test]
+    async fn explicit_empty_flag_keys_skip_local_and_remote_evaluation() {
+        let server = MockServer::start();
+        let definitions_mock = server.mock(|when, then| {
+            when.method(GET).path("/flags/definitions/");
+            then.status(200).json_body(local_definitions_fixture());
+        });
+        let flags_mock = server.mock(|when, then| {
+            when.method(POST).path("/flags/");
+            then.status(200).json_body(flags_response_fixture());
+        });
+        let capture_mock = capture_path_mock(&server);
+        let options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key("test_api_key".to_string())
+            .host(server.base_url())
+            .secret_key("test_personal_key".to_string())
+            .enable_local_evaluation(true)
+            .poll_interval_seconds(3600)
+            .build()
+            .unwrap();
+        let client = posthog_rs::client(options).await;
+        definitions_mock.assert_calls(1);
+
+        let snapshot = client
+            .evaluate_flags(
+                "user-1",
+                EvaluateFlagsOptions {
+                    flag_keys: Some(Vec::new()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("empty key scope should be valid");
+
+        assert!(snapshot.keys().is_empty());
+        assert!(!snapshot.is_enabled("alpha"));
+        client.flush().await;
+        definitions_mock.assert_calls(1);
+        flags_mock.assert_calls(0);
+        capture_mock.assert_calls(1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## :bulb: Motivation and Context

This aligns Rust flag evaluation with the behavior defined in [sdk-specs PR #47](https://github.com/PostHog/sdk-specs/pull/47).

When `flag_keys` is omitted or null, the SDK continues to evaluate all flags. When it is an explicit empty list, the SDK now returns an empty snapshot without local evaluation or a `/flags/` request. The snapshot keeps the caller identity and context, so looking up a missing key still records access in the normal way. When the list is non-empty, the SDK continues to evaluate only the requested keys.

The blocking and async clients now apply the same explicit-empty behavior. The option documentation also describes the difference between an omitted value and an empty list.

## :green_heart: How did you test it?

- `cargo test --test test_evaluate_flags explicit_empty_flag_keys_skip_local_and_remote_evaluation` - passed the focused async regression: 1 passed, 0 failed.
- `cargo test --no-default-features --test test_evaluate_flags explicit_empty_flag_keys_skip_local_and_remote_evaluation` - passed the focused blocking regression: 1 passed, 0 failed.
- `cargo fmt --check` - passed.
- `git diff --check` - passed.
- `"$HOME/.pi/agent/skills/autoreview/scripts/autoreview" --mode branch --base origin/main` - clean with no accepted or actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->

