### PR TITLE
feat!: Make the TLS provider configurable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,12 @@ jobs:
             toolchain: stable
             cache-key: blocking-client
             command: cargo build --verbose --no-default-features
+          - name: TLS without a built-in provider
+            toolchain: stable
+            cache-key: tls-no-provider
+            command: >-
+              cargo build --verbose --no-default-features --features async-client,error-tracking,tls-no-provider
+              && ! cargo tree --package posthog-rs --edges normal --invert aws-lc-sys --no-default-features --features async-client,error-tracking,tls-no-provider
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -159,9 +165,15 @@ jobs:
           - name: Unit test (error-tracking, blocking client)
             cache-key: error-tracking-blocking-client
             command: cargo test --verbose --no-default-features --features error-tracking
+          - name: TLS without a built-in provider (async client)
+            cache-key: tls-no-provider-async
+            command: cargo test --verbose --no-default-features --features async-client,tls-no-provider --test test_tls_no_provider
+          - name: TLS without a built-in provider (blocking client)
+            cache-key: tls-no-provider-blocking
+            command: cargo test --verbose --no-default-features --features tls-no-provider --test test_tls_no_provider
           - name: E2E test
             cache-key: e2e
-            command: cargo test --verbose --features e2e-test --no-default-features
+            command: cargo test --verbose --features e2e-test,tls --no-default-features
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.sampo/changesets/tls-provider-selection.md
+++ b/.sampo/changesets/tls-provider-selection.md
@@ -1,0 +1,7 @@
+---
+cargo/posthog-rs: major
+---
+
+Make TLS backend selection explicit. Default users continue to use Rustls with reqwest's built-in provider through the new `tls` default feature. Applications can instead enable `tls-no-provider` and install their own process-level Rustls `CryptoProvider`, avoiding the `aws-lc-sys` native build dependency when no other dependency enables `tls`.
+
+This is breaking for `default-features = false` consumers: TLS is no longer enabled implicitly, so HTTPS clients must enable either `tls` or `tls-no-provider`.

--- a/.sampo/changesets/tls-provider-selection.md
+++ b/.sampo/changesets/tls-provider-selection.md
@@ -1,7 +1,0 @@
----
-cargo/posthog-rs: major
----
-
-Make TLS backend selection explicit. Default users continue to use Rustls with reqwest's built-in provider through the new `tls` default feature. Applications can instead enable `tls-no-provider` and install their own process-level Rustls `CryptoProvider`, avoiding the `aws-lc-sys` native build dependency when no other dependency enables `tls`.
-
-This is breaking for `default-features = false` consumers: TLS is no longer enabled implicitly, so HTTPS clients must enable either `tls` or `tls-no-provider`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ From the repository root:
 ```bash
 cargo build --verbose
 cargo test --verbose
-cargo test --verbose --features e2e-test --no-default-features
+cargo test --verbose --features e2e-test,tls --no-default-features
 cargo fmt -- --check
 cargo clippy -- -D warnings
 scripts/check-public-api.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "os_info",
  "regex",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sha1 0.11.0",
@@ -1887,6 +1888,7 @@ checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ rust-version = "1.78.0"
 
 [dependencies]
 reqwest = { version = "0.13.2", default-features = false, features = [
-    "rustls",
     "blocking",
     "json",
     "gzip",
@@ -38,6 +37,10 @@ zstd = "0.13"
 
 [dev-dependencies]
 dotenv = "0.15.0"
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+] }
 ctor = "1.0.12"
 tokio = { version = "1", features = ["full"] }
 httpmock = "0.8"
@@ -47,11 +50,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 eyre = "0.6.12"
 
 [features]
-default = ["async-client", "error-tracking"]
+default = ["async-client", "error-tracking", "tls"]
 e2e-test = []
 async-client = ["tokio"]
 test-harness = []
 error-tracking = ["dep:backtrace", "dep:findshlibs"]
+tls = ["reqwest/rustls"]
+tls-no-provider = ["reqwest/rustls-no-provider"]
 
 [workspace]
 members = [".", "compliance/adapter"]

--- a/docs/migration-0.x-to-1.0.md
+++ b/docs/migration-0.x-to-1.0.md
@@ -14,15 +14,17 @@ posthog-rs = { version = "0.25", features = ["capture-v1"] }
 posthog-rs = "1"
 ```
 
-The default features remain the async client and error tracking. Use `default-features = false` for the blocking client.
+The default features are the async client, error tracking, and TLS. Use `default-features = false` for the blocking client and explicitly enable a TLS feature when sending to an HTTPS endpoint.
 
 ```toml
-# Async client with error tracking
+# Async client with error tracking and TLS
 posthog-rs = "1"
 
-# Blocking client without error tracking
-posthog-rs = { version = "1", default-features = false }
+# Blocking client with TLS
+posthog-rs = { version = "1", default-features = false, features = ["tls"] }
 ```
+
+TLS was previously enabled even with `default-features = false`. In 1.0, choose `tls` to use reqwest's default Rustls provider, or choose `tls-no-provider` when the application installs a process-level Rustls `CryptoProvider`. The latter avoids pulling in `aws-lc-rs` from this SDK, but constructing a client before installing a provider will panic. Cargo features are additive, so `tls-no-provider` only avoids the built-in provider when no dependency enables `tls`.
 
 The V0 capture implementation and its `/i/v0/e/` and batch plumbing have been removed. `Endpoint::Batch` no longer exists, and `Endpoint::Capture` now resolves to `/i/v1/analytics/events`.
 

--- a/tests/test_tls_no_provider.rs
+++ b/tests/test_tls_no_provider.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "tls-no-provider")]
+//! Bring-your-own-provider TLS: with `tls-no-provider` (and without `tls`)
+//! the SDK links no rustls crypto provider, so the application must install
+//! a process-level provider before constructing a client. Reqwest builds its
+//! TLS connector at client construction time and rustls panics if no provider
+//! is available, so successfully constructing a client is the regression check.
+
+use posthog_rs::{ClientOptions, ClientOptionsBuilder};
+
+fn install_ring_provider() {
+    // Ignore the result: `install_default` fails if a process-level provider
+    // is already installed.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn options() -> ClientOptions {
+    ClientOptionsBuilder::default()
+        .api_key("phc_test_token".to_string())
+        .host("https://eu.i.posthog.com".to_string())
+        .build()
+        .unwrap()
+}
+
+#[cfg(not(feature = "async-client"))]
+#[test]
+fn blocking_client_builds_with_installed_provider() {
+    install_ring_provider();
+    let _client = posthog_rs::client(options());
+}
+
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn async_client_builds_with_installed_provider() {
+    install_ring_provider();
+    let _client = posthog_rs::client(options()).await;
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

The SDK currently enables `reqwest/rustls` directly on the dependency. This pulls `aws-lc-rs` and `aws-lc-sys` into every build, including builds with `default-features = false`. Applications that install their own Rustls crypto provider still compile the built-in provider and its native dependencies.

This moves TLS selection into Cargo features. The new default `tls` feature preserves the current behavior for default users. Applications can instead enable `tls-no-provider` and install a process-level Rustls `CryptoProvider` before constructing the client.

This is breaking for `default-features = false` consumers. HTTPS clients must now explicitly enable `tls` or `tls-no-provider`. The migration guide documents this requirement and the additive Cargo feature behavior.

This ports the proposal from #201 onto the current `v1` branch and completes the TLS configuration task in #207.

## :green_heart: How did you test it?

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo check --examples`
- `cargo test --workspace`
- `cargo test --no-default-features`
- `cargo test --no-default-features --features error-tracking`
- Async and blocking `tls-no-provider` integration tests
- Built with `async-client,error-tracking,tls-no-provider`
- Confirmed `aws-lc-sys` is absent from the normal dependency tree with `tls-no-provider`
- `scripts/check-public-api.sh`
- `cargo publish --dry-run --locked --allow-dirty`
- `actionlint .github/workflows/ci.yaml`
- Autoreview completed on `d61e1b3`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

