### PR TITLE
ci: Test capture compliance across clients and encodings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/.github/workflows/sdk-compliance-tests.yml
+++ b/.github/workflows/sdk-compliance-tests.yml
@@ -10,7 +10,7 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/sdk-compliance-tests.yml'
   pull_request:
-    branches: [main]
+    branches: [main, v1]
     paths:
       - 'src/**'
       - 'compliance/**'
@@ -22,14 +22,85 @@ on:
 permissions:
   contents: read
   packages: read
-  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.client }}-${{ matrix.compression }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test-rust-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@6d19abb9c81e2262dacbe340e7dddda9c871c178
-    with:
-      adapter-dockerfile: compliance/Dockerfile
-      adapter-context: .
-      test-harness-version: "0.10.0"
-      report-name: rust-sdk-compliance-report
-      concurrency: 10
+    name: ${{ matrix.client }} / ${{ matrix.compression }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        client: [async, blocking]
+        compression: [gzip, deflate, br, zstd]
+    steps:
+      - name: Checkout SDK repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull test harness
+        run: docker pull ghcr.io/posthog/sdk-test-harness:0.10.0
+
+      - name: Build SDK adapter
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: compliance/Dockerfile
+          build-args: CLIENT_MODE=${{ matrix.client }}
+          tags: sdk-adapter:test
+          load: true
+          cache-from: type=gha,scope=compliance-${{ matrix.client }}
+          cache-to: type=gha,mode=max,scope=compliance-${{ matrix.client }}
+
+      - name: Create Docker network
+        run: docker network create test-network
+
+      - name: Start SDK adapter
+        run: |
+          docker run -d \
+            --name sdk-adapter \
+            --network test-network \
+            -e COMPRESSION=${{ matrix.compression }} \
+            sdk-adapter:test
+
+      - name: Run compliance suite
+        run: |
+          mkdir -p report
+          docker run --rm \
+            --name test-harness \
+            --network test-network \
+            -v "${GITHUB_WORKSPACE}/report:/report" \
+            ghcr.io/posthog/sdk-test-harness:0.10.0 \
+            run \
+            --adapter-url http://sdk-adapter:8080 \
+            --mock-url http://test-harness:8081 \
+            --output text \
+            --report /report/sdk-compliance-report.md \
+            --sdk-type server \
+            --concurrency 10
+
+      - name: Upload compliance report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rust-sdk-compliance-${{ matrix.client }}-${{ matrix.compression }}
+          path: report/sdk-compliance-report.md
+
+      - name: Stop containers
+        if: always()
+        run: |
+          docker stop sdk-adapter || true
+          docker rm sdk-adapter || true
+          docker network rm test-network || true

--- a/.github/workflows/sdk-compliance-tests.yml
+++ b/.github/workflows/sdk-compliance-tests.yml
@@ -23,10 +23,6 @@ permissions:
   contents: read
   packages: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.client }}-${{ matrix.compression }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   test-rust-sdk:
     name: ${{ matrix.client }} / ${{ matrix.compression }}
@@ -36,6 +32,9 @@ jobs:
       matrix:
         client: [async, blocking]
         compression: [gzip, deflate, br, zstd]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.client }}-${{ matrix.compression }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout SDK repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/compliance/Dockerfile
+++ b/compliance/Dockerfile
@@ -1,7 +1,15 @@
 FROM rust:1-bookworm AS builder
+ARG CLIENT_MODE=async
 WORKDIR /app
 COPY . .
-RUN cargo build --release -p sdk-adapter
+RUN if [ "$CLIENT_MODE" = "async" ]; then \
+        cargo build --release --manifest-path compliance/adapter/Cargo.toml; \
+    elif [ "$CLIENT_MODE" = "blocking" ]; then \
+        cargo build --release --manifest-path compliance/adapter/Cargo.toml --no-default-features; \
+    else \
+        echo "unsupported CLIENT_MODE: $CLIENT_MODE" >&2; \
+        exit 1; \
+    fi
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/compliance/adapter/Cargo.toml
+++ b/compliance/adapter/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[features]
+default = ["async-client"]
+async-client = ["posthog-rs/async-client"]
+
 [dependencies]
-posthog-rs = { path = "../..", features = ["async-client", "test-harness"] }
+posthog-rs = { path = "../..", default-features = false, features = ["test-harness"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/compliance/adapter/src/main.rs
+++ b/compliance/adapter/src/main.rs
@@ -138,6 +138,46 @@ fn compression_capability(c: CaptureCompression) -> &'static str {
     }
 }
 
+async fn build_client(options: posthog_rs::ClientOptions) -> Client {
+    #[cfg(feature = "async-client")]
+    {
+        posthog_rs::client(options).await
+    }
+    #[cfg(not(feature = "async-client"))]
+    {
+        posthog_rs::client(options)
+    }
+}
+
+async fn evaluate_flags(
+    client: &Client,
+    distinct_id: String,
+    options: EvaluateFlagsOptions,
+) -> Result<posthog_rs::FeatureFlagEvaluations, posthog_rs::Error> {
+    #[cfg(feature = "async-client")]
+    {
+        client.evaluate_flags(distinct_id, options).await
+    }
+    #[cfg(not(feature = "async-client"))]
+    {
+        client.evaluate_flags(distinct_id, options)
+    }
+}
+
+async fn flush_client(client: &Client) {
+    #[cfg(feature = "async-client")]
+    client.flush().await;
+    #[cfg(not(feature = "async-client"))]
+    client.flush();
+}
+
+async fn shutdown_client(client: &Client) {
+    #[cfg(feature = "async-client")]
+    client.shutdown().await;
+    #[cfg(not(feature = "async-client"))]
+    client.shutdown();
+}
+
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     // `capture_v1` is the harness contract key that selects the capture suite
     // (see `requires:` in contracts/capture_analytics_v1_tests.yaml) — it is a
@@ -203,7 +243,7 @@ async fn init(
 
     match builder.build() {
         Ok(opts) => {
-            let client = posthog_rs::client(opts).await;
+            let client = build_client(opts).await;
             s.client = Some(Arc::new(client));
             Json(serde_json::json!({ "success": true })).into_response()
         }
@@ -312,7 +352,7 @@ async fn get_feature_flag(
     options.disable_geoip = req.disable_geoip;
     options.flag_keys = Some(vec![key.clone()]);
 
-    match client.evaluate_flags(req.distinct_id, options).await {
+    match evaluate_flags(&client, req.distinct_id, options).await {
         Ok(flags) => {
             let value = flags.get_flag(&key);
             Json(serde_json::json!({ "success": true, "value": value })).into_response()
@@ -350,7 +390,7 @@ async fn flush(
     };
 
     let before = client.pending_events() as u64;
-    client.flush().await;
+    flush_client(&client).await;
     let flushed = before.saturating_sub(client.pending_events() as u64);
 
     Json(serde_json::json!({
@@ -378,7 +418,7 @@ async fn shutdown(
         }
     };
 
-    client.shutdown().await;
+    shutdown_client(&client).await;
     Json(serde_json::json!({ "success": true })).into_response()
 }
 
@@ -433,8 +473,13 @@ async fn main() {
         Some(algo) => compression_capability(algo),
         None => "none",
     };
+    let client_mode = if cfg!(feature = "async-client") {
+        "async"
+    } else {
+        "blocking"
+    };
     eprintln!(
-        "Starting posthog-rs SDK adapter (compression={compression_str}, parallel={SUPPORTS_PARALLEL})"
+        "Starting posthog-rs SDK adapter (client={client_mode}, compression={compression_str}, parallel={SUPPORTS_PARALLEL})"
     );
 
     let state = AppState {


### PR DESCRIPTION
## :bulb: Motivation and Context

Issue #207 requires the V1 compliance suite to cover both async and blocking clients, every supported content encoding, and retry behavior. The existing adapter always built the async client and the workflow only exercised gzip.

This makes the adapter compile in either client mode and runs the complete compliance suite across async and blocking clients with gzip, deflate, Brotli, and Zstandard. Each of the eight jobs is blocking and uploads its own report. The harness retry contract runs in every matrix entry.

Closes the compliance coverage task in #207 once all matrix jobs pass.

## :green_heart: How did you test it?

- `cargo fmt --all -- --check`
- `cargo check -p sdk-adapter`
- `cargo check --manifest-path compliance/adapter/Cargo.toml --no-default-features`
- Built the blocking adapter Docker image
- Ran the 0.10.0 SDK compliance harness against blocking plus Zstandard: 110/110 passed
- Autoreview passed on `35acb17`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
