### PR TITLE
fix: omit null object properties when serializing events

### DIFF
--- a/.sampo/changesets/omit-null-event-properties.md
+++ b/.sampo/changesets/omit-null-event-properties.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-rs: patch
+---
+
+Omit null object properties recursively when serializing captured events, while preserving null array entries and generated feature flag response metadata.

--- a/src/event.rs
+++ b/src/event.rs
@@ -470,15 +470,36 @@ pub struct BatchRequest {
 
 // With `capture-v1` enabled nothing outside tests builds the V0 wire format.
 #[cfg_attr(feature = "capture-v1", allow(dead_code))]
-#[derive(Serialize)]
 pub struct InnerEvent {
-    #[serde(skip_serializing_if = "Option::is_none")]
     api_key: Option<String>,
     uuid: Uuid,
     event: String,
     distinct_id: String,
     properties: HashMap<String, serde_json::Value>,
     timestamp: Option<DateTime<Utc>>,
+}
+
+impl Serialize for InnerEvent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut wire =
+            serializer.serialize_struct("InnerEvent", 5 + usize::from(self.api_key.is_some()))?;
+        if let Some(api_key) = &self.api_key {
+            wire.serialize_field("api_key", api_key)?;
+        }
+        wire.serialize_field("uuid", &self.uuid)?;
+        wire.serialize_field("event", &self.event)?;
+        wire.serialize_field("distinct_id", &self.distinct_id)?;
+        wire.serialize_field(
+            "properties",
+            &crate::property_serialization::EventProperties {
+                event: &self.event,
+                properties: &self.properties,
+            },
+        )?;
+        wire.serialize_field("timestamp", &self.timestamp)?;
+        wire.end()
+    }
 }
 
 impl InnerEvent {

--- a/src/event_v1.rs
+++ b/src/event_v1.rs
@@ -14,18 +14,46 @@ use crate::event::Event;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct Options(serde_json::Map<String, serde_json::Value>);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct V1Event {
     pub event: String,
     pub uuid: Uuid,
     pub distinct_id: String,
     pub timestamp: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub session_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub window_id: Option<String>,
     pub(crate) options: Options,
     pub properties: serde_json::Value,
+}
+
+impl Serialize for V1Event {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let fields =
+            6 + usize::from(self.session_id.is_some()) + usize::from(self.window_id.is_some());
+        let mut wire = serializer.serialize_struct("V1Event", fields)?;
+        wire.serialize_field("event", &self.event)?;
+        wire.serialize_field("uuid", &self.uuid)?;
+        wire.serialize_field("distinct_id", &self.distinct_id)?;
+        wire.serialize_field("timestamp", &self.timestamp)?;
+        if let Some(session_id) = &self.session_id {
+            wire.serialize_field("session_id", session_id)?;
+        }
+        if let Some(window_id) = &self.window_id {
+            wire.serialize_field("window_id", window_id)?;
+        }
+        wire.serialize_field("options", &self.options)?;
+        wire.serialize_field(
+            "properties",
+            &crate::property_serialization::EventProperties {
+                event: &self.event,
+                properties: &self.properties,
+            },
+        )?;
+        wire.end()
+    }
 }
 
 impl V1Event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ mod feature_flag_evaluations;
 mod feature_flags;
 mod global;
 mod local_evaluation;
+mod property_serialization;
 
 // Public interface - any change to this is breaking!
 // Client

--- a/src/property_serialization.rs
+++ b/src/property_serialization.rs
@@ -1,0 +1,155 @@
+use serde::{Serialize, Serializer};
+use serde_json::Value;
+
+/// Only wire-event property fields use this serializer. Event inputs and typed
+/// envelope metadata retain their existing serialization rules. Normalize a
+/// private JSON tree after hooks/enrichment without changing the source event.
+pub(crate) struct EventProperties<'a, T> {
+    pub event: &'a str,
+    pub properties: &'a T,
+}
+
+impl<T: Serialize> Serialize for EventProperties<'_, T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut value = serde_json::to_value(self.properties).map_err(serde::ser::Error::custom)?;
+        // Missing/error flag evaluations deliberately emit these root nulls.
+        // Determine the exact dynamic key from the final event properties, never
+        // a prefix exemption, and never reinsert fields trimmed by privacy rules.
+        if self.event == "$feature_flag_called" {
+            if let Value::Object(properties) = &mut value {
+                let feature_key = properties
+                    .get("$feature_flag")
+                    .and_then(Value::as_str)
+                    .map(|key| format!("$feature/{key}"));
+                properties.retain(|key, value| {
+                    !value.is_null()
+                        || key == "$feature_flag_response"
+                        || feature_key.as_ref() == Some(key)
+                });
+                for value in properties.values_mut() {
+                    drop_null_object_members(value);
+                }
+            } else {
+                drop_null_object_members(&mut value);
+            }
+        } else {
+            drop_null_object_members(&mut value);
+        }
+        value.serialize(serializer)
+    }
+}
+
+fn drop_null_object_members(value: &mut Value) {
+    match value {
+        Value::Object(properties) => {
+            properties.retain(|_, value| !value.is_null());
+            for value in properties.values_mut() {
+                drop_null_object_members(value);
+            }
+        }
+        Value::Array(items) => {
+            for value in items {
+                drop_null_object_members(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::event::InnerEvent;
+    use crate::Event;
+    use serde_json::{json, Value};
+
+    #[test]
+    fn v0_properties_are_normalized_only_at_serialization() {
+        let mut event = Event::new("test", "user");
+        event.insert_prop("test", Value::Null).unwrap();
+        event
+            .insert_prop("items", json!([null, {"drop": null}]))
+            .unwrap();
+        let input = serde_json::to_value(&event).unwrap();
+        assert_eq!(input["properties"]["test"], Value::Null);
+        let wire = serde_json::to_value(InnerEvent::new(event.clone(), "test-key".into())).unwrap();
+        assert!(wire["properties"].get("test").is_none());
+        assert_eq!(wire["properties"]["items"], json!([null, {}]));
+        // Optional typed envelope metadata is not recursively pruned.
+        assert_eq!(wire.get("timestamp"), Some(&Value::Null));
+        assert_eq!(serde_json::to_value(&event).unwrap(), input);
+    }
+
+    #[test]
+    fn flag_null_preservation_is_event_and_exact_key_scoped() {
+        for minimal in [false, true] {
+            let mut event = Event::new("$feature_flag_called", "user");
+            event.insert_prop("$feature_flag", "missing").unwrap();
+            for key in [
+                "$feature_flag_response",
+                "$feature/missing",
+                "$feature/other",
+                "custom",
+            ] {
+                event.insert_prop(key, Value::Null).unwrap();
+            }
+            if minimal {
+                event.mark_minimal_flag_called();
+                event.apply_minimal_flag_called_allowlist();
+            }
+            let wire =
+                serde_json::to_value(InnerEvent::new(event.clone(), "test-key".into())).unwrap();
+            assert_eq!(
+                wire["properties"].get("$feature_flag_response"),
+                Some(&Value::Null)
+            );
+            assert_eq!(
+                wire["properties"].get("$feature/missing").is_none(),
+                minimal
+            );
+            assert!(wire["properties"].get("$feature/other").is_none());
+            assert!(wire["properties"].get("custom").is_none());
+            #[cfg(feature = "capture-v1")]
+            {
+                let wire =
+                    serde_json::to_value(crate::event_v1::V1Event::from_event(&event)).unwrap();
+                assert_eq!(
+                    wire["properties"].get("$feature_flag_response"),
+                    Some(&Value::Null)
+                );
+                assert_eq!(
+                    wire["properties"].get("$feature/missing").is_none(),
+                    minimal
+                );
+            }
+        }
+        let properties = json!({"$feature_flag":"key", "$feature_flag_response":{"drop":null},
+            "$feature/key":{"items":[null,{"drop":null}]}});
+        let wire = serde_json::to_value(super::EventProperties {
+            event: "$feature_flag_called",
+            properties: &properties,
+        })
+        .unwrap();
+        assert_eq!(wire["$feature_flag_response"], json!({}));
+        assert_eq!(wire["$feature/key"], json!({"items":[null,{}]}));
+        // Even a non-object V1 property value retains the recursive array policy.
+        let wire = serde_json::to_value(super::EventProperties {
+            event: "$feature_flag_called",
+            properties: &json!([null,{"drop":null}]),
+        })
+        .unwrap();
+        assert_eq!(wire, json!([null, {}]));
+    }
+
+    #[cfg(feature = "capture-v1")]
+    #[test]
+    fn v1_properties_added_after_build_are_normalized_without_mutation() {
+        let event = Event::new("test", "user");
+        let mut wire = crate::event_v1::V1Event::from_event(&event);
+        wire.properties["late"] = json!({"drop": null, "items": [null, {"drop": null}]});
+        let json = serde_json::to_value(&wire).unwrap();
+        assert_eq!(json["properties"]["late"], json!({"items": [null, {}]}));
+        assert_eq!(json["options"], json!({}));
+        assert!(json.get("session_id").is_none());
+        assert_eq!(wire.properties["late"]["drop"], Value::Null);
+    }
+}

--- a/tests/test_flag_property_serialization.rs
+++ b/tests/test_flag_property_serialization.rs
@@ -1,0 +1,111 @@
+//! Producer-backed flag metadata on real wire requests, shared by all client/protocol builds.
+use httpmock::{HttpMockRequest, HttpMockResponse, MockServer};
+use posthog_rs::{ClientOptionsBuilder, EvaluateFlagsOptions, Event};
+use serde_json::{json, Value};
+use std::sync::{Arc, Mutex};
+
+#[cfg(feature = "async-client")]
+macro_rules! client_call {
+    ($call:expr) => {
+        $call.await
+    };
+}
+#[cfg(not(feature = "async-client"))]
+macro_rules! client_call {
+    ($call:expr) => {
+        $call
+    };
+}
+
+macro_rules! exercise_flag_wire {
+    () => {{
+        let server = MockServer::start();
+        let flags = server.mock(|when, then| {
+            when.method("POST").path("/flags/");
+            then.status(200).json_body(json!({
+                "flags": {"plain": {"key":"plain", "enabled":false,
+                    "metadata":{"id":1,"version":1,"has_experiment":false}}},
+                "minimalFlagCalledEvents":true, "errorsWhileComputingFlags":true
+            }));
+        });
+        let bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let received = bodies.clone();
+        let wire = server.mock(|when, then| {
+            #[cfg(feature = "capture-v1")]
+            when.method("POST").path("/i/v1/analytics/events");
+            #[cfg(not(feature = "capture-v1"))]
+            when.method("POST").path("/batch/");
+            then.respond_with(move |request: &HttpMockRequest| {
+                let body: Value = serde_json::from_slice(request.body_ref()).unwrap();
+                let mut results = serde_json::Map::new();
+                for event in body["batch"].as_array().unwrap() {
+                    results.insert(event["uuid"].as_str().unwrap().to_string(), json!({"result":"ok"}));
+                }
+                received.lock().unwrap().push(body);
+                HttpMockResponse::builder().status(200)
+                    .header("content-type", "application/json")
+                    .body(json!({"results":results}).to_string()).build()
+            });
+        });
+        let options = ClientOptionsBuilder::default()
+            .api_key("test-key".to_string()).host(server.base_url())
+            .flush_interval_ms(600_000u64).flush_at(100usize).max_capture_attempts(1u32)
+            .before_send(|mut event| {
+                for key in ["customNull", "$feature/other", "$feature_flag_response_extra"] {
+                    event.insert_prop(key, Value::Null).unwrap();
+                }
+                event.insert_prop("customKeep", true).unwrap();
+                event.insert_prop("items", json!([null, {"drop":null}])).unwrap();
+                Some(event)
+            }).build().unwrap();
+        let client = client_call!(posthog_rs::client(options));
+        let snapshot = client_call!(client.evaluate_flags("test-user", EvaluateFlagsOptions::default())).unwrap();
+        assert!(!snapshot.is_enabled("missing"));
+        assert!(!snapshot.is_enabled("plain"));
+        let mut ordinary = Event::new("ordinary", "test-user");
+        ordinary.insert_prop("$feature_flag", "missing").unwrap();
+        ordinary.insert_prop("$feature_flag_response", Value::Null).unwrap();
+        ordinary.insert_prop("$feature/missing", Value::Null).unwrap();
+        client.capture(ordinary);
+        client_call!(client.flush());
+        client_call!(client.shutdown());
+        flags.assert_calls(1);
+        wire.assert_calls(1);
+        let bodies = bodies.lock().unwrap();
+        let events: Vec<_> = bodies.iter().flat_map(|b| b["batch"].as_array().unwrap()).collect();
+        assert_eq!(events.len(), 3);
+        for e in events {
+            let p = &e["properties"];
+            for key in ["customNull", "$feature/other", "$feature_flag_response_extra"] {
+                assert!(p.get(key).is_none(), "custom key retained: {}", e);
+            }
+            if e["event"] == "ordinary" {
+                assert!(p.get("$feature_flag_response").is_none());
+                assert!(p.get("$feature/missing").is_none());
+            } else if p["$feature_flag"] == "missing" {
+                assert_eq!(p.get("$feature_flag_response"), Some(&Value::Null), "generated response missing: {}", e);
+                assert_eq!(p.get("$feature/missing"), Some(&Value::Null), "exact feature null missing: {}", e);
+                assert_eq!(p["$feature_flag_error"], "errors_while_computing_flags,flag_missing");
+                assert_eq!(p["items"], json!([null, {}]));
+                assert_eq!(p["customKeep"], true);
+            } else {
+                assert_eq!(p["$feature_flag"], "plain");
+                assert_eq!(p["$feature_flag_response"], false);
+                for key in ["$feature/plain", "items", "customKeep"] {
+                    assert!(p.get(key).is_none(), "minimal privacy bypassed: {}", e);
+                }
+            }
+        }
+    }};
+}
+
+#[cfg(not(feature = "async-client"))]
+#[test]
+fn flag_property_serialization_wire() {
+    exercise_flag_wire!();
+}
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn flag_property_serialization_wire() {
+    exercise_flag_wire!();
+}

--- a/tests/test_property_serialization.rs
+++ b/tests/test_property_serialization.rs
@@ -1,0 +1,168 @@
+//! Real loopback wire coverage shared by blocking/async and v0/v1 builds.
+use httpmock::{HttpMockRequest, HttpMockResponse, MockServer};
+use posthog_rs::{ClientOptionsBuilder, Event};
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::sync::{Arc, Mutex};
+
+#[derive(Serialize)]
+struct CustomProperties {
+    drop: Option<String>,
+    keep: u64,
+}
+fn event(name: &str) -> Event {
+    let mut event = Event::new(name, "test-user");
+    for (key, value) in json!({
+        "test": null, "nested": {"drop":null},
+        "items":["1",null,2,{"drop":null},[null]],
+        "emptyObject":{}, "emptyArray":[], "empty":"", "zero":0,
+        "enabled":false, "literal":"null", "literalUndefined":"undefined",
+        "$set":{"drop":null}, "$group_set":{"drop":null}
+    })
+    .as_object()
+    .unwrap()
+    {
+        event.insert_prop(key, value).unwrap();
+    }
+    event.insert_prop("optionNone", None::<String>).unwrap();
+    event
+        .insert_prop(
+            "struct",
+            CustomProperties {
+                drop: None,
+                keep: u64::MAX,
+            },
+        )
+        .unwrap();
+    event
+        .insert_prop("optionArray", vec![None::<String>])
+        .unwrap();
+    event
+}
+fn assert_properties(properties: &Value) {
+    for key in ["test", "optionNone", "missing", "hookNull"] {
+        assert!(
+            properties.get(key).is_none(),
+            "{} must be absent: {}",
+            key,
+            properties
+        );
+    }
+    for (key, expected) in json!({
+        "nested":{}, "items":["1",null,2,{},[null]],
+        "emptyObject":{}, "emptyArray":[], "empty":"", "zero":0,
+        "enabled":false, "literal":"null", "literalUndefined":"undefined",
+        "$set":{}, "$group_set":{}, "optionArray":[null],
+        "struct":{"keep":u64::MAX}, "hookItems":[null,{}]
+    })
+    .as_object()
+    .unwrap()
+    {
+        assert_eq!(properties.get(key), Some(expected), "{}", key);
+    }
+}
+
+#[cfg(feature = "async-client")]
+macro_rules! client_call {
+    ($call:expr) => {
+        $call.await
+    };
+}
+#[cfg(not(feature = "async-client"))]
+macro_rules! client_call {
+    ($call:expr) => {
+        $call
+    };
+}
+
+macro_rules! exercise_routes {
+    () => {{
+        let server = MockServer::start();
+        let bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let received = bodies.clone();
+        let wire = server.mock(|when, then| {
+            #[cfg(feature = "capture-v1")]
+            when.method("POST").path("/i/v1/analytics/events");
+            #[cfg(not(feature = "capture-v1"))]
+            when.method("POST").path("/batch/");
+            then.respond_with(move |request: &HttpMockRequest| {
+                let body: Value = serde_json::from_slice(request.body_ref()).unwrap();
+                let mut results = serde_json::Map::new();
+                for event in body["batch"].as_array().unwrap() {
+                    results.insert(event["uuid"].as_str().unwrap().to_string(), json!({"result":"ok"}));
+                }
+                received.lock().unwrap().push(body);
+                HttpMockResponse::builder().status(200)
+                    .header("content-type", "application/json")
+                    .body(json!({"results":results}).to_string()).build()
+            });
+        });
+        let options = ClientOptionsBuilder::default()
+            .api_key("test-key".to_string()).host(server.base_url())
+            .flush_interval_ms(600_000u64).flush_at(100usize)
+            .max_capture_attempts(1u32)
+            .before_send(|mut event| {
+                if event.event_name() == "drop" { return None; }
+                event.insert_prop("hookNull", Value::Null).unwrap();
+                event.insert_prop("hookItems", json!([null,{"drop":null}])).unwrap();
+                Some(event)
+            }).build().unwrap();
+        let client = client_call!(posthog_rs::client(options));
+        let original = event("queued");
+        client.capture(original.clone());
+        assert_eq!(original.properties().get("test"), Some(&Value::Null));
+        assert_eq!(original.properties()["nested"], json!({"drop":null}));
+        client.capture_batch(vec![event("batch"), event("$ai_generation")], false);
+        client.capture(Event::new("drop", "test-user"));
+        let mut only = Event::new("only", "test-user");
+        only.insert_prop("test", Value::Null).unwrap();
+        client.capture(only.clone());
+        #[cfg(feature = "error-tracking")]
+        {
+            let error = std::io::Error::other("synthetic test error");
+            let options = posthog_rs::CaptureExceptionOptions::default()
+                .property("test", None::<String>).unwrap()
+                .property("nested", json!({"drop":null})).unwrap()
+                .property("items", json!([null,{"drop":null}])).unwrap();
+            client_call!(client.capture_exception_with(&error, options)).unwrap();
+        }
+        client_call!(client.flush());
+        client_call!(client.capture_immediate(event("immediate"))).unwrap();
+        client_call!(client.capture_batch_immediate(vec![event("batch_immediate")], false)).unwrap();
+        client_call!(client.capture_immediate(only)).unwrap();
+        client_call!(client.capture_immediate(Event::new("drop", "test-user"))).unwrap();
+        client_call!(client.shutdown());
+        wire.assert_calls(4);
+        let bodies = bodies.lock().unwrap();
+        let events: Vec<_> = bodies.iter().flat_map(|b| b["batch"].as_array().unwrap()).collect();
+        let expected_count = if cfg!(feature = "error-tracking") { 8 } else { 7 };
+        assert_eq!(events.len(), expected_count);
+        for e in events {
+            let p = &e["properties"];
+            assert!(p.get("test").is_none(), "null retained: {}", e);
+            assert!(p.get("hookNull").is_none());
+            assert_eq!(p["hookItems"], json!([null,{}]));
+            match e["event"].as_str().unwrap() {
+                "only" => {},
+                "$exception" => {
+                    assert_eq!(p["nested"], json!({}));
+                    assert_eq!(p["items"], json!([null,{}]));
+                    assert!(!p["$exception_list"].as_array().unwrap().is_empty());
+                },
+                "drop" => panic!("hook drop bypassed"),
+                _ => assert_properties(p),
+            }
+        }
+    }};
+}
+
+#[cfg(not(feature = "async-client"))]
+#[test]
+fn event_property_serialization_wire() {
+    exercise_routes!();
+}
+#[cfg(feature = "async-client")]
+#[tokio::test]
+async fn event_property_serialization_wire() {
+    exercise_routes!();
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Captured custom properties currently send null object members. This implements the serialization contract in https://github.com/PostHog/sdk-specs/pull/60 without narrowing the public property API.

Both v0 and v1 wire serializers use one private helper to omit null object members recursively after hooks and enrichment. Null array entries keep their positions. Empty objects and arrays, other scalar values, and caller-owned events stay unchanged. Queued, batch, immediate, AI-named and exception events use the same boundary.

Generated missing/error feature flag response nulls retain their existing meaning only on `$feature_flag_called`, for `$feature_flag_response` and the exact `$feature/<key>` selected by `$feature_flag`. Privacy filtering remains authoritative. Envelope fields and unrelated caches are unchanged.

Includes a manually authored Sampo patch entry using the repository's required package key.

## :green_heart: How did you test it?

- Both permanent loopback HTTP tests pass across blocking/async clients, v0/v1 capture, and error tracking enabled/disabled (eight feature combinations).
- Focused serializer, event, envelope and minimal flag privacy unit tests pass in four error-tracking-enabled builds (21 tests per v0 build and 40 per v1 build).
- Formatting and the public API snapshot check pass. Strict Clippy passes for both async builds.
- **Known baseline limitation:** strict blocking Clippy fails on existing `clippy::type_complexity` at `src/client/blocking.rs:706`, also reproduced on unchanged baseline. Both blocking builds pass with only that lint allowed on the command line. No source suppression was added.
- Isolated committed-head review reports no actionable findings. All 25 hosted checks passed for `eb246af5dab6041f1a7fe56cb4db8325b3fd6384`, including the CI test matrix, public API, CodeQL and both SDK compliance workflows. Existing compliance coverage does not prove all null-policy scenarios.
- Full suites, minimum Rust versions, performance, local-poller and retry/compression-specific null behavior were not validated locally. The SDK has no disk-backed event queue to exercise. This draft is not release or universal conformance clearance.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

The equivalent Sampo patch file was authored manually as permitted by `RELEASING.md`. No release command was run.
