### PR TITLE
fix(flags)!: honor versioned local property matching

### DIFF
--- a/.sampo/changesets/versioned-property-matching.md
+++ b/.sampo/changesets/versioned-property-matching.md
@@ -1,0 +1,7 @@
+---
+cargo/posthog-rs: minor
+---
+
+Honor definition snapshots' `property_matching_version` during local flag evaluation, including group conditions, recursive cohorts, and flag dependencies. Version 2 uses explicit case-insensitive equality instead of legacy boolean coercion; missing metadata and other versions retain legacy matching. Empty filters retain recursive truthiness in both versions. Keep matching semantics and definitions together across cache refreshes and version-only updates.
+
+`LocalEvaluationResponse` and `EvaluationContext` struct literals now require a `property_matching_version` field (use `1` for legacy behavior); older serialized definitions still load without it. The context-free `match_feature_flag` helper remains legacy.

--- a/api/public-api.txt
+++ b/api/public-api.txt
@@ -227,6 +227,7 @@ pub posthog_rs::EvaluationContext::flags: &'a std::collections::hash::map::HashM
 pub posthog_rs::EvaluationContext::group_properties: &'a std::collections::hash::map::HashMap<alloc::string::String, std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>>
 pub posthog_rs::EvaluationContext::group_type_mapping: &'a std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
 pub posthog_rs::EvaluationContext::groups: &'a std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub posthog_rs::EvaluationContext::property_matching_version: i64
 pub struct posthog_rs::Event
 impl posthog_rs::Event
 pub fn posthog_rs::Event::add_group(&mut self, &str, &str)
@@ -337,6 +338,7 @@ pub posthog_rs::LocalEvaluationResponse::cohorts: std::collections::hash::map::H
 pub posthog_rs::LocalEvaluationResponse::flags: alloc::vec::Vec<posthog_rs::FeatureFlag>
 pub posthog_rs::LocalEvaluationResponse::group_type_mapping: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
 pub posthog_rs::LocalEvaluationResponse::minimal_flag_called_events: bool
+pub posthog_rs::LocalEvaluationResponse::property_matching_version: i64
 pub struct posthog_rs::LocalEvaluator
 impl posthog_rs::LocalEvaluator
 pub fn posthog_rs::LocalEvaluator::cache(&self) -> &posthog_rs::FlagCache

--- a/src/client/local_payload_test_support.rs
+++ b/src/client/local_payload_test_support.rs
@@ -57,6 +57,7 @@ pub(super) fn payload_definitions() -> LocalEvaluationResponse {
     };
 
     LocalEvaluationResponse {
+        property_matching_version: 1,
         flags: vec![
             // The definitions endpoint JSON-encodes payloads, so the common
             // case is an object stored as a string.

--- a/src/client/minimal_gate_test_support.rs
+++ b/src/client/minimal_gate_test_support.rs
@@ -47,6 +47,7 @@ fn gated_flag(has_experiment: Option<bool>) -> FeatureFlag {
 
 pub(super) fn definitions(has_experiment: Option<bool>, gate: bool) -> LocalEvaluationResponse {
     LocalEvaluationResponse {
+        property_matching_version: 1,
         flags: vec![gated_flag(has_experiment)],
         group_type_mapping: HashMap::new(),
         cohorts: HashMap::new(),

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -293,6 +293,9 @@ pub struct EvaluationContext<'a> {
     pub group_properties: &'a HashMap<String, HashMap<String, serde_json::Value>>,
     /// Mapping from PostHog group type index to group type name.
     pub group_type_mapping: &'a HashMap<String, String>,
+    /// Matching semantics pinned to the definitions snapshot. Exactly `2` uses
+    /// explicit equality; `1` (and other versions) uses legacy boolean coercion.
+    pub property_matching_version: i64,
 }
 
 /// Configuration for multivariate (A/B/n) feature flags.
@@ -587,6 +590,27 @@ pub fn match_feature_flag(
     group_properties: &HashMap<String, HashMap<String, serde_json::Value>>,
     group_type_mapping: &HashMap<String, String>,
 ) -> Result<FlagValue, InconclusiveMatchError> {
+    match_feature_flag_with_version(
+        flag,
+        distinct_id,
+        person_properties,
+        groups,
+        group_properties,
+        group_type_mapping,
+        1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn match_feature_flag_with_version(
+    flag: &FeatureFlag,
+    distinct_id: &str,
+    person_properties: &HashMap<String, serde_json::Value>,
+    groups: &HashMap<String, String>,
+    group_properties: &HashMap<String, HashMap<String, serde_json::Value>>,
+    group_type_mapping: &HashMap<String, String>,
+    property_matching_version: i64,
+) -> Result<FlagValue, InconclusiveMatchError> {
     if !flag.active {
         return Ok(FlagValue::Boolean(false));
     }
@@ -621,7 +645,13 @@ pub fn match_feature_flag(
             }
         };
 
-        match is_condition_match(flag, &effective_bucketing, &condition, effective_properties) {
+        match is_condition_match(
+            flag,
+            &effective_bucketing,
+            &condition,
+            effective_properties,
+            property_matching_version,
+        ) {
             Ok(ConditionMatch::Match) => {
                 if let Some(variant_override) = &condition.variant {
                     // Check if variant is valid
@@ -692,10 +722,11 @@ fn is_condition_match(
     bucketing_id: &str,
     condition: &FeatureFlagCondition,
     properties: &HashMap<String, serde_json::Value>,
+    property_matching_version: i64,
 ) -> Result<ConditionMatch, InconclusiveMatchError> {
     // Check properties first
     for prop in &condition.properties {
-        if !match_property(prop, properties)? {
+        if !match_property_with_version(prop, properties, property_matching_version)? {
             return Ok(ConditionMatch::NoMatch);
         }
     }
@@ -868,8 +899,8 @@ pub fn match_property_with_context(
         return match_flag_dependency_property(property, ctx);
     }
 
-    // Fall back to regular property matching
-    match_property(property, properties)
+    // Use the same snapshot version for direct and recursive cohort leaves.
+    match_property_with_version(property, properties, ctx.property_matching_version)
 }
 
 /// Evaluate cohort membership referenced by a flag property (`type = "cohort"`).
@@ -1169,13 +1200,14 @@ fn match_flag_dependency_property(
     // Evaluate the dependent flag for this user (with empty properties to avoid recursion issues).
     // Group context flows through from the outer ctx so dependent group/mixed flags can resolve.
     let empty_props = HashMap::new();
-    let flag_value = match_feature_flag(
+    let flag_value = match_feature_flag_with_version(
         flag,
         ctx.distinct_id,
         &empty_props,
         ctx.groups,
         ctx.group_properties,
         ctx.group_type_mapping,
+        ctx.property_matching_version,
     )?;
 
     // Compare the flag value with the expected value
@@ -1400,9 +1432,18 @@ fn parse_target_semver(
     })
 }
 
+#[cfg(test)]
 fn match_property(
     property: &Property,
     properties: &HashMap<String, serde_json::Value>,
+) -> Result<bool, InconclusiveMatchError> {
+    match_property_with_version(property, properties, 1)
+}
+
+fn match_property_with_version(
+    property: &Property,
+    properties: &HashMap<String, serde_json::Value>,
+    property_matching_version: i64,
 ) -> Result<bool, InconclusiveMatchError> {
     let value = match properties.get(&property.key) {
         Some(v) => v,
@@ -1431,8 +1472,8 @@ fn match_property(
     };
 
     Ok(match property.operator.as_str() {
-        "exact" => compute_exact_match(&property.value, value),
-        "is_not" => !compute_exact_match(&property.value, value),
+        "exact" => compute_exact_match(&property.value, value, property_matching_version),
+        "is_not" => !compute_exact_match(&property.value, value, property_matching_version),
         "is_set" => true,      // We already know the property exists
         "is_not_set" => false, // We already know the property exists
         "icontains" => {
@@ -1559,12 +1600,20 @@ fn match_property(
     })
 }
 
-fn compute_exact_match(value: &serde_json::Value, override_value: &serde_json::Value) -> bool {
-    if is_truthy_or_falsy_property_value(value) {
+fn compute_exact_match(
+    value: &serde_json::Value,
+    override_value: &serde_json::Value,
+    property_matching_version: i64,
+) -> bool {
+    if property_matching_version != 2 && is_truthy_or_falsy_property_value(value) {
         return is_truthy_property_value(value) == is_truthy_property_value(override_value);
     }
 
     if let Some(values) = value.as_array() {
+        // Empty filters retain recursive legacy truthiness in both versions.
+        if values.is_empty() {
+            return is_truthy_property_value(override_value);
+        }
         return values
             .iter()
             .any(|candidate| compare_values(candidate, override_value));
@@ -2538,6 +2587,7 @@ mod tests {
         properties.insert("country".to_string(), json!("US"));
 
         let ctx = EvaluationContext {
+            property_matching_version: 1,
             cohorts: &cohorts,
             flags: &HashMap::new(),
             distinct_id: "user-123",
@@ -2579,6 +2629,7 @@ mod tests {
         properties.insert("status".to_string(), json!("active"));
 
         let ctx = EvaluationContext {
+            property_matching_version: 1,
             cohorts: &cohorts,
             flags: &HashMap::new(),
             distinct_id: "user-123",
@@ -2607,6 +2658,7 @@ mod tests {
 
         let properties = HashMap::new();
         let ctx = EvaluationContext {
+            property_matching_version: 1,
             cohorts: &cohorts,
             flags: &HashMap::new(),
             distinct_id: "user-123",
@@ -2624,6 +2676,7 @@ mod tests {
     /// which is all cohort-membership tests need.
     fn cohort_ctx(cohorts: &HashMap<String, CohortDefinition>) -> EvaluationContext<'_> {
         EvaluationContext {
+            property_matching_version: 1,
             cohorts,
             flags: EMPTY_FLAGS.get_or_init(HashMap::new),
             distinct_id: "user-123",
@@ -3177,6 +3230,7 @@ mod tests {
 
         let properties = HashMap::new();
         let ctx = EvaluationContext {
+            property_matching_version: 1,
             cohorts: &HashMap::new(),
             flags: &flags,
             distinct_id: "user-123",
@@ -3218,6 +3272,7 @@ mod tests {
 
         let properties = HashMap::new();
         let ctx = EvaluationContext {
+            property_matching_version: 1,
             cohorts: &HashMap::new(),
             flags: &flags,
             distinct_id: "user-123",
@@ -3275,6 +3330,7 @@ mod tests {
 
         let properties = HashMap::new();
         let ctx = EvaluationContext {
+            property_matching_version: 1,
             cohorts: &HashMap::new(),
             flags: &flags,
             distinct_id: "user-gets-control", // This distinct_id should deterministically get "control"
@@ -3301,6 +3357,7 @@ mod tests {
 
         let properties = HashMap::new();
         let ctx = EvaluationContext {
+            property_matching_version: 1,
             cohorts: &HashMap::new(),
             flags: &flags,
             distinct_id: "user-123",
@@ -4522,6 +4579,7 @@ mod tests {
             fn $name() {
                 let flag = early_exit_flag($early_exit);
                 let ctx = EvaluationContext {
+                    property_matching_version: 1,
                     cohorts: &HashMap::new(),
                     flags: &HashMap::new(),
                     distinct_id: "user-123",

--- a/src/local_evaluation.rs
+++ b/src/local_evaluation.rs
@@ -1,7 +1,7 @@
 use crate::client::{apply_on_error_hooks, get_default_user_agent, OnErrorHook};
 use crate::feature_flags::{
-    match_feature_flag, match_feature_flag_with_context, CohortDefinition, EvaluationContext,
-    FeatureFlag, FlagValue, InconclusiveMatchError,
+    match_feature_flag_with_context, match_feature_flag_with_version, CohortDefinition,
+    EvaluationContext, FeatureFlag, FlagValue, InconclusiveMatchError,
 };
 use crate::{Error, LocalEvaluationFailure, PostHogError};
 use reqwest::header::{HeaderMap, ETAG, IF_NONE_MATCH, USER_AGENT};
@@ -71,6 +71,14 @@ pub struct LocalEvaluationResponse {
     /// strict property allowlist. Absent fails safe to `false` (full event).
     #[serde(default)]
     pub minimal_flag_called_events: bool,
+    /// Property equality semantics for this snapshot. Exactly `2` selects
+    /// explicit matching; absent metadata and other versions use legacy matching.
+    #[serde(default = "legacy_property_matching_version")]
+    pub property_matching_version: i64,
+}
+
+fn legacy_property_matching_version() -> i64 {
+    1
 }
 
 /// A cohort definition for local evaluation.
@@ -104,87 +112,34 @@ pub struct Cohort {
 /// (which updates it) and the evaluator (which reads from it).
 #[derive(Clone)]
 pub struct FlagCache {
-    flags: Arc<RwLock<HashMap<String, FeatureFlag>>>,
-    group_type_mapping: Arc<RwLock<HashMap<String, String>>>,
-    cohorts: Arc<RwLock<HashMap<String, Cohort>>>,
-    /// The `minimal_flag_called_events` gate from the most recent definitions
-    /// poll. Read once when a local evaluation succeeds and pinned onto that
-    /// flag's record, so the minimization decision reflects the definitions
-    /// snapshot that produced the value.
-    minimal_flag_called_events: Arc<AtomicBool>,
+    // One lock keeps definitions and their matching version together, including
+    // when a poll replaces them while an evaluation follows cohort/dependency leaves.
+    snapshot: Arc<RwLock<FlagSnapshot>>,
 }
 
-impl Default for FlagCache {
+struct FlagSnapshot {
+    flags: HashMap<String, FeatureFlag>,
+    group_type_mapping: HashMap<String, String>,
+    cohorts: HashMap<String, Cohort>,
+    minimal_flag_called_events: bool,
+    property_matching_version: i64,
+}
+
+impl Default for FlagSnapshot {
     fn default() -> Self {
-        Self::new()
+        Self {
+            flags: HashMap::new(),
+            group_type_mapping: HashMap::new(),
+            cohorts: HashMap::new(),
+            minimal_flag_called_events: false,
+            property_matching_version: legacy_property_matching_version(),
+        }
     }
 }
 
-impl FlagCache {
-    /// Create an empty shared flag cache.
-    pub fn new() -> Self {
-        Self {
-            flags: Arc::new(RwLock::new(HashMap::new())),
-            group_type_mapping: Arc::new(RwLock::new(HashMap::new())),
-            cohorts: Arc::new(RwLock::new(HashMap::new())),
-            minimal_flag_called_events: Arc::new(AtomicBool::new(false)),
-        }
-    }
-
-    /// Replace cached flags, group type mappings, and cohorts from a local
-    /// evaluation API response.
-    pub fn update(&self, response: LocalEvaluationResponse) {
-        let flag_count = response.flags.len();
-        let mut flags = self.flags.write().unwrap();
-        flags.clear();
-        for flag in response.flags {
-            flags.insert(flag.key.clone(), flag);
-        }
-
-        let mut mapping = self.group_type_mapping.write().unwrap();
-        *mapping = response.group_type_mapping;
-
-        let mut cohorts = self.cohorts.write().unwrap();
-        *cohorts = response.cohorts;
-
-        self.minimal_flag_called_events
-            .store(response.minimal_flag_called_events, Ordering::Relaxed);
-
-        debug!(flag_count, "Updated flag cache");
-    }
-
-    /// Whether the most recent definitions poll enabled minimal
-    /// `$feature_flag_called` events. `false` until definitions load, so a
-    /// missing signal always yields full events.
-    pub fn minimal_flag_called_events(&self) -> bool {
-        self.minimal_flag_called_events.load(Ordering::Relaxed)
-    }
-
-    /// Return a cached feature flag by key.
-    pub fn get_flag(&self, key: &str) -> Option<FeatureFlag> {
-        self.flags.read().unwrap().get(key).cloned()
-    }
-
-    /// Return all cached feature flag definitions.
-    pub fn get_all_flags(&self) -> Vec<FeatureFlag> {
-        self.flags.read().unwrap().values().cloned().collect()
-    }
-
-    /// Return a cached cohort by ID.
-    pub fn get_cohort(&self, id: &str) -> Option<Cohort> {
-        self.cohorts.read().unwrap().get(id).cloned()
-    }
-
-    /// Return all cached cohorts, keyed by cohort ID.
-    pub fn get_all_cohorts(&self) -> HashMap<String, Cohort> {
-        self.cohorts.read().unwrap().clone()
-    }
-
-    /// Get all cohorts as CohortDefinitions for evaluation context
-    pub fn get_cohort_definitions(&self) -> HashMap<String, CohortDefinition> {
+impl FlagSnapshot {
+    fn cohort_definitions(&self) -> HashMap<String, CohortDefinition> {
         self.cohorts
-            .read()
-            .unwrap()
             .iter()
             .map(|(k, v)| {
                 (
@@ -197,22 +152,97 @@ impl FlagCache {
             })
             .collect()
     }
+}
+
+impl Default for FlagCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FlagCache {
+    /// Create an empty shared flag cache.
+    pub fn new() -> Self {
+        Self {
+            snapshot: Arc::new(RwLock::new(FlagSnapshot::default())),
+        }
+    }
+
+    /// Replace cached flags, group type mappings, and cohorts from a local
+    /// evaluation API response.
+    pub fn update(&self, response: LocalEvaluationResponse) {
+        let flag_count = response.flags.len();
+        let snapshot = FlagSnapshot {
+            flags: response
+                .flags
+                .into_iter()
+                .map(|flag| (flag.key.clone(), flag))
+                .collect(),
+            group_type_mapping: response.group_type_mapping,
+            cohorts: response.cohorts,
+            minimal_flag_called_events: response.minimal_flag_called_events,
+            property_matching_version: response.property_matching_version,
+        };
+        *self.snapshot.write().unwrap() = snapshot;
+
+        debug!(flag_count, "Updated flag cache");
+    }
+
+    /// Whether the most recent definitions poll enabled minimal
+    /// `$feature_flag_called` events. `false` until definitions load, so a
+    /// missing signal always yields full events.
+    pub fn minimal_flag_called_events(&self) -> bool {
+        self.snapshot.read().unwrap().minimal_flag_called_events
+    }
+
+    /// Return a cached feature flag by key.
+    pub fn get_flag(&self, key: &str) -> Option<FeatureFlag> {
+        self.snapshot.read().unwrap().flags.get(key).cloned()
+    }
+
+    /// Return all cached feature flag definitions.
+    pub fn get_all_flags(&self) -> Vec<FeatureFlag> {
+        self.snapshot
+            .read()
+            .unwrap()
+            .flags
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    /// Return a cached cohort by ID.
+    pub fn get_cohort(&self, id: &str) -> Option<Cohort> {
+        self.snapshot.read().unwrap().cohorts.get(id).cloned()
+    }
+
+    /// Return all cached cohorts, keyed by cohort ID.
+    pub fn get_all_cohorts(&self) -> HashMap<String, Cohort> {
+        self.snapshot.read().unwrap().cohorts.clone()
+    }
+
+    /// Get all cohorts as CohortDefinitions for evaluation context
+    pub fn get_cohort_definitions(&self) -> HashMap<String, CohortDefinition> {
+        self.snapshot.read().unwrap().cohort_definitions()
+    }
 
     /// Get all flags as a HashMap for evaluation context
     pub fn get_flags_map(&self) -> HashMap<String, FeatureFlag> {
-        self.flags.read().unwrap().clone()
+        self.snapshot.read().unwrap().flags.clone()
     }
 
     /// Get the group type mapping (group type index → group type name).
     pub fn get_group_type_mapping(&self) -> HashMap<String, String> {
-        self.group_type_mapping.read().unwrap().clone()
+        self.snapshot.read().unwrap().group_type_mapping.clone()
     }
 
     /// Remove all cached flags, group type mappings, and cohorts.
     pub fn clear(&self) {
-        self.flags.write().unwrap().clear();
-        self.group_type_mapping.write().unwrap().clear();
-        self.cohorts.write().unwrap().clear();
+        let mut snapshot = self.snapshot.write().unwrap();
+        snapshot.flags.clear();
+        snapshot.group_type_mapping.clear();
+        snapshot.cohorts.clear();
+        snapshot.property_matching_version = legacy_property_matching_version();
     }
 }
 
@@ -755,23 +785,22 @@ impl LocalEvaluator {
         groups: &HashMap<String, String>,
         group_properties: &HashMap<String, HashMap<String, serde_json::Value>>,
     ) -> Result<Option<FlagValue>, InconclusiveMatchError> {
-        match self.cache.get_flag(key) {
+        let snapshot = self.cache.snapshot.read().unwrap();
+        match snapshot.flags.get(key) {
             Some(flag) => {
-                // Build evaluation context with cohorts, flags, and group info
-                let cohorts = self.cache.get_cohort_definitions();
-                let flags = self.cache.get_flags_map();
-                let group_type_mapping = self.cache.get_group_type_mapping();
+                let cohorts = snapshot.cohort_definitions();
 
                 let ctx = EvaluationContext {
                     cohorts: &cohorts,
-                    flags: &flags,
+                    flags: &snapshot.flags,
                     distinct_id,
                     groups,
                     group_properties,
-                    group_type_mapping: &group_type_mapping,
+                    group_type_mapping: &snapshot.group_type_mapping,
+                    property_matching_version: snapshot.property_matching_version,
                 };
 
-                let result = match_feature_flag_with_context(&flag, person_properties, &ctx);
+                let result = match_feature_flag_with_context(flag, person_properties, &ctx);
                 trace!(key, ?result, "Local flag evaluation");
                 result.map(Some)
             }
@@ -809,16 +838,17 @@ impl LocalEvaluator {
         groups: &HashMap<String, String>,
         group_properties: &HashMap<String, HashMap<String, serde_json::Value>>,
     ) -> Result<Option<FlagValue>, InconclusiveMatchError> {
-        match self.cache.get_flag(key) {
+        let snapshot = self.cache.snapshot.read().unwrap();
+        match snapshot.flags.get(key) {
             Some(flag) => {
-                let group_type_mapping = self.cache.get_group_type_mapping();
-                let result = match_feature_flag(
-                    &flag,
+                let result = match_feature_flag_with_version(
+                    flag,
                     distinct_id,
                     person_properties,
                     groups,
                     group_properties,
-                    &group_type_mapping,
+                    &snapshot.group_type_mapping,
+                    snapshot.property_matching_version,
                 );
                 trace!(key, ?result, "Local flag evaluation (simple)");
                 result.map(Some)
@@ -867,20 +897,20 @@ impl LocalEvaluator {
         let mut results = HashMap::new();
 
         // Build one definitions snapshot for evaluation and its metadata.
-        let cohorts = self.cache.get_cohort_definitions();
-        let flags = self.cache.get_flags_map();
-        let group_type_mapping = self.cache.get_group_type_mapping();
+        let snapshot = self.cache.snapshot.read().unwrap();
+        let cohorts = snapshot.cohort_definitions();
 
         let ctx = EvaluationContext {
             cohorts: &cohorts,
-            flags: &flags,
+            flags: &snapshot.flags,
             distinct_id,
             groups,
             group_properties,
-            group_type_mapping: &group_type_mapping,
+            group_type_mapping: &snapshot.group_type_mapping,
+            property_matching_version: snapshot.property_matching_version,
         };
 
-        for flag in flags.values() {
+        for flag in snapshot.flags.values() {
             let result = match_feature_flag_with_context(flag, person_properties, &ctx);
             let payload = result
                 .as_ref()
@@ -913,6 +943,7 @@ mod tests {
         has_experiment: bool,
     ) -> LocalEvaluationResponse {
         LocalEvaluationResponse {
+            property_matching_version: 1,
             flags: vec![FeatureFlag {
                 key: "snapshot-flag".to_string(),
                 active,

--- a/tests/test_local_evaluation.rs
+++ b/tests/test_local_evaluation.rs
@@ -45,6 +45,7 @@ fn test_local_evaluation_basic() {
 
     // Update cache with the flag
     let response = LocalEvaluationResponse {
+        property_matching_version: 1,
         flags: vec![flag],
         group_type_mapping: HashMap::new(),
         cohorts: HashMap::new(),
@@ -308,6 +309,7 @@ fn test_local_evaluation_with_properties() {
 
     // Update cache
     let response = LocalEvaluationResponse {
+        property_matching_version: 1,
         flags: vec![flag],
         group_type_mapping: HashMap::new(),
         cohorts: HashMap::new(),
@@ -739,6 +741,7 @@ fn test_cache_operations() {
     ];
 
     let response = LocalEvaluationResponse {
+        property_matching_version: 1,
         flags: flags.clone(),
         group_type_mapping: HashMap::new(),
         cohorts: HashMap::new(),
@@ -1282,6 +1285,7 @@ fn cache_with(flag: FeatureFlag) -> FlagCache {
     let mut group_type_mapping = HashMap::new();
     group_type_mapping.insert("0".to_string(), "company".to_string());
     cache.update(LocalEvaluationResponse {
+        property_matching_version: 1,
         flags: vec![flag],
         group_type_mapping,
         cohorts: HashMap::new(),

--- a/tests/test_property_matching_version.rs
+++ b/tests/test_property_matching_version.rs
@@ -1,0 +1,343 @@
+use posthog_rs::{FlagCache, FlagValue, LocalEvaluationResponse, LocalEvaluator};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+fn definitions(version: Option<i64>, filter: Value, operator: &str) -> LocalEvaluationResponse {
+    let mut response = json!({
+        "flags": [{"key": "person", "active": true, "filters": {"groups": [{
+            "properties": [{"key": "value", "value": filter, "operator": operator}]
+        }]}}]
+    });
+    if let Some(version) = version {
+        response["property_matching_version"] = json!(version);
+    }
+    // Exercise the actual wire envelope, not a manually constructed cache entry.
+    serde_json::from_value(response).unwrap()
+}
+
+fn assert_paths(evaluator: &LocalEvaluator, property: Value, expected: bool) {
+    let properties = HashMap::from([("value".into(), property)]);
+    let groups = HashMap::new();
+    let group_properties = HashMap::new();
+    assert_eq!(
+        evaluator
+            .evaluate_flag("person", "user", &properties, &groups, &group_properties)
+            .unwrap(),
+        Some(FlagValue::Boolean(expected)),
+        "full path"
+    );
+    assert_eq!(
+        evaluator
+            .evaluate_flag_simple("person", "user", &properties, &groups, &group_properties)
+            .unwrap(),
+        Some(FlagValue::Boolean(expected)),
+        "simple path"
+    );
+    assert_eq!(
+        evaluator.evaluate_all_flags("user", &properties, &groups, &group_properties)["person"]
+            .as_ref()
+            .unwrap(),
+        &FlagValue::Boolean(expected),
+        "all flags path"
+    );
+}
+
+#[test]
+fn property_matching_version_wire_matrix() {
+    let cases = [
+        (json!(false), json!("banana"), true, false),
+        (json!(false), json!(0), true, false),
+        (json!(["true", "false"]), json!("true"), false, true),
+        (json!(["true", "false"]), json!("pro"), true, false),
+        (json!([]), json!(true), true, true),
+        (json!([]), json!([]), true, true),
+        (json!(true), json!([true]), true, false),
+        (json!(true), json!([]), true, false),
+        (json!(false), json!("FALSE"), true, true),
+        (json!(false), Value::Null, true, false),
+        (json!(false), json!(""), true, false),
+        (json!([]), json!([true, "TRUE", [true, []]]), true, true),
+        (json!([]), json!(false), false, false),
+        (json!([]), json!(1), false, false),
+        (json!([]), json!("banana"), false, false),
+        (json!([]), json!([true, [false]]), false, false),
+        (json!([false, "PRO"]), json!("pro"), true, true),
+        (json!([true, "pro"]), json!("TRUE"), true, true),
+        (json!([[true], "PRO"]), json!([true]), true, true),
+        (json!(["FREE", "PRO"]), json!("pro"), true, true),
+        (json!("ÄBC"), json!("äbc"), true, true),
+        (json!([1, "pro"]), json!("1"), true, true),
+        (Value::Null, Value::Null, true, true),
+    ];
+    for version in [None, Some(1), Some(2), Some(0), Some(3)] {
+        for (filter, property, legacy, explicit) in &cases {
+            for operator in ["exact", "is_not"] {
+                let cache = FlagCache::new();
+                cache.update(definitions(version, filter.clone(), operator));
+                let expected = if version == Some(2) {
+                    *explicit
+                } else {
+                    *legacy
+                };
+                assert_paths(
+                    &LocalEvaluator::new(cache),
+                    property.clone(),
+                    expected != (operator == "is_not"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn property_matching_version_only_reload_and_older_cache_roundtrip() {
+    let cache = FlagCache::new();
+    let evaluator = LocalEvaluator::new(cache.clone());
+    for version in [Some(1), Some(2), Some(1), Some(2), None] {
+        let response = definitions(version, json!(false), "exact");
+        let serialized = serde_json::to_string(&response).unwrap();
+        cache.update(serde_json::from_str(&serialized).unwrap());
+        assert_paths(&evaluator, json!("banana"), version != Some(2));
+    }
+}
+
+#[test]
+fn property_matching_version_missing_property_is_inconclusive() {
+    for version in [None, Some(1), Some(2)] {
+        for operator in ["exact", "is_not"] {
+            let cache = FlagCache::new();
+            cache.update(definitions(version, json!(false), operator));
+            let evaluator = LocalEvaluator::new(cache);
+            assert!(evaluator
+                .evaluate_flag(
+                    "person",
+                    "user",
+                    &HashMap::new(),
+                    &HashMap::new(),
+                    &HashMap::new()
+                )
+                .is_err());
+            assert!(evaluator
+                .evaluate_flag_simple(
+                    "person",
+                    "user",
+                    &HashMap::new(),
+                    &HashMap::new(),
+                    &HashMap::new()
+                )
+                .is_err());
+        }
+    }
+}
+
+#[test]
+fn property_matching_version_reaches_groups_recursive_cohorts_and_dependencies() {
+    let cache = FlagCache::new();
+    let evaluator = LocalEvaluator::new(cache.clone());
+    for version in [None, Some(1), Some(2), Some(1), Some(2), None] {
+        let mut response =
+            serde_json::to_value(definitions(version, json!(false), "exact")).unwrap();
+        let mut group = response["flags"][0].clone();
+        group["key"] = json!("group");
+        group["filters"]["aggregation_group_type_index"] = json!(0);
+        response["flags"].as_array_mut().unwrap().push(group);
+        response["flags"].as_array_mut().unwrap().push(json!({
+            "key": "cohort", "active": true, "filters": {"groups": [{"properties": [
+                {"key": "id", "value": "outer", "type": "cohort"}
+            ]}]}
+        }));
+        response["flags"].as_array_mut().unwrap().push(json!({
+            "key": "dependency", "active": true, "filters": {"groups": [{"properties": [
+                {"key": "$feature/group", "value": true, "operator": "exact"}
+            ]}]}
+        }));
+        response["group_type_mapping"] = json!({"0": "company"});
+        response["cohorts"] = json!({
+            "outer": {"type": "AND", "values": [{"type": "cohort", "value": "inner"}]},
+            "inner": {"type": "OR", "values": [{"type": "AND", "values": [
+                {"key": "value", "value": false, "operator": "exact", "type": "person"}
+            ]}]}
+        });
+        cache.update(serde_json::from_value(response).unwrap());
+        let properties = HashMap::from([("value".into(), json!("banana"))]);
+        let groups = HashMap::from([("company".into(), "acme".into())]);
+        let group_properties = HashMap::from([("company".into(), properties.clone())]);
+        let expected = FlagValue::Boolean(version != Some(2));
+        for key in ["person", "group", "cohort", "dependency"] {
+            assert_eq!(
+                evaluator
+                    .evaluate_flag(key, "user", &properties, &groups, &group_properties)
+                    .unwrap(),
+                Some(expected.clone()),
+                "{key}, version {version:?}"
+            );
+            assert_eq!(
+                evaluator.evaluate_all_flags("user", &properties, &groups, &group_properties)[key]
+                    .as_ref()
+                    .unwrap(),
+                &expected
+            );
+        }
+        assert_eq!(
+            evaluator
+                .evaluate_flag_simple("group", "user", &properties, &groups, &group_properties)
+                .unwrap(),
+            Some(expected)
+        );
+    }
+}
+
+fn poller_config(server: &httpmock::MockServer) -> posthog_rs::LocalEvaluationConfig {
+    posthog_rs::LocalEvaluationConfig {
+        personal_api_key: "personal-key".into(),
+        project_api_key: "project-key".into(),
+        api_host: server.base_url(),
+        poll_interval: std::time::Duration::from_millis(20),
+        request_timeout: std::time::Duration::from_secs(5),
+    }
+}
+
+fn mock_definitions(server: &httpmock::MockServer, version: Option<i64>) -> httpmock::Mock<'_> {
+    let mut body = serde_json::to_value(definitions(version, json!(false), "exact")).unwrap();
+    // A fresh old-server response must really omit the field on the wire.
+    if version.is_none() {
+        body.as_object_mut()
+            .unwrap()
+            .remove("property_matching_version");
+    }
+    server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path("/flags/definitions/")
+            .query_param("send_cohorts", "")
+            .header("Authorization", "Bearer personal-key")
+            .header("X-PostHog-Project-Api-Key", "project-key");
+        then.status(200)
+            .header("ETag", "\"definitions\"")
+            .json_body(body);
+    })
+}
+
+#[test]
+fn property_matching_version_blocking_poller_reload_failure_and_304() {
+    let server = httpmock::MockServer::start();
+    let cache = FlagCache::new();
+    let evaluator = LocalEvaluator::new(cache.clone());
+    let mut poller = posthog_rs::FlagPoller::new(poller_config(&server), cache);
+    for version in [Some(1), Some(2), Some(1), Some(2), None, Some(2)] {
+        let mut response = mock_definitions(&server, version);
+        poller.load_flags().unwrap();
+        response.assert_calls(1);
+        assert_paths(&evaluator, json!("banana"), version != Some(2));
+        response.delete();
+    }
+    for (status, body) in [(500, "unavailable"), (200, "invalid json")] {
+        let mut response = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/flags/definitions/");
+            then.status(status).body(body);
+        });
+        assert!(poller.load_flags().is_err());
+        assert_paths(&evaluator, json!("banana"), false);
+        response.delete();
+    }
+    let unchanged = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path("/flags/definitions/")
+            .header("If-None-Match", "\"definitions\"");
+        then.status(304);
+    });
+    let _response = mock_definitions(&server, Some(2));
+    poller.start();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while unchanged.calls() == 0 && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    poller.stop();
+    assert!(unchanged.calls() > 0, "poller must receive a real 304");
+    assert_paths(&evaluator, json!("banana"), false);
+}
+
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn property_matching_version_async_poller_reload_failure_and_304() {
+    let server = httpmock::MockServer::start();
+    let cache = FlagCache::new();
+    let evaluator = LocalEvaluator::new(cache.clone());
+    let mut poller = posthog_rs::AsyncFlagPoller::new(poller_config(&server), cache);
+    for version in [Some(1), Some(2), Some(1), Some(2), None, Some(2)] {
+        let mut response = mock_definitions(&server, version);
+        poller.load_flags().await.unwrap();
+        response.assert_calls(1);
+        assert_paths(&evaluator, json!("banana"), version != Some(2));
+        response.delete();
+    }
+    for (status, body) in [(500, "unavailable"), (200, "invalid json")] {
+        let mut response = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/flags/definitions/");
+            then.status(status).body(body);
+        });
+        assert!(poller.load_flags().await.is_err());
+        assert_paths(&evaluator, json!("banana"), false);
+        response.delete();
+    }
+    let unchanged = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path("/flags/definitions/")
+            .header("If-None-Match", "\"definitions\"");
+        then.status(304);
+    });
+    let _response = mock_definitions(&server, Some(2));
+    poller.start().await;
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while unchanged.calls_async().await == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("poller must receive a real 304");
+    poller.stop().await;
+    assert_paths(&evaluator, json!("banana"), false);
+}
+
+#[test]
+fn property_matching_version_public_helper_defaults_to_legacy() {
+    let response = definitions(Some(2), json!(false), "exact");
+    // Context-free callers have no definitions metadata; retain released behavior.
+    assert_eq!(
+        posthog_rs::match_feature_flag(
+            &response.flags[0],
+            "user",
+            &HashMap::from([("value".into(), json!("banana"))]),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .unwrap(),
+        FlagValue::Boolean(true)
+    );
+}
+
+#[test]
+fn property_matching_version_stays_with_definitions_during_concurrent_refresh() {
+    let cache = FlagCache::new();
+    let legacy = definitions(Some(1), json!(false), "exact");
+    let explicit = definitions(Some(2), json!("banana"), "exact");
+    // Both snapshots match. A legacy flag paired with the explicit version does not.
+    cache.update(legacy.clone());
+    let evaluator = LocalEvaluator::new(cache.clone());
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let writer_barrier = barrier.clone();
+    let writer = std::thread::spawn(move || {
+        writer_barrier.wait();
+        for _ in 0..1000 {
+            cache.update(explicit.clone());
+            cache.update(legacy.clone());
+        }
+    });
+    barrier.wait();
+    for _ in 0..1000 {
+        assert_paths(&evaluator, json!("banana"), true);
+    }
+    writer.join().unwrap();
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Local flag evaluation needs to use the property matching version returned with flag definitions. Without it, version 2 definitions still use legacy boolean coercion. For example, a `false` filter matches `"banana"` under legacy matching but should not match under version 2.

This follows the [backend behavior](https://github.com/PostHog/posthog/pull/90694) and [shared SDK contract](https://github.com/PostHog/sdk-specs/pull/59). [Optional shared harness coverage](https://github.com/PostHog/posthog-sdk-test-harness/pull/53) is separate. This PR does not opt the Rust adapter into that coverage.

### Changes

- Deserialize `property_matching_version` with a default of 1. Exactly 2 uses explicit scalar equality and member equality for nonempty filter arrays. Missing metadata and other versions keep released legacy matching.
- Preserve recursive truthiness for empty filters and case-insensitive value normalization. For known properties, `is_not` complements `exact`. Missing properties remain inconclusive.
- Keep definitions, group mappings, cohorts, and the matching version in one cache snapshot. Full, simple, and all-flags evaluations use that version through person, group, recursive cohort, and existing flag-dependency paths. Existing dependency limitations are unchanged.
- Apply version-only refreshes even when definitions are unchanged. Failed responses and HTTP 304 responses preserve the installed snapshot.

### Source compatibility

**This is source-breaking for public struct-literal callers.** Callers constructing `LocalEvaluationResponse` or `EvaluationContext` must add `property_matching_version: 1` for legacy behavior, or pass the version associated with their definitions. Older serialized definitions still load without this field. The context-free `match_feature_flag` helper remains legacy.

The existing Sampo changeset is **minor** because this crate is pre-1.0 (`0.25.x`). The public API snapshot includes both new fields.

## :green_heart: How did you test it?

The committed tree matches the previously validated implementation exactly.

- Reran `cargo test --offline --test test_property_matching_version`: 8 passed. Coverage includes wire matching cases, version-only refreshes, older serialized definitions, missing properties, propagation, blocking and async pollers, HTTP failure/304 preservation, the legacy helper, and concurrent snapshots.
- Required committed-branch autoreview against `origin/main`: clean, no actionable findings, on `4c50b3ecdeef4bdcfdf5d78cc966c1c742a57a12`.
- Prior publication checks on the same tree passed: focused no-default suite (7 tests), `cargo fmt -- --check`, `scripts/check-public-api.sh`, and focused default-feature Clippy with `-D warnings`.
- Prior implementation validation passed the complete default suite (354 passed, 1 ignored) and no-default suite (294 passed, 1 ignored). These full suites were not rerun for publication.

Known pre-existing strict all-target/no-default Clippy warnings remain out of scope. Live-service/e2e and capture-v1 runtime suites were not run. Local results do not establish CI success.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. Public field docs and the API snapshot are updated.
- [ ] No breaking change or entry added to the changelog. This has the source-breaking change described above and a pending Sampo changeset.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file. The existing manually maintained `.sampo/changesets/versioned-property-matching.md` is included with `cargo/posthog-rs: minor`.
