### PR TITLE
ci: Add v1 release candidate validation

### DIFF
--- a/.github/workflows/v1-release-candidate.yml
+++ b/.github/workflows/v1-release-candidate.yml
@@ -1,0 +1,77 @@
+name: V1 Release Candidate Validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_ref:
+        description: Commit SHA, tag, or branch to validate
+        required: true
+        default: v1
+        type: string
+      soak_days:
+        description: Minimum production validation period after publishing the candidate
+        required: true
+        default: '7'
+        type: string
+
+permissions:
+  contents: read
+  checks: read
+
+concurrency:
+  group: v1-release-candidate-${{ inputs.candidate_ref }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Release candidate preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.candidate_ref }}
+
+      - name: Set up Rust
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add clippy rustfmt
+          rustup toolchain install nightly-2026-06-12 --profile minimal
+
+      - name: Install public API tooling
+        run: cargo install cargo-public-api --version 0.52.0 --locked
+
+      - name: Run release candidate preflight
+        run: scripts/validate-release-candidate.sh
+
+      - name: Record candidate
+        env:
+          CANDIDATE_REF: ${{ inputs.candidate_ref }}
+          SOAK_DAYS: ${{ inputs.soak_days }}
+        run: |
+          {
+            echo "candidate_ref=${CANDIDATE_REF}"
+            echo "candidate_sha=$(git rev-parse HEAD)"
+            echo "validated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "minimum_soak_days=${SOAK_DAYS}"
+          } | tee release-candidate.txt
+
+      - name: Upload candidate record
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v1-release-candidate-${{ github.run_id }}
+          path: release-candidate.txt
+
+  required-checks:
+    name: Verify candidate checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout validation scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify CI and SDK compliance checks
+        env:
+          CANDIDATE_REF: ${{ inputs.candidate_ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/verify-release-candidate-checks.sh "$CANDIDATE_REF"

--- a/.github/workflows/v1-release-candidate.yml
+++ b/.github/workflows/v1-release-candidate.yml
@@ -23,14 +23,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  preflight:
-    name: Release candidate preflight
+  resolve-candidate:
+    name: Resolve candidate SHA
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - name: Checkout candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.candidate_ref }}
+
+      - name: Resolve immutable SHA
+        id: resolve
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  preflight:
+    name: Release candidate preflight
+    needs: resolve-candidate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.sha }}
 
       - name: Set up Rust
         run: |
@@ -48,11 +64,12 @@ jobs:
       - name: Record candidate
         env:
           CANDIDATE_REF: ${{ inputs.candidate_ref }}
+          CANDIDATE_SHA: ${{ needs.resolve-candidate.outputs.sha }}
           SOAK_DAYS: ${{ inputs.soak_days }}
         run: |
           {
             echo "candidate_ref=${CANDIDATE_REF}"
-            echo "candidate_sha=$(git rev-parse HEAD)"
+            echo "candidate_sha=${CANDIDATE_SHA}"
             echo "validated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "minimum_soak_days=${SOAK_DAYS}"
           } | tee release-candidate.txt
@@ -65,6 +82,7 @@ jobs:
 
   required-checks:
     name: Verify candidate checks
+    needs: resolve-candidate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout validation scripts
@@ -72,6 +90,6 @@ jobs:
 
       - name: Verify CI and SDK compliance checks
         env:
-          CANDIDATE_REF: ${{ inputs.candidate_ref }}
+          CANDIDATE_SHA: ${{ needs.resolve-candidate.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
-        run: scripts/verify-release-candidate-checks.sh "$CANDIDATE_REF"
+        run: scripts/verify-release-candidate-checks.sh "$CANDIDATE_SHA"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,3 +19,28 @@ This repository uses [Sampo](https://github.com/bruits/sampo) for versioning, ch
 4. Approve the release in Slack when prompted — this triggers version bump, crates.io publish, git tag, and GitHub Release
 
 You can also trigger a release manually via the workflow's `workflow_dispatch` trigger (still requires pending changesets).
+
+## Validating the v1 release candidate
+
+Do not publish `1.0.0` directly from the long-lived `v1` branch.
+
+1. Merge every intended v1 change into `v1`, including the package rename in #183 if it is part of the release.
+2. Open or update the release PR from `v1` to `main` and wait for its normal CI and SDK compliance checks. The candidate commit must have successful async and blocking compliance jobs for gzip, deflate, Brotli, and Zstandard.
+3. Run the **V1 Release Candidate Validation** workflow with the immutable candidate commit SHA. Do not use a moving branch name in the final record. The workflow:
+   - reruns formatting, Clippy, public API, examples, async, blocking, and blocking error-tracking checks;
+   - runs `cargo publish --workspace --dry-run --locked`, which validates every publishable workspace crate after #183 lands;
+   - verifies the candidate SHA already has every required CI and SDK compliance check;
+   - uploads a record containing the SHA, validation time, and minimum soak period.
+4. Publish a prerelease version such as `1.0.0-rc.1` only after the validation workflow succeeds. The candidate version must already be committed in every publishable manifest and `Cargo.lock`. Follow the package order and retry handling from #183; do not use the current single-crate release workflow to publish two crates.
+5. Record the prerelease URL, validation workflow URL, candidate SHA, publication time, and chosen soak duration on issue #207.
+6. Exercise capture, immediate capture, error tracking, feature flag events, historical migration, `before_send`, and `on_error` in production during the soak period. Record any incidents and the final decision on issue #207.
+7. After the full soak period, rerun validation against the exact commit that will become `1.0.0`. Only then approve the stable release.
+
+The workflow validates readiness but does not claim that a candidate was published or that the production soak elapsed. Keep those issue tasks unchecked until their links and dates are recorded.
+
+The same preflight can be run locally:
+
+```sh
+scripts/validate-release-candidate.sh
+GH_TOKEN=... scripts/verify-release-candidate-checks.sh <candidate-sha>
+```

--- a/scripts/validate-release-candidate.sh
+++ b/scripts/validate-release-candidate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo fmt --all -- --check
+cargo clippy -- -D warnings
+scripts/check-public-api.sh
+cargo check --examples
+cargo test --workspace
+cargo test --no-default-features
+cargo test --no-default-features --features error-tracking
+cargo publish --workspace --dry-run --locked

--- a/scripts/verify-release-candidate-checks.sh
+++ b/scripts/verify-release-candidate-checks.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+candidate=${1:-}
+repository=${GITHUB_REPOSITORY:-PostHog/posthog-rs}
+
+if [[ -z "$candidate" ]]; then
+    echo "usage: $0 <candidate-ref-or-sha>" >&2
+    exit 2
+fi
+
+sha=$(gh api "repos/${repository}/commits/${candidate}" --jq .sha)
+successful_checks=$(mktemp)
+trap 'rm -f "$successful_checks"' EXIT
+
+gh api "repos/${repository}/commits/${sha}/check-runs?per_page=100" \
+    --paginate \
+    --jq '.check_runs[] | select(.conclusion == "success") | .name' \
+    | sort -u > "$successful_checks"
+
+required_checks=(
+    "Format"
+    "Clippy"
+    "Public API"
+    "Build (default features)"
+    "Build (blocking client)"
+    "Cargo publish dry run"
+    "Unit test (default features)"
+    "Unit test (workspace)"
+    "Unit test (blocking client)"
+    "Unit test (error-tracking, blocking client)"
+    "E2E test"
+    "async / gzip"
+    "async / deflate"
+    "async / br"
+    "async / zstd"
+    "blocking / gzip"
+    "blocking / deflate"
+    "blocking / br"
+    "blocking / zstd"
+)
+
+missing=0
+for check in "${required_checks[@]}"; do
+    if ! grep -Fxq "$check" "$successful_checks"; then
+        echo "missing successful check: $check" >&2
+        missing=1
+    fi
+done
+
+if (( missing )); then
+    echo "Candidate ${sha} is not release-ready." >&2
+    exit 1
+fi
+
+echo "Candidate ${sha} has every required CI and SDK compliance check."


### PR DESCRIPTION
## :bulb: Motivation and Context

Issue #207 needs a repeatable release-candidate gate that proves the selected commit passed the full client matrix, SDK compliance, public API checks, and locked package dry runs. It also needs a clear separation between automated readiness and the production soak that must happen over time.

This adds a manual validation workflow. It resolves the requested ref once to an immutable SHA, reruns the local release preflight, verifies all required CI checks plus the eight async/blocking compression compliance jobs on that SHA, and stores a candidate record as an artifact.

The package check uses `cargo publish --workspace --dry-run --locked`, so it covers the current crate and automatically covers both publishable crates after #183 lands. The release guide now records the prerelease and soak process. This PR does not publish a candidate or claim that production validation elapsed.

Part of #207.

## :green_heart: How did you test it?

- `scripts/validate-release-candidate.sh`
- `bash -n scripts/validate-release-candidate.sh scripts/verify-release-candidate-checks.sh`
- Parsed and linted `.github/workflows/v1-release-candidate.yml`
- Confirmed `verify-release-candidate-checks.sh 96a3816` rejects the existing commit because it predates the eight-job compliance matrix
- Autoreview passed on `b8b58af`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added validation for the release process.
- [x] I updated the release documentation.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
