### PR TITLE
ci: remove redundant release contents permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     if: always() && needs.check-changesets.outputs.has-changesets == 'true'
     environment: "Release"
     permissions:
-      contents: write
+      contents: read
       actions: write
       id-token: write
     steps:


### PR DESCRIPTION
## :bulb: Motivation and Context

The `release` job grants the built-in `GITHUB_TOKEN` repository write access even though its repository writes use a separate GitHub App token.

Lower `release` to `contents: read`. Preserve the App-authenticated checkout and all App-token commit, tag and release operations. No authentication input or App permission changes.

Keep `id-token: write` for crates.io authentication and `actions: write` for upgrade-workflow dispatch.

Read-only workflow inheritance remains allowed. This reduces the built-in token's permissions, not the job's separate App-token authority or build/publish exposure. No package release or changeset is needed.

## :green_heart: How did you test it?

- Checked every repository-write operation in the affected job and traced it to the App token, including the pinned action contracts.
- Compared parsed YAML with the baseline and verified that only the intended permission keys changed. Triggers, steps, dependencies, secrets and token wiring are unchanged.
- `actionlint -shellcheck= -pyflakes=` and `git diff --check` passed. Existing shell-lint diagnostics were checked against the baseline and left unchanged.
- Reviewed the final branch diff. No live release or SDK tests were run for this permission-only change.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes. No SDK tests apply to this permission-only change.
- [x] I updated the docs if needed. No documentation change is needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

No package release or changeset is needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi and delegate agents using file tools, Git, GitHub CLI, Python/PyYAML and actionlint. The parent agent reviewed the final diff. Work was performed in a dedicated worktree. Autoreview was skipped because all changes are GitHub workflow permission administration. No session transcript was published. Human review is required.
