### PR TITLE
fix(flags): align local string matching with the flags service

### DIFF
--- a/.sampo/changesets/fuzzy-jaguars-fold.md
+++ b/.sampo/changesets/fuzzy-jaguars-fold.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Match local feature flag string properties with the same case folding and string coercion as the flags service. Substring and prefix/suffix operators now fold ASCII only, while `exact` and `is_not` use Unicode lowercase after stringifying both operands.

--- a/.sampo/changesets/fuzzy-jaguars-fold.md
+++ b/.sampo/changesets/fuzzy-jaguars-fold.md
@@ -2,4 +2,4 @@
 cargo/posthog-rs: patch
 ---
 
-Match local feature flag string properties with the same case folding and string coercion as the flags service. Substring and prefix/suffix operators now fold ASCII only, while `exact` and `is_not` use Unicode lowercase after stringifying both operands.
+Match local feature flag properties with the same case folding, string coercion, and boolean-like filter precedence as the flags service. Substring and prefix/suffix operators now fold ASCII only, while `exact` and `is_not` use the service's truthiness handling before Unicode-lowercase comparison.

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1717,29 +1717,38 @@ mod tests {
             match_property(&property, &HashMap::from([("key".to_string(), actual)])).unwrap()
         };
 
-        // Exact matching stringifies both sides and applies Unicode lowercase.
-        assert!(matches("exact", json!("PRO"), json!("pro")));
-        assert!(matches("exact", json!("Ä"), json!("ä")));
-        assert!(!matches("exact", json!("ß"), json!("ss")));
-        assert!(!matches("exact", json!("Σ"), json!("ς")));
-        assert!(matches("exact", json!(323), json!("323")));
-        assert!(matches("exact", json!(["FREE", "PRÖ"]), json!("prö")));
-        assert!(!matches("is_not", json!(["FREE", "PRÖ"]), json!("prö")));
-        assert!(matches("is_not", json!(["FREE", "PRÖ"]), json!("team")));
-
         // Serde preserves a float's decimal point; exact matching must not collapse it to an integer.
         assert_eq!(value_to_string(&json!(323.0)), "323.0");
-        assert!(matches("exact", json!("323.0"), json!(323.0)));
-        assert!(!matches("exact", json!("323"), json!(323.0)));
 
-        // Substring and anchored operators fold ASCII only.
-        assert!(matches("icontains", json!("ADMIN"), json!("admin-user")));
-        assert!(!matches("icontains", json!("Ä"), json!("äbc")));
-        assert!(matches("not_icontains", json!("Ä"), json!("äbc")));
-        assert!(!matches("starts_with", json!("Ä"), json!("äbc")));
-        assert!(matches("not_starts_with", json!("Ä"), json!("äbc")));
-        assert!(!matches("ends_with", json!("Ä"), json!("bcä")));
-        assert!(matches("not_ends_with", json!("Ä"), json!("bcä")));
+        let cases = [
+            // Exact matching stringifies both sides and applies Unicode lowercase.
+            ("exact", json!("PRO"), json!("pro"), true),
+            ("exact", json!("Ä"), json!("ä"), true),
+            ("exact", json!("ß"), json!("ss"), false),
+            ("exact", json!("Σ"), json!("ς"), false),
+            ("exact", json!(323), json!("323"), true),
+            ("exact", json!(["FREE", "PRÖ"]), json!("prö"), true),
+            ("is_not", json!(["FREE", "PRÖ"]), json!("prö"), false),
+            ("is_not", json!(["FREE", "PRÖ"]), json!("team"), true),
+            ("exact", json!("323.0"), json!(323.0), true),
+            ("exact", json!("323"), json!(323.0), false),
+            // Substring and anchored operators fold ASCII only.
+            ("icontains", json!("ADMIN"), json!("admin-user"), true),
+            ("icontains", json!("Ä"), json!("äbc"), false),
+            ("not_icontains", json!("Ä"), json!("äbc"), true),
+            ("starts_with", json!("Ä"), json!("äbc"), false),
+            ("not_starts_with", json!("Ä"), json!("äbc"), true),
+            ("ends_with", json!("Ä"), json!("bcä"), false),
+            ("not_ends_with", json!("Ä"), json!("bcä"), true),
+        ];
+
+        for (operator, expected, actual, should_match) in cases {
+            let result = matches(operator, expected.clone(), actual.clone());
+            assert_eq!(
+                result, should_match,
+                "operator {operator} comparing {actual} against {expected}"
+            );
+        }
     }
 
     #[test]

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1428,32 +1428,8 @@ fn match_property(
     };
 
     Ok(match property.operator.as_str() {
-        "exact" => {
-            if property.value.is_array() {
-                if let Some(arr) = property.value.as_array() {
-                    for val in arr {
-                        if compare_values(val, value) {
-                            return Ok(true);
-                        }
-                    }
-                    return Ok(false);
-                }
-            }
-            compare_values(&property.value, value)
-        }
-        "is_not" => {
-            if property.value.is_array() {
-                if let Some(arr) = property.value.as_array() {
-                    for val in arr {
-                        if compare_values(val, value) {
-                            return Ok(false);
-                        }
-                    }
-                    return Ok(true);
-                }
-            }
-            !compare_values(&property.value, value)
-        }
+        "exact" => compute_exact_match(&property.value, value),
+        "is_not" => !compute_exact_match(&property.value, value),
         "is_set" => true,      // We already know the property exists
         "is_not_set" => false, // We already know the property exists
         "icontains" => {
@@ -1578,6 +1554,40 @@ fn match_property(
             )));
         }
     })
+}
+
+fn compute_exact_match(value: &serde_json::Value, override_value: &serde_json::Value) -> bool {
+    if is_truthy_or_falsy_property_value(value) {
+        return is_truthy_property_value(value) == is_truthy_property_value(override_value);
+    }
+
+    if let Some(values) = value.as_array() {
+        return values
+            .iter()
+            .any(|candidate| compare_values(candidate, override_value));
+    }
+
+    compare_values(value, override_value)
+}
+
+fn is_truthy_or_falsy_property_value(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Bool(_) => true,
+        serde_json::Value::String(value) => {
+            value.eq_ignore_ascii_case("true") || value.eq_ignore_ascii_case("false")
+        }
+        serde_json::Value::Array(values) => values.iter().all(is_truthy_or_falsy_property_value),
+        _ => false,
+    }
+}
+
+fn is_truthy_property_value(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Bool(value) => *value,
+        serde_json::Value::String(value) => value.eq_ignore_ascii_case("true"),
+        serde_json::Value::Array(values) => values.iter().all(is_truthy_property_value),
+        _ => false,
+    }
 }
 
 fn compare_values(a: &serde_json::Value, b: &serde_json::Value) -> bool {
@@ -1726,6 +1736,10 @@ mod tests {
             ("exact", json!("Ä"), json!("ä"), true),
             ("exact", json!("ß"), json!("ss"), false),
             ("exact", json!("Σ"), json!("ς"), false),
+            ("exact", json!("ΟΣ"), json!("ος"), true),
+            ("exact", json!("ΟΣ"), json!("οσ"), false),
+            ("exact", json!("İ"), json!("i\u{0307}"), true),
+            ("exact", json!("İ"), json!("i"), false),
             ("exact", json!(323), json!("323"), true),
             ("exact", json!(["FREE", "PRÖ"]), json!("prö"), true),
             ("is_not", json!(["FREE", "PRÖ"]), json!("prö"), false),
@@ -1747,6 +1761,51 @@ mod tests {
             assert_eq!(
                 result, should_match,
                 "operator {operator} comparing {actual} against {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_exact_boolean_coercion_matches_flags_service() {
+        let matches = |operator: &str, expected, actual| {
+            let property = Property {
+                key: "key".to_string(),
+                value: expected,
+                operator: operator.to_string(),
+                property_type: None,
+            };
+            match_property(&property, &HashMap::from([("key".to_string(), actual)])).unwrap()
+        };
+
+        let cases = [
+            // Boolean-like filters compare aggregate truthiness before array membership.
+            (json!(false), json!("banana"), true),
+            (json!("false"), json!(0), true),
+            (json!(["false"]), json!(null), true),
+            (json!(["true", "false"]), json!("true"), false),
+            (json!(["true", "false"]), json!("pro"), true),
+            // Empty arrays are boolean-like and truthy because all() on an empty iterator is true.
+            (json!([]), json!(true), true),
+            (json!([]), json!("true"), true),
+            (json!([]), json!([]), true),
+            (json!([]), json!([true]), true),
+            (json!([]), json!(false), false),
+            (json!([]), json!("banana"), false),
+            // Non-boolean-like arrays retain ordinary ANY membership.
+            (json!(["FREE", "PRO"]), json!("pro"), true),
+            (json!(["FREE", "PRO"]), json!("team"), false),
+        ];
+
+        for (expected, actual, exact_match) in cases {
+            assert_eq!(
+                matches("exact", expected.clone(), actual.clone()),
+                exact_match,
+                "exact comparing {actual} against {expected}"
+            );
+            assert_eq!(
+                matches("is_not", expected.clone(), actual.clone()),
+                !exact_match,
+                "is_not comparing {actual} against {expected}"
             );
         }
     }

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1459,40 +1459,44 @@ fn match_property(
         "icontains" => {
             let prop_str = value_to_string(value);
             let search_str = value_to_string(&property.value);
-            prop_str.to_lowercase().contains(&search_str.to_lowercase())
+            prop_str
+                .to_ascii_lowercase()
+                .contains(&search_str.to_ascii_lowercase())
         }
         "not_icontains" => {
             let prop_str = value_to_string(value);
             let search_str = value_to_string(&property.value);
-            !prop_str.to_lowercase().contains(&search_str.to_lowercase())
+            !prop_str
+                .to_ascii_lowercase()
+                .contains(&search_str.to_ascii_lowercase())
         }
         "starts_with" => {
             let prop_str = value_to_string(value);
             let search_str = value_to_string(&property.value);
             prop_str
-                .to_lowercase()
-                .starts_with(&search_str.to_lowercase())
+                .to_ascii_lowercase()
+                .starts_with(&search_str.to_ascii_lowercase())
         }
         "not_starts_with" => {
             let prop_str = value_to_string(value);
             let search_str = value_to_string(&property.value);
             !prop_str
-                .to_lowercase()
-                .starts_with(&search_str.to_lowercase())
+                .to_ascii_lowercase()
+                .starts_with(&search_str.to_ascii_lowercase())
         }
         "ends_with" => {
             let prop_str = value_to_string(value);
             let search_str = value_to_string(&property.value);
             prop_str
-                .to_lowercase()
-                .ends_with(&search_str.to_lowercase())
+                .to_ascii_lowercase()
+                .ends_with(&search_str.to_ascii_lowercase())
         }
         "not_ends_with" => {
             let prop_str = value_to_string(value);
             let search_str = value_to_string(&property.value);
             !prop_str
-                .to_lowercase()
-                .ends_with(&search_str.to_lowercase())
+                .to_ascii_lowercase()
+                .ends_with(&search_str.to_ascii_lowercase())
         }
         "regex" => {
             let prop_str = value_to_string(value);
@@ -1577,13 +1581,7 @@ fn match_property(
 }
 
 fn compare_values(a: &serde_json::Value, b: &serde_json::Value) -> bool {
-    // Case-insensitive string comparison
-    if let (Some(a_str), Some(b_str)) = (a.as_str(), b.as_str()) {
-        return a_str.eq_ignore_ascii_case(b_str);
-    }
-
-    // Direct comparison for other types
-    a == b
+    value_to_string(a).to_lowercase() == value_to_string(b).to_lowercase()
 }
 
 fn value_to_string(value: &serde_json::Value) -> String {
@@ -1705,6 +1703,43 @@ mod tests {
 
         properties.insert("country".to_string(), json!("UK"));
         assert!(!match_property(&prop, &properties).unwrap());
+    }
+
+    #[test]
+    fn test_property_case_folding_matches_flags_service() {
+        let matches = |operator: &str, expected, actual| {
+            let property = Property {
+                key: "key".to_string(),
+                value: expected,
+                operator: operator.to_string(),
+                property_type: None,
+            };
+            match_property(&property, &HashMap::from([("key".to_string(), actual)])).unwrap()
+        };
+
+        // Exact matching stringifies both sides and applies Unicode lowercase.
+        assert!(matches("exact", json!("PRO"), json!("pro")));
+        assert!(matches("exact", json!("Ä"), json!("ä")));
+        assert!(!matches("exact", json!("ß"), json!("ss")));
+        assert!(!matches("exact", json!("Σ"), json!("ς")));
+        assert!(matches("exact", json!(323), json!("323")));
+        assert!(matches("exact", json!(["FREE", "PRÖ"]), json!("prö")));
+        assert!(!matches("is_not", json!(["FREE", "PRÖ"]), json!("prö")));
+        assert!(matches("is_not", json!(["FREE", "PRÖ"]), json!("team")));
+
+        // Serde preserves a float's decimal point; exact matching must not collapse it to an integer.
+        assert_eq!(value_to_string(&json!(323.0)), "323.0");
+        assert!(matches("exact", json!("323.0"), json!(323.0)));
+        assert!(!matches("exact", json!("323"), json!(323.0)));
+
+        // Substring and anchored operators fold ASCII only.
+        assert!(matches("icontains", json!("ADMIN"), json!("admin-user")));
+        assert!(!matches("icontains", json!("Ä"), json!("äbc")));
+        assert!(matches("not_icontains", json!("Ä"), json!("äbc")));
+        assert!(!matches("starts_with", json!("Ä"), json!("äbc")));
+        assert!(matches("not_starts_with", json!("Ä"), json!("äbc")));
+        assert!(!matches("ends_with", json!("Ä"), json!("bcä")));
+        assert!(matches("not_ends_with", json!("Ä"), json!("bcä")));
     }
 
     #[test]


### PR DESCRIPTION
## :bulb: Motivation and Context

Local feature flag evaluation must match the currently released `/flags` service until its behavior changes. The service applies boolean-like truthiness before ordinary array membership for `exact` and `is_not`. This includes all-boolean arrays and the vacuous truthiness of an empty array.

The separate backend proposal in [PostHog/posthog#90694](https://github.com/PostHog/posthog/pull/90694) would replace those semantics. This PR intentionally does not adopt that draft behavior.

This fixes PostHog/posthog#78019 by:

- applying the service's boolean-like filter precedence before ordinary array membership
- preserving `is_not` as the direct complement of `exact`
- using ordinary ANY membership only for arrays that are not entirely boolean-like
- keeping serde_json stringification and Rust Unicode lowercase for `exact` and `is_not`
- keeping ASCII-only lowercase for contains, prefix, and suffix operators
- adding final-sigma, dotted-I, boolean-array, and empty-array regression vectors

The patch changeset for `cargo/posthog-rs` describes the complete matching update.

## :green_heart: How did you test it?

- Red: `cargo test test_exact_boolean_coercion_matches_flags_service -- --nocapture` failed at `exact` with filter `false` and property `"banana"`.
- Green: the same focused test passed after porting the service truthiness helpers.
- `cargo test test_property_case_folding_matches_flags_service -- --nocapture`
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `scripts/check-public-api.sh`
- Autoreview with `autoreview --mode local`

The test suite emits existing deprecation warnings from httpmock-based tests. No test failed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using the address-pr-comments, check-pr, autoreview, and karpathy-guidelines skills. Verification showed that Rust and serde_json already match the service's Unicode and JSON behavior, so production changes remain limited to boolean-like precedence.
