### PR TITLE
fix(flags): align presence operator semantics

### DIFF
--- a/.sampo/changesets/partial-properties-align.md
+++ b/.sampo/changesets/partial-properties-align.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Treat omitted local evaluation properties as inconclusive for presence operators.

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1404,15 +1404,6 @@ fn match_property(
     let value = match properties.get(&property.key) {
         Some(v) => v,
         None => {
-            // Handle is_not_set operator
-            if property.operator == "is_not_set" {
-                return Ok(true);
-            }
-            // Handle is_set operator
-            if property.operator == "is_set" {
-                return Ok(false);
-            }
-            // For other operators, missing property is inconclusive
             return Err(InconclusiveMatchError::new(&format!(
                 "Property '{}' not found in provided properties",
                 property.key
@@ -2041,11 +2032,23 @@ mod tests {
         };
 
         let mut properties = HashMap::new();
-        properties.insert("email".to_string(), json!("test@example.com"));
-        assert!(match_property(&prop, &properties).unwrap());
+        for value in [
+            json!(null),
+            json!(false),
+            json!(0),
+            json!(""),
+            json!([]),
+            json!({}),
+        ] {
+            properties.insert("email".to_string(), value);
+            assert!(match_property(&prop, &properties).unwrap());
+        }
 
         properties.remove("email");
-        assert!(!match_property(&prop, &properties).unwrap());
+        assert!(matches!(
+            match_property(&prop, &properties),
+            Err(InconclusiveMatchError { .. })
+        ));
     }
 
     #[test]
@@ -2058,10 +2061,23 @@ mod tests {
         };
 
         let mut properties = HashMap::new();
-        assert!(match_property(&prop, &properties).unwrap());
+        for value in [
+            json!(null),
+            json!(false),
+            json!(0),
+            json!(""),
+            json!([]),
+            json!({}),
+        ] {
+            properties.insert("phone".to_string(), value);
+            assert!(!match_property(&prop, &properties).unwrap());
+        }
 
-        properties.insert("phone".to_string(), json!("+1234567890"));
-        assert!(!match_property(&prop, &properties).unwrap());
+        properties.remove("phone");
+        assert!(matches!(
+            match_property(&prop, &properties),
+            Err(InconclusiveMatchError { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## :bulb: Motivation and Context

[sdk-specs PR #49](https://github.com/PostHog/sdk-specs/pull/49) defines omitted properties as inconclusive because SDK property maps contain partial context. The Rust local evaluator returned false for missing `is_set` properties and true for missing `is_not_set` properties.

This change returns `InconclusiveMatchError` when either presence operator's key is omitted. Present keys remain conclusive, including null and other falsey values.

## :green_heart: How did you test it?

- `cargo fmt --all -- --check`
- `cargo test --lib test_is_set_operator`
- `cargo test --lib test_is_not_set_operator`
- `cargo test --lib` (231 tests passed)
- Autoreview completed with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent worker subagents implemented and validated the focused matcher change. The bundled autoreview tool reviewed the final committed diff against `origin/main`.
