### PR TITLE
feat: report an injected $release_id on every event

### DIFF
--- a/.sampo/changesets/release-injection.md
+++ b/.sampo/changesets/release-injection.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: minor
+---
+
+Report `$release_id` on every event when `posthog-cli` has injected one into the binary. The crate compiles a fixed placeholder into the build, and `posthog-cli symbol-sets upload --release-mode=event` overwrites it with the id of the release it created. This is the native equivalent of the `$release_id` a web build injects into its bundle: the release id is the primary key the server resolves an exception's release from, so it no longer depends on the crate version, the app name, or git metadata matching between the build and the upload. `injected_release_id()` returns the id when a build was injected, for programs that want to log which release they run. An un-injected binary sends nothing.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -372,6 +372,7 @@ pub fn posthog_rs::disable_global()
 pub async fn posthog_rs::flush()
 pub fn posthog_rs::global_is_disabled() -> bool
 pub async fn posthog_rs::init_global<C: core::convert::Into<posthog_rs::ClientOptions>>(C) -> core::result::Result<(), posthog_rs::Error>
+pub fn posthog_rs::injected_release_id() -> core::option::Option<alloc::string::String>
 pub fn posthog_rs::match_feature_flag(&posthog_rs::FeatureFlag, &str, &std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>, &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>, &std::collections::hash::map::HashMap<alloc::string::String, std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>, &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::result::Result<posthog_rs::FlagValue, posthog_rs::InconclusiveMatchError>
 pub fn posthog_rs::match_feature_flag_with_context(&posthog_rs::FeatureFlag, &std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>, &posthog_rs::EvaluationContext<'_>) -> core::result::Result<posthog_rs::FlagValue, posthog_rs::InconclusiveMatchError>
 pub fn posthog_rs::match_property_with_context(&posthog_rs::Property, &std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>, &posthog_rs::EvaluationContext<'_>) -> core::result::Result<bool, posthog_rs::InconclusiveMatchError>

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -55,6 +55,11 @@ pub(super) fn apply_capture_defaults(event: &mut Event, defaults: &CaptureDefaul
     if defaults.is_server {
         event.insert_prop_default("$is_server", serde_json::Value::Bool(true));
     }
+    // The `$release_id` the CLI stamped into this binary, if any — the server resolves the release
+    // from it. `insert_prop_default` keeps a caller-set value.
+    if let Some(release_id) = crate::release_marker::cached() {
+        event.insert_prop_default("$release_id", serde_json::Value::String(release_id.clone()));
+    }
 }
 
 pub(super) fn apply_before_send_hooks(hooks: &[BeforeSendHook], event: Event) -> Option<Event> {

--- a/src/client/v1_capture.rs
+++ b/src/client/v1_capture.rs
@@ -52,6 +52,11 @@ pub(crate) fn build_events_at(
                     map.entry("$is_server")
                         .or_insert(serde_json::Value::Bool(true));
                 }
+                // The injected `$release_id` (see `apply_capture_defaults` for the V0 path).
+                if let Some(release_id) = crate::release_marker::cached() {
+                    map.entry("$release_id")
+                        .or_insert(serde_json::Value::String(release_id.clone()));
+                }
                 // Final step for minimized `$feature_flag_called` events: drop
                 // everything outside the allowlist. Wire-lifted keys
                 // ($session_id/$window_id/$process_person_profile) already moved

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ mod feature_flag_evaluations;
 mod feature_flags;
 mod global;
 mod local_evaluation;
+mod release_marker;
 
 // Public interface - any change to this is breaking!
 // Client
@@ -120,6 +121,9 @@ pub use endpoints::{
 
 // Error
 pub use error::Error;
+
+// Release injection
+pub use release_marker::injected_release_id;
 
 // Error Tracking
 #[cfg(feature = "error-tracking")]

--- a/src/release_marker.rs
+++ b/src/release_marker.rs
@@ -1,0 +1,91 @@
+//! A release id the compiled binary carries, for `posthog-cli` to stamp after the build.
+//!
+//! The native equivalent of the `$release_id` a web build injects into its bundle: the crate
+//! compiles a fixed placeholder in, `posthog-cli symbol-sets upload --release-mode=event`
+//! overwrites it with the created release's id, and the SDK reports it as `$release_id`. An
+//! un-injected binary keeps the nil placeholder and reports nothing.
+//!
+//! The layout is a shared contract with the CLI's injector — keep it in sync with
+//! `cli/src/release_injection.rs`.
+
+use std::sync::OnceLock;
+
+use uuid::Uuid;
+
+/// Marks the slot so the CLI can find it by scanning the file. Long and unusual to avoid a
+/// coincidental match.
+const MAGIC: &[u8] = b"~posthog-release-id~v1~";
+/// The slot holds a 36-byte canonical UUID.
+const SLOT_LEN: usize = 36;
+/// Total marker size; the literal below is checked against it at compile time.
+const MARKER_LEN: usize = MAGIC.len() + SLOT_LEN;
+
+/// The placeholder the CLI overwrites. `#[used]` keeps the linker from dropping it, so the bytes
+/// are always in the binary. The nil-UUID slot means "not injected".
+#[used]
+static MARKER: [u8; MARKER_LEN] = *b"~posthog-release-id~v1~00000000-0000-0000-0000-000000000000";
+
+/// The release id the CLI stamped into this binary, or `None` if it was never injected. Cached.
+///
+/// The SDK sets `$release_id` from this on its own; this is exposed only so a program can log the
+/// release it runs.
+pub fn injected_release_id() -> Option<String> {
+    cached().clone()
+}
+
+/// The cached read, so the marker is read at most once per process.
+pub(crate) fn cached() -> &'static Option<String> {
+    static CACHED: OnceLock<Option<String>> = OnceLock::new();
+    CACHED.get_or_init(read_marker)
+}
+
+fn read_marker() -> Option<String> {
+    // Volatile so the optimizer can't fold the static's compile-time value and return the
+    // placeholder even after the CLI patched the bytes.
+    let base = std::ptr::addr_of!(MARKER) as *const u8;
+    let mut bytes = [0u8; MARKER_LEN];
+    for (i, byte) in bytes.iter_mut().enumerate() {
+        // SAFETY: `base` points at `MARKER`, which is `MARKER_LEN` bytes, and `i < MARKER_LEN`.
+        *byte = unsafe { std::ptr::read_volatile(base.add(i)) };
+    }
+
+    // Check the prefix before trusting the slot.
+    if &bytes[..MAGIC.len()] != MAGIC {
+        return None;
+    }
+
+    let slot = std::str::from_utf8(&bytes[MAGIC.len()..]).ok()?;
+    let id = Uuid::parse_str(slot).ok()?;
+    // Nil = the placeholder, i.e. not injected.
+    if id.is_nil() {
+        return None;
+    }
+    Some(id.hyphenated().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_is_magic_then_a_nil_uuid_placeholder() {
+        // An un-patched binary must read back `None`.
+        assert_eq!(&MARKER[..MAGIC.len()], MAGIC);
+        let slot = std::str::from_utf8(&MARKER[MAGIC.len()..]).unwrap();
+        assert_eq!(Uuid::parse_str(slot).unwrap(), Uuid::nil());
+        assert_eq!(cached().as_deref(), None);
+    }
+
+    #[test]
+    fn a_patched_slot_parses_as_the_release_id() {
+        // Mirror the CLI's overwrite and confirm the parsing recovers the id (the reader reads the
+        // process's own static, which a test can't patch).
+        let id = Uuid::now_v7();
+        let mut bytes = MARKER;
+        bytes[MAGIC.len()..].copy_from_slice(id.hyphenated().to_string().as_bytes());
+
+        assert_eq!(&bytes[..MAGIC.len()], MAGIC);
+        let slot = std::str::from_utf8(&bytes[MAGIC.len()..]).unwrap();
+        assert_eq!(Uuid::parse_str(slot).unwrap(), id);
+    }
+}

--- a/tests/test_release_marker.rs
+++ b/tests/test_release_marker.rs
@@ -1,0 +1,73 @@
+// A binary that was never injected — every test binary — keeps the nil placeholder, so it must
+// send no `$release_id`. The patched case is covered by the unit test in `src/release_marker.rs`.
+#![cfg(feature = "error-tracking")]
+
+use httpmock::prelude::*;
+use std::error::Error as StdError;
+use std::fmt;
+
+#[derive(Debug)]
+struct TestError;
+impl fmt::Display for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "boom")
+    }
+}
+impl StdError for TestError {}
+
+#[cfg(not(feature = "capture-v1"))]
+const CAPTURE_PATH: &str = "/batch/";
+#[cfg(feature = "capture-v1")]
+const CAPTURE_PATH: &str = "/i/v1/analytics/events";
+
+/// The request carries no `$release_id`. A `when` matcher, so a request that does carry one
+/// matches no mock and `assert_calls(1)` fails.
+fn body_has_no_release_id(req: &HttpMockRequest) -> bool {
+    std::str::from_utf8(req.body_ref())
+        .map(|body| !body.contains("$release_id"))
+        .unwrap_or(false)
+}
+
+#[cfg(not(feature = "async-client"))]
+#[test]
+fn an_uninjected_binary_sends_no_release_id() {
+    assert_eq!(posthog_rs::injected_release_id(), None);
+
+    let server = MockServer::start();
+    let capture = server.mock(|when, then| {
+        when.method(POST)
+            .path(CAPTURE_PATH)
+            .is_true(body_has_no_release_id);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({ "results": {} }));
+    });
+
+    let client = posthog_rs::client(("test_api_key", server.base_url().as_str()));
+    client.capture_exception(&TestError).unwrap();
+    client.flush();
+
+    capture.assert_calls(1);
+}
+
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn an_uninjected_binary_sends_no_release_id() {
+    assert_eq!(posthog_rs::injected_release_id(), None);
+
+    let server = MockServer::start();
+    let capture = server.mock(|when, then| {
+        when.method(POST)
+            .path(CAPTURE_PATH)
+            .is_true(body_has_no_release_id);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({ "results": {} }));
+    });
+
+    let client = posthog_rs::client(("test_api_key", server.base_url().as_str())).await;
+    client.capture_exception(&TestError).await.unwrap();
+    client.flush().await;
+
+    capture.assert_calls(1);
+}


### PR DESCRIPTION
## 💡 Motivation and Context

A web build injects `$release_id` into its bundle and the SDK reads it back at runtime. A compiled Rust binary has no bundle to inject into — so this adds the native equivalent. The crate compiles a fixed placeholder into the binary, and the paired CLI change (**PostHog/posthog#89117**, `symbol-sets upload --release-mode=event`) overwrites that placeholder with the id of the release it created. The SDK reads it back and reports it as `$release_id` on every event.

`$release_id` is the primary key the server resolves an exception's release from, so this closes the two holes an earlier app-metadata approach had: the release no longer has to be a bumped crate version, and the CLI's release coordinates no longer have to match the app's — the CLI copies **one** id into both the release row and the binary.

```rust
// nothing to configure — the marker is compiled in, and the SDK reads it when the CLI patched it
let client = posthog_rs::client((key, host));
// injected_release_id() exposes the id, e.g. to log what you're running
if let Some(release) = posthog_rs::injected_release_id() {
    println!("running release {release}");
}
```

## 💚 How did you test it?

Automated (the agent ran these):

- New unit tests in `src/release_marker.rs`: the compiled marker is the magic prefix followed by the nil-UUID placeholder, and an un-patched binary reads back `None`; a mirror of the CLI's overwrite parses back to the id.
- New integration test `tests/test_release_marker.rs`: an un-injected binary (every test binary) sends **no** `$release_id`, on both the v0 and v1 wire formats — guarding against stamping a bogus release on every event.
- `cargo test` across `default`, `error-tracking` (no default), `capture-v1`, and `error-tracking,capture-v1`; `cargo fmt --check`; `cargo clippy` clean on the changed lib; `scripts/check-public-api.sh --update` (snapshot gained only `injected_release_id`).

The placeholder is read with a **volatile load** so the optimizer cannot fold its compile-time value and miss the CLI's patch — verified end to end: after the CLI injects and re-signs, the example binary printed back the exact id the CLI wrote, and the server resolved the release from the `$release_id` it sent. That full round trip, with screenshots and CLI logs (including the same binary shipped as two releases off one symbol set), is on the CLI PR: **PostHog/posthog#89117**.

## 📝 Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file — `.sampo/changesets/release-injection.md` (minor)

---
Authored by Claude (Fable 5) in Claude Code, directed by @ablaszkiewicz. Replaces an earlier `AppInfo` app-metadata approach on this branch, after the DRI showed it could silently resolve no release; injection makes `$release_id` load-bearing instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
